### PR TITLE
fix(server): security hardening, memory leak fixes, and operational g…

### DIFF
--- a/apps/server/.env.example
+++ b/apps/server/.env.example
@@ -1,0 +1,12 @@
+# Required: API key for authenticating all routes (Authorization: Bearer <key>)
+API_KEY=your-api-key-here
+
+# Required: Stellar network to connect to. Must be "mainnet" or "testnet".
+NETWORK=testnet
+
+# Optional: Port to listen on. Defaults to 3000.
+PORT=3000
+
+# Optional: HMAC key used to hash webhook secrets at rest.
+# If omitted, a default key is used (not recommended for production).
+WEBHOOK_SECRET=your-webhook-hmac-key-here

--- a/apps/server/src/auth.ts
+++ b/apps/server/src/auth.ts
@@ -1,0 +1,24 @@
+import type { Request, Response, NextFunction } from "express";
+
+export function requireApiKey(req: Request, res: Response, next: NextFunction): void {
+  const apiKey = process.env.API_KEY;
+
+  if (!apiKey) {
+    res.status(500).json({ error: "Server misconfigured: API_KEY not set" });
+    return;
+  }
+
+  const authHeader = req.headers["authorization"];
+  if (!authHeader || !authHeader.startsWith("Bearer ")) {
+    res.status(401).json({ error: "Unauthorized" });
+    return;
+  }
+
+  const provided = authHeader.slice("Bearer ".length);
+  if (provided !== apiKey) {
+    res.status(401).json({ error: "Unauthorized" });
+    return;
+  }
+
+  next();
+}

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -1,10 +1,33 @@
-import express from "express";
+import express, { type Request, type Response } from "express";
 import { EventEngine } from "@orbital/pulse-core";
 import { WebhookRegistry } from "./registry.js";
 import { createRoutes } from "./routes.js";
 
-const PORT = process.env.PORT || 3000;
-const NETWORK = (process.env.NETWORK as "mainnet" | "testnet") || "testnet";
+// --- Environment validation ---
+
+const VALID_NETWORKS = ["mainnet", "testnet"] as const;
+type Network = (typeof VALID_NETWORKS)[number];
+
+const rawNetwork = process.env.NETWORK;
+if (!rawNetwork || !(VALID_NETWORKS as readonly string[]).includes(rawNetwork)) {
+  console.error(
+    `[server] Invalid or missing NETWORK env var: "${rawNetwork}". Must be "mainnet" or "testnet".`
+  );
+  process.exit(1);
+}
+const NETWORK = rawNetwork as Network;
+
+const rawPort = process.env.PORT;
+const parsedPort = rawPort ? parseInt(rawPort, 10) : NaN;
+let PORT: number;
+if (!rawPort || isNaN(parsedPort) || parsedPort <= 0 || parsedPort > 65535) {
+  console.warn(`[server] Invalid or missing PORT env var: "${rawPort}". Falling back to 3000.`);
+  PORT = 3000;
+} else {
+  PORT = parsedPort;
+}
+
+// --- Bootstrap ---
 
 const engine = new EventEngine({ network: NETWORK });
 engine.start();
@@ -14,14 +37,37 @@ const registry = new WebhookRegistry(engine);
 
 const app = express();
 app.use(express.json());
-
-// Pass both registry and engine into routes
 app.use(createRoutes(registry, engine));
 
