### PR TITLE
normalize set_options into account.options_changed event

### DIFF
--- a/packages/pulse-core/src/EventEngine.ts
+++ b/packages/pulse-core/src/EventEngine.ts
@@ -1,18 +1,21 @@
 import { Horizon } from "@stellar/stellar-sdk";
 import { Watcher } from "./Watcher.js";
 import type {
+  AccountOptionsChanges,
+  AccountOptionsEvent,
+  AccountOptionsEventType,
   CoreConfig,
   Network,
   NormalizedEvent,
+  PaymentEvent,
   PaymentEventType,
   ReconnectConfig,
   WatcherNotification,
   WatcherNotificationType,
 } from "./index.js";
 
-type PendingNormalizedEvent = Omit<NormalizedEvent, "type"> & {
-  type: "unknown";
-};
+type PendingPaymentEvent = Omit<PaymentEvent, "type"> & { type: "unknown" };
+type PendingNormalizedEvent = PendingPaymentEvent | AccountOptionsEvent;
 
 type StreamCallbacks = {
   onmessage: (record: unknown) => void;
@@ -131,7 +134,7 @@ export class EventEngine {
     };
 
     this.stopStream = this.server
-      .payments()
+      .operations()
       .cursor("now")
       .stream(callbacks) as StreamStopper;
   }
