### PR TITLE
fix: set 16kb body size limit on express.json()

### DIFF
--- a/apps/server/README.md
+++ b/apps/server/README.md
@@ -66,6 +66,7 @@ useStellarEvent({
 
 ## Security defaults
 
+- **Request body limit.** `express.json()` enforces a **16 kb** maximum body size. Webhook registration payloads are small by design; oversized requests are rejected with `413 Payload Too Large`.
 - **HTTPS enforcement.** The server rejects `http://`, `localhost`, and private-IP-range webhook URLs at registration time to prevent SSRF.
 - **Stellar key validation.** Registered addresses must pass `StrKey.isValidEd25519PublicKey` before they're accepted.
 - **Secrets are hashed.** Webhook secrets are HMAC-hashed before storage; the plaintext never persists beyond the request.

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -36,7 +36,7 @@ console.log(`[server] Event engine started on ${NETWORK}`);
 const registry = new WebhookRegistry(engine);
 
 const app = express();
-app.use(express.json());
+app.use(express.json({ limit: "16kb" }));
 app.use(createRoutes(registry, engine));
 
 app.get("/health", (_req: Request, res: Response) => {


### PR DESCRIPTION
- Pass { limit: '16kb' } to express.json() in apps/server/src/index.ts
- Document the limit in apps/server/README.md security defaults

## Linked issue

Closes #162

## What changed and why

Sets an explicit 16kb body size limit on express.json() in the reference server.
The Express default of 100kb is unnecessarily generous for webhook registration
payloads, which are small by design. Making the limit explicit removes 
ambiguity and reduces the attack surface for oversized-body abuse. The limit is 
also documented in the server README under Security defaults.

## Test plan

- [ ] Existing tests pass (pnpm test)
- [ ] New tests added for new behaviour
- [ ] Typechecks pass (pnpm -r typecheck)
- [ ] Manually tested against testnet / mainnet (describe what you tested)

## Breaking changes

None

## Notes for reviewers

The only functional change is express.json() → express.json({ limit: "16kb" }). 
Requests with a body larger than 16kb will now receive a 413 Payload Too Large 
response. No existing endpoint accepts bodies anywhere near that size, so no 
legitimate client should be affected.