-app.get("/health", (_req, res) => {
+app.get("/health", (_req: Request, res: Response) => {
   res.json({ status: "ok", network: NETWORK });
 });
 
-app.listen(PORT, () => {
+const server = app.listen(PORT, () => {
   console.log(`[server] Listening on port ${PORT}`);
 });
+
+// --- Graceful shutdown ---
+
+const SHUTDOWN_TIMEOUT_MS = 5000;
+
+function shutdown(signal: string): void {
+  console.log(`[server] Received ${signal}, shutting down...`);
+
+  // Hard-exit if graceful shutdown takes too long
+  const forceExit = setTimeout(() => {
+    console.error("[server] Graceful shutdown timed out, forcing exit.");
+    process.exit(1);
+  }, SHUTDOWN_TIMEOUT_MS) as unknown as NodeJS.Timeout;
+  // Don't let this timer keep the process alive on its own
+  forceExit.unref();
+  engine.stop();
+
+  server.close(() => {
+    console.log("[server] HTTP server closed. Exiting.");
+    process.exit(0);
+  });
+}
+
+process.on("SIGTERM", () => shutdown("SIGTERM"));
+process.on("SIGINT", () => shutdown("SIGINT"));

--- a/apps/server/src/registry.ts
+++ b/apps/server/src/registry.ts
@@ -1,3 +1,4 @@
+import { createHmac } from "crypto";
 import { EventEngine } from "@orbital/pulse-core";
 import { WebhookDelivery } from "@orbital/pulse-webhooks";
 
@@ -6,9 +7,24 @@ import { WebhookDelivery } from "@orbital/pulse-webhooks";
 export type WebhookRegistration = {
   address: string;
   url: string;
-  secret: string;
+  /** HMAC-SHA256 hash of the original secret — never the plaintext */
+  secretHash: string;
   createdAt: string;
+  /** Retained to keep retry timers alive and enable cleanup */
+  delivery: WebhookDelivery;
 };
+
+/** Shape returned to callers — secret fields are omitted */
+export type WebhookRegistrationPublic = Omit<WebhookRegistration, "secretHash" | "delivery">;
+
+// --- Helpers ---
+
+function hashSecret(secret: string): string {
+  // Use a fixed HMAC key from env so the hash is deterministic for signature
+  // verification, but not reversible without the key.
+  const hmacKey = process.env.WEBHOOK_SECRET ?? "pulse-default-hmac-key";
+  return createHmac("sha256", hmacKey).update(secret).digest("hex");
+}
 
 // --- Registry ---
 
@@ -20,48 +36,62 @@ export class WebhookRegistry {
     this.engine = engine;
   }
 
-  register(address: string, url: string, secret: string): WebhookRegistration {
-    // If already registered, return existing
+  register(address: string, url: string, secret: string): WebhookRegistrationPublic {
+    // Guard: return existing without re-subscribing or re-attaching listeners
     if (this.registrations.has(address)) {
-      return this.registrations.get(address)!;
+      return this.toPublic(this.registrations.get(address)!);
     }
+
+    const secretHash = hashSecret(secret);
+
+    // Subscribe to pulse-core — engine deduplicates by address
+    const watcher = this.engine.subscribe(address);
+
+    // Store the delivery instance so its retry timers are not GC'd
+    const delivery = new WebhookDelivery(watcher, { url, secret });
+
+    // Use watcher.once so this listener cannot accumulate on re-register
+    watcher.once("webhook.failed", (event) => {
+      console.error(`[registry] Webhook delivery failed for ${address}:`, event.raw);
+    });
 
     const registration: WebhookRegistration = {
       address,
       url,
-      secret,
+      secretHash,
       createdAt: new Date().toISOString(),
+      delivery,
     };
-
-    // Subscribe to pulse-core
-    const watcher = this.engine.subscribe(address);
-
-    // Attach webhook delivery
-    new WebhookDelivery(watcher, { url, secret });
-
-    // Listen for delivery failures
-    watcher.on("webhook.failed", (event) => {
-      console.error(`[registry] Webhook delivery failed for ${address}:`, event.raw);
-    });
 
     this.registrations.set(address, registration);
     console.log(`[registry] Registered ${address} → ${url}`);
-    return registration;
+    return this.toPublic(registration);
   }
 
   unregister(address: string): boolean {
     if (!this.registrations.has(address)) return false;
+
+    // Stopping the watcher clears its retry timers via addStopHandler in WebhookDelivery
     this.engine.unsubscribe(address);
     this.registrations.delete(address);
     console.log(`[registry] Unregistered ${address}`);
     return true;
   }
 
-  list(): WebhookRegistration[] {
-    return Array.from(this.registrations.values());
+  list(): WebhookRegistrationPublic[] {
+    return Array.from(this.registrations.values()).map(this.toPublic);
   }
 
   has(address: string): boolean {
     return this.registrations.has(address);
+  }
+
+  /** Returns the stored secret hash for a given address (used for HMAC verification) */
+  getSecretHash(address: string): string | undefined {
+    return this.registrations.get(address)?.secretHash;
+  }
+
+  private toPublic(reg: WebhookRegistration): WebhookRegistrationPublic {
+    return { address: reg.address, url: reg.url, createdAt: reg.createdAt };
   }
 }

--- a/apps/server/src/routes.ts
+++ b/apps/server/src/routes.ts
@@ -1,25 +1,73 @@
-import { Router } from "express";
+import { Router, type Request, type Response } from "express";
+import { StrKey, type EventEngine } from "@orbital/pulse-core";
 import type { WebhookRegistry } from "./registry.js";
-import type { EventEngine } from "@orbital/pulse-core";
+import { requireApiKey } from "./auth.js";
+
+// --- SSRF-safe URL validation ---
+
+const PRIVATE_IP_RE = /^(127\.|10\.|192\.168\.|172\.(1[6-9]|2\d|3[01])\.)/;
+
+function validateWebhookUrl(raw: string): string | null {
+  let parsed: URL;
+  try {
+    parsed = new URL(raw);
+  } catch {
+    return "url must be a valid URL";
+  }
+
+  if (parsed.protocol !== "https:") {
+    return "url must use HTTPS";
+  }
+
+  const hostname = parsed.hostname.toLowerCase();
+  if (hostname === "localhost" || hostname === "::1") {
+    return "url must not target localhost";
+  }
+
+  if (PRIVATE_IP_RE.test(hostname)) {
+    return "url must not target a private IP range";
+  }
+
+  return null; // valid
+}
+
+// --- Routes ---
 
 export function createRoutes(registry: WebhookRegistry, engine: EventEngine): Router {
   const router = Router();
 
+  // Apply auth to every route in this router
+  router.use(requireApiKey);
+
   // Register a webhook
-  router.post("/webhooks/register", (req, res) => {
-    const { address, url, secret } = req.body;
+  router.post("/webhooks/register", (req: Request, res: Response) => {
+    const { address, url, secret } = req.body as Record<string, unknown>;
 
     if (!address || !url || !secret) {
-      res.status(400).json({
-        error: "address, url and secret are required",
-      });
+      res.status(400).json({ error: "address, url and secret are required" });
+      return;
+    }
+
+    if (typeof address !== "string" || typeof url !== "string" || typeof secret !== "string") {
+      res.status(400).json({ error: "address, url and secret must be strings" });
+      return;
+    }
+
+    // Validate Stellar public key
+    if (!StrKey.isValidEd25519PublicKey(address)) {
+      res.status(400).json({ error: "address must be a valid Stellar public key" });
+      return;
+    }
+
+    // Validate webhook URL (HTTPS, no SSRF)
+    const urlError = validateWebhookUrl(url);
+    if (urlError) {
+      res.status(400).json({ error: urlError });
       return;
     }
 
     if (registry.has(address)) {
-      res.status(409).json({
-        error: "Address already registered",
-      });
+      res.status(409).json({ error: "Address already registered" });
       return;
     }
 
@@ -28,7 +76,7 @@ export function createRoutes(registry: WebhookRegistry, engine: EventEngine): Ro
   });
 
   // Unregister a webhook
-  router.delete("/webhooks/:address", (req, res) => {
+  router.delete("/webhooks/:address", (req: Request, res: Response) => {
     const { address } = req.params;
     const removed = registry.unregister(address);
 
@@ -40,40 +88,49 @@ export function createRoutes(registry: WebhookRegistry, engine: EventEngine): Ro
     res.status(200).json({ message: `Unregistered ${address}` });
   });
 
-  // List all registrations
-  router.get("/webhooks", (_req, res) => {
+  // List all registrations — secrets are never included
+  router.get("/webhooks", (_req: Request, res: Response) => {
     res.status(200).json(registry.list());
   });
 
+  // Get a single registration
+  router.get("/webhooks/:address", (req: Request, res: Response) => {
+    const { address } = req.params;
+    if (!registry.has(address)) {
+      res.status(404).json({ error: "Address not registered" });
+      return;
+    }
+    // list() already strips secrets; find the one entry
+    const entry = registry.list().find((r) => r.address === address);
+    res.status(200).json(entry);
+  });
+
   // SSE endpoint — browser connects here to receive live events
-  router.get("/events/:address", (req, res) => {
+  router.get("/events/:address", (req: Request, res: Response) => {
     const { address } = req.params;
 
-    // Set SSE headers
     res.setHeader("Content-Type", "text/event-stream");
     res.setHeader("Cache-Control", "no-cache");
     res.setHeader("Connection", "keep-alive");
     res.flushHeaders();
 
-    // Subscribe to pulse-core
     const watcher = engine.subscribe(address);
 
-    // Send events to browser
     const handler = (event: unknown) => {
       res.write(`data: ${JSON.stringify(event)}\n\n`);
     };
 
     watcher.on("*", handler);
 
-    // Send a heartbeat every 30s to keep connection alive
     const heartbeat = setInterval(() => {
       res.write(`: heartbeat\n\n`);
     }, 30000);
 
-    // Cleanup when browser disconnects
     req.on("close", () => {
       clearInterval(heartbeat);
       watcher.removeListener("*", handler);
+      // Fully remove the watcher from the engine so no dead watchers remain
+      engine.unsubscribe(address);
       console.log(`[sse] Client disconnected from ${address}`);
     });
 

--- a/packages/pulse-core/src/index.ts
+++ b/packages/pulse-core/src/index.ts
@@ -1,5 +1,6 @@
 export { EventEngine } from "./EventEngine.js";
 export { Watcher } from "./Watcher.js";
+export { StrKey } from "@stellar/stellar-sdk";
 
 export type Network = "mainnet" | "testnet";
 


### PR DESCRIPTION
closes #24
…uardrails

- Add API key auth middleware (requireApiKey) applied to all routes
- Hash webhook secrets at rest with HMAC-SHA256, never return in responses
- Validate Stellar address (StrKey.isValidEd25519PublicKey) and webhook URL
- Reject non-HTTPS and private/localhost URLs to prevent SSRF
- Unsubscribe engine watcher on SSE client disconnect (no dead watchers)
- Store WebhookDelivery on registry to prevent GC of retry timers
- Guard register() against duplicate listeners with early return + watcher.once()
- Add SIGTERM/SIGINT graceful shutdown with 5s hard-exit timeout
- Validate NETWORK and PORT env vars at startup, exit(1) on invalid NETWORK
- Add .env.example with API_KEY, NETWORK, PORT, WEBHOOK_SECRET
- Re-export StrKey from pulse-core to avoid lockfile drift in apps/server