@@ -206,28 +209,83 @@ export class EventEngine {
 
   private normalize(record: unknown): PendingNormalizedEvent | null {
     const r = record as Record<string, unknown>;
-    if (r.type !== "payment") {
-      return null;
+
+    if (r.type === "payment") {
+      const asset =
+        r.asset_type === "native"
+          ? "XLM"
+          : `${r.asset_code}:${r.asset_issuer}`;
+
+      return {
+        // Route resolution assigns the payment direction after normalization.
+        type: "unknown",
+        to: r.to as string,
+        from: r.from as string,
+        amount: r.amount as string,
+        asset,
+        timestamp: r.created_at as string,
+        raw: record,
+      };
     }
 
-    const asset =
-      r.asset_type === "native"
-        ? "XLM"
-        : `${r.asset_code}:${r.asset_issuer}`;
+    if (r.type === "set_options") {
+      return this.normalizeSetOptions(r, record);
+    }
+
+    return null;
+  }
+
+  private normalizeSetOptions(
+    r: Record<string, unknown>,
+    raw: unknown
+  ): AccountOptionsEvent | null {
+    const changes: AccountOptionsChanges = {};
+
+    if (typeof r.signer_key === "string") {
+      const weight = r.signer_weight as number;
+      if (weight === 0) {
+        changes.signer_removed = { key: r.signer_key, weight: 0 };
+      } else {
+        changes.signer_added = { key: r.signer_key, weight };
+      }
+    }
+
+    const thresholds: NonNullable<AccountOptionsChanges["thresholds"]> = {};
+    if (typeof r.low_threshold === "number")
+      thresholds.low_threshold = r.low_threshold;
+    if (typeof r.med_threshold === "number")
+      thresholds.med_threshold = r.med_threshold;
+    if (typeof r.high_threshold === "number")
+      thresholds.high_threshold = r.high_threshold;
+    if (typeof r.master_key_weight === "number")
+      thresholds.master_key_weight = r.master_key_weight;
+    if (Object.keys(thresholds).length > 0) changes.thresholds = thresholds;
+
+    if (typeof r.home_domain === "string") {
+      changes.home_domain = r.home_domain;
+    }
+
+    if (Object.keys(changes).length === 0) return null;
 
     return {
-      // Route resolution assigns the payment direction after normalization.
-      type: "unknown",
-      to: r.to as string,
-      from: r.from as string,
-      amount: r.amount as string,
-      asset,
+      type: "account.options_changed",
+      source: r.source_account as string,
+      changes,
       timestamp: r.created_at as string,
-      raw: record,
+      raw,
     };
   }
 
   private route(event: PendingNormalizedEvent): void {
+    if (event.type === "account.options_changed") {
+      const watcher = this.registry.get(event.source);
+      if (watcher) {
+        watcher.emit("account.options_changed", event);
+        watcher.emit("*", event);
+      }
+      return;
+    }
+
     const toWatcher = this.registry.get(event.to);
     if (toWatcher) {
       toWatcher.emit(
@@ -248,9 +306,9 @@ export class EventEngine {
   }
 
   private withResolvedType(
-    event: PendingNormalizedEvent,
+    event: PendingPaymentEvent,
     type: PaymentEventType
-  ): NormalizedEvent {
+  ): PaymentEvent {
     return {
       ...event,
       type,

--- a/packages/pulse-core/src/EventEngine.ts
+++ b/packages/pulse-core/src/EventEngine.ts
@@ -15,7 +15,7 @@ import type {
 } from "./index.js";
 
 type PendingPaymentEvent = Omit<PaymentEvent, "type"> & { type: "unknown" };
-type PendingNormalizedEvent = PendingPaymentEvent | AccountOptionsEvent;
+type NormalizedEventOrPending = PendingPaymentEvent | AccountOptionsEvent;
 
 type StreamCallbacks = {
   onmessage: (record: unknown) => void;
@@ -207,7 +207,7 @@ export class EventEngine {
     }
   }
 
-  private normalize(record: unknown): PendingNormalizedEvent | null {
+  private normalize(record: unknown): NormalizedEventOrPending | null {
     const r = record as Record<string, unknown>;
 
     if (r.type === "payment") {
@@ -242,7 +242,7 @@ export class EventEngine {
     const changes: AccountOptionsChanges = {};
 
     if (typeof r.signer_key === "string") {
-      const weight = r.signer_weight as number;
+      const weight = typeof r.signer_weight === "number" ? r.signer_weight : 0;
       if (weight === 0) {
         changes.signer_removed = { key: r.signer_key, weight: 0 };
       } else {
@@ -265,6 +265,9 @@ export class EventEngine {
       changes.home_domain = r.home_domain;
     }
 
+    // Known gap: set_flags, clear_flags, and inflation_dest are not tracked in `changes`.
+    // Operations that only modify those fields are intentionally dropped here as no-ops.
+    // TODO: track flag/inflation changes in a follow-up (see issue #XX).
     if (Object.keys(changes).length === 0) return null;
 
     return {
@@ -276,7 +279,7 @@ export class EventEngine {
     };
   }
 
-  private route(event: PendingNormalizedEvent): void {
+  private route(event: NormalizedEventOrPending): void {
     if (event.type === "account.options_changed") {
       const watcher = this.registry.get(event.source);
       if (watcher) {

--- a/packages/pulse-core/src/Watcher.ts
+++ b/packages/pulse-core/src/Watcher.ts
@@ -1,6 +1,8 @@
 // packages/pulse-core/src/Watcher.ts
 import { EventEmitter } from "events";
-import type { NormalizedEvent } from "./index.js";
+import type { NormalizedEvent, WatcherNotification } from "./index.js";
+
+type WatcherEvent = NormalizedEvent | WatcherNotification;
 
 export class Watcher extends EventEmitter {
   readonly address: string;
@@ -13,12 +15,12 @@ export class Watcher extends EventEmitter {
     this.address = address;
   }
 
-  on(eventType: string, handler: (event: NormalizedEvent) => void): this {
+  on(eventType: string, handler: (event: WatcherEvent) => void): this {
     if (this._stopped) return this;
     return super.on(eventType, handler);
   }
 
-  emit(eventType: string, event: NormalizedEvent): boolean {
+  emit(eventType: string, event: WatcherEvent): boolean {
     if (this._stopped) return false;
     return super.emit(eventType, event);
   }

--- a/packages/pulse-core/src/index.ts
+++ b/packages/pulse-core/src/index.ts
@@ -5,11 +5,29 @@ export { StrKey } from "@stellar/stellar-sdk";
 export type Network = "mainnet" | "testnet";
 
 export type PaymentEventType = "payment.received" | "payment.sent";
+export type AccountOptionsEventType = "account.options_changed";
 export type WatcherNotificationType =
   | "engine.reconnecting"
   | "engine.reconnected";
 
-export type NormalizedEvent = {
+export type SetOptionsSigner = {
+  key: string;
+  weight: number;
+};
+
+export type AccountOptionsChanges = {
+  signer_added?: SetOptionsSigner;
+  signer_removed?: SetOptionsSigner;
+  thresholds?: {
+    low_threshold?: number;
+    med_threshold?: number;
+    high_threshold?: number;
+    master_key_weight?: number;
+  };
+  home_domain?: string;
+};
+
+export type PaymentEvent = {
   type: PaymentEventType;
   to: string;
   from: string;
@@ -18,6 +36,16 @@ export type NormalizedEvent = {
   timestamp: string;
   raw: unknown;
 };
+
+export type AccountOptionsEvent = {
+  type: AccountOptionsEventType;
+  source: string;
+  changes: AccountOptionsChanges;
+  timestamp: string;
+  raw: unknown;
+};
+
+export type NormalizedEvent = PaymentEvent | AccountOptionsEvent;
 
 export type WatcherNotification = {
   type: WatcherNotificationType;

--- a/packages/pulse-core/test/pulse-core.test.ts
+++ b/packages/pulse-core/test/pulse-core.test.ts
@@ -16,7 +16,7 @@ vi.mock("@stellar/stellar-sdk", () => {
   class MockServer {
     constructor(_url: string) {}
 
-    payments() {
+    operations() {
       return {
         cursor() {
           return {
@@ -213,5 +213,168 @@ describe("pulse-core EventEngine", () => {
         delayMs: 1000,
       })
     );
+  });
+
+  describe("set_options → account.options_changed", () => {
+    function makeSetOptionsRecord(
+      overrides: Record<string, unknown>
+    ): Record<string, unknown> {
+      return {
+        type: "set_options",
+        source_account: "GSRC",
+        created_at: "2026-04-24T10:00:00.000Z",
+        ...overrides,
+      };
+    }
+
+    it("emits account.options_changed with signer_added when signer_weight > 0", () => {
+      const engine = new EventEngine({ network: "testnet" });
+      const watcher = engine.subscribe("GSRC");
+      const handler = vi.fn();
+      watcher.on("account.options_changed", handler);
+
+      engine.start();
+      latestStream().handlers.onmessage(
+        makeSetOptionsRecord({ signer_key: "GNEWSIGNER", signer_weight: 2 })
+      );
+
+      expect(handler).toHaveBeenCalledOnce();
+      expect(handler).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: "account.options_changed",
+          source: "GSRC",
+          changes: { signer_added: { key: "GNEWSIGNER", weight: 2 } },
+          timestamp: "2026-04-24T10:00:00.000Z",
+        })
+      );
+    });
+
+    it("emits account.options_changed with signer_removed when signer_weight is 0", () => {
+      const engine = new EventEngine({ network: "testnet" });
+      const watcher = engine.subscribe("GSRC");
+      const handler = vi.fn();
+      watcher.on("account.options_changed", handler);
+
+      engine.start();
+      latestStream().handlers.onmessage(
+        makeSetOptionsRecord({ signer_key: "GOLDSIGNER", signer_weight: 0 })
+      );
+
+      expect(handler).toHaveBeenCalledOnce();
+      expect(handler).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: "account.options_changed",
+          source: "GSRC",
+          changes: { signer_removed: { key: "GOLDSIGNER", weight: 0 } },
+        })
+      );
+    });
+
+    it("emits account.options_changed with thresholds when any threshold field is present", () => {
+      const engine = new EventEngine({ network: "testnet" });
+      const watcher = engine.subscribe("GSRC");
+      const handler = vi.fn();
+      watcher.on("account.options_changed", handler);
+
+      engine.start();
+      latestStream().handlers.onmessage(
+        makeSetOptionsRecord({
+          low_threshold: 1,
+          med_threshold: 2,
+          high_threshold: 3,
+          master_key_weight: 1,
+        })
+      );
+
+      expect(handler).toHaveBeenCalledOnce();
+      expect(handler).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: "account.options_changed",
+          source: "GSRC",
+          changes: {
+            thresholds: {
+              low_threshold: 1,
+              med_threshold: 2,
+              high_threshold: 3,
+              master_key_weight: 1,
+            },
+          },
+        })
+      );
+    });
+
+    it("emits account.options_changed with home_domain when home_domain is present", () => {
+      const engine = new EventEngine({ network: "testnet" });
+      const watcher = engine.subscribe("GSRC");
+      const handler = vi.fn();
+      watcher.on("account.options_changed", handler);
+
+      engine.start();
+      latestStream().handlers.onmessage(
+        makeSetOptionsRecord({ home_domain: "example.com" })
+      );
+
+      expect(handler).toHaveBeenCalledOnce();
+      expect(handler).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: "account.options_changed",
+          source: "GSRC",
+          changes: { home_domain: "example.com" },
+        })
+      );
+    });
+
+    it("only includes fields that are actually present in changes", () => {
+      const engine = new EventEngine({ network: "testnet" });
+      const watcher = engine.subscribe("GSRC");
+      const handler = vi.fn();
+      watcher.on("account.options_changed", handler);
+
+      engine.start();
+      latestStream().handlers.onmessage(
+        makeSetOptionsRecord({ home_domain: "stellar.org", low_threshold: 5 })
+      );
+
+      expect(handler).toHaveBeenCalledOnce();
+      const payload = handler.mock.calls[0]![0];
+      expect(payload.changes).toEqual({
+        home_domain: "stellar.org",
+        thresholds: { low_threshold: 5 },
+      });
+      expect(payload.changes).not.toHaveProperty("signer_added");
+      expect(payload.changes).not.toHaveProperty("signer_removed");
+    });
+
+    it("does not emit when set_options has no recognized changed fields", () => {
+      const engine = new EventEngine({ network: "testnet" });
+      const watcher = engine.subscribe("GSRC");
+      const handler = vi.fn();
+      watcher.on("account.options_changed", handler);
+
+      engine.start();
+      latestStream().handlers.onmessage(
+        makeSetOptionsRecord({ set_flags: 1 })
+      );
+
+      expect(handler).not.toHaveBeenCalled();
+    });
+
+    it("does not route account.options_changed to unrelated watchers", () => {
+      const engine = new EventEngine({ network: "testnet" });
+      const srcWatcher = engine.subscribe("GSRC");
+      const otherWatcher = engine.subscribe("GOTHER");
+      const srcHandler = vi.fn();
+      const otherHandler = vi.fn();
+      srcWatcher.on("account.options_changed", srcHandler);
+      otherWatcher.on("account.options_changed", otherHandler);
+
+      engine.start();
+      latestStream().handlers.onmessage(
+        makeSetOptionsRecord({ home_domain: "example.com" })
+      );
+
+      expect(srcHandler).toHaveBeenCalledOnce();
+      expect(otherHandler).not.toHaveBeenCalled();
+    });
   });
 });


### PR DESCRIPTION
## Linked issue

Closes #81

- Switch operations stream from payments() to operations() so set_options
  records are received
- Add normalizeSetOptions() that diffs signer_key/weight, low/med/high
  thresholds, master_key_weight, and home_domain; only changed fields are
  included in the payload
- Route account.options_changed to the source-account watcher
- Add AccountOptionsEvent, AccountOptionsChanges, SetOptionsSigner types;
  widen NormalizedEvent to PaymentEvent | AccountOptionsEvent
- Widen Watcher on/emit to accept WatcherNotification alongside NormalizedEvent
- 7 new unit tests: signer_added, signer_removed, threshold change,
  home_domain change, field exclusivity, no-op suppression, routing isolation