### PR TITLE
fix: normalize change_trust into typed trustline lifecycle events

### DIFF
--- a/packages/pulse-core/src/EventEngine.ts
+++ b/packages/pulse-core/src/EventEngine.ts
@@ -3,19 +3,23 @@ import { Watcher } from "./Watcher.js";
 import type {
   AccountOptionsChanges,
   AccountOptionsEvent,
-  AccountOptionsEventType,
   CoreConfig,
   Network,
   NormalizedEvent,
   PaymentEvent,
   PaymentEventType,
   ReconnectConfig,
+  TrustlineEvent,
+  TrustlineEventType,
   WatcherNotification,
   WatcherNotificationType,
 } from "./index.js";
 
 type PendingPaymentEvent = Omit<PaymentEvent, "type"> & { type: "unknown" };
-type NormalizedEventOrPending = PendingPaymentEvent | AccountOptionsEvent;
+type NormalizedEventOrPending =
+  | PendingPaymentEvent
+  | AccountOptionsEvent
+  | TrustlineEvent;
 
 type StreamCallbacks = {
   onmessage: (record: unknown) => void;
@@ -36,6 +40,8 @@ const DEFAULT_RECONNECT: Required<ReconnectConfig> = {
   maxDelayMs: 30000,
   maxRetries: Number.POSITIVE_INFINITY,
 };
+
+const STELLAR_MAX_TRUSTLINE_LIMIT = "922337203685.4775807";
 
 export class EventEngine {
   private server: Horizon.Server;
@@ -234,7 +240,59 @@ export class EventEngine {
       return this.normalizeSetOptions(r, record);
     }
 
+    if (r.type === "change_trust") {
+      return this.normalizeChangeTrust(r, record);
+    }
+
     return null;
+  }
+
+  private normalizeChangeTrust(
+    r: Record<string, unknown>,
+    raw: unknown
+  ): TrustlineEvent | null {
+    if (typeof r.source_account !== "string") {
+      return null;
+    }
+
+    if (typeof r.created_at !== "string") {
+      return null;
+    }
+
+    if (typeof r.limit !== "string" && typeof r.limit !== "number") {
+      return null;
+    }
+
+    const asset =
+      r.asset_type === "native"
+        ? "XLM"
+        : `${r.asset_code as string}:${r.asset_issuer as string}`;
+    const limit = String(r.limit);
+
+    return {
+      type: this.resolveTrustlineEventType(limit),
+      account: r.source_account,
+      asset,
+      limit,
+      timestamp: r.created_at,
+      raw,
+    };
+  }
+
+  private resolveTrustlineEventType(limit: string): TrustlineEventType {
+    if (this.isZeroTrustlineLimit(limit)) {
+      return "trustline.removed";
+    }
+
+    if (limit === STELLAR_MAX_TRUSTLINE_LIMIT) {
+      return "trustline.added";
+    }
+
+    return "trustline.updated";
+  }
+
+  private isZeroTrustlineLimit(limit: string): boolean {
+    return /^0(?:\.0+)?$/.test(limit);
   }
 
   private normalizeSetOptions(
@@ -288,6 +346,23 @@ export class EventEngine {
         watcher.emit("account.options_changed", event);
         watcher.emit("*", event);
       }
+      return;
+    }
+
+    if (
+      event.type === "trustline.added" ||
+      event.type === "trustline.removed" ||
+      event.type === "trustline.updated"
+    ) {
+      const watcher = this.registry.get(event.account);
+      if (watcher) {
+        watcher.emit(event.type, event);
+        watcher.emit("*", event);
+      }
+      return;
+    }
+
+    if (event.type !== "unknown") {
       return;
     }
 

--- a/packages/pulse-core/src/index.ts
+++ b/packages/pulse-core/src/index.ts
@@ -6,6 +6,10 @@ export type Network = "mainnet" | "testnet";
 
 export type PaymentEventType = "payment.received" | "payment.sent";
 export type AccountOptionsEventType = "account.options_changed";
+export type TrustlineEventType =
+  | "trustline.added"
+  | "trustline.removed"
+  | "trustline.updated";
 export type WatcherNotificationType =
   | "engine.reconnecting"
   | "engine.reconnected";
@@ -45,7 +49,19 @@ export type AccountOptionsEvent = {
   raw: unknown;
 };
 
-export type NormalizedEvent = PaymentEvent | AccountOptionsEvent;
+export type TrustlineEvent = {
+  type: TrustlineEventType;
+  account: string;
+  asset: string;
+  limit: string;
+  timestamp: string;
+  raw: unknown;
+};
+
+export type NormalizedEvent =
+  | PaymentEvent
+  | AccountOptionsEvent
+  | TrustlineEvent;
 
 export type WatcherNotification = {
   type: WatcherNotificationType;

--- a/packages/pulse-core/test/pulse-core.test.ts
+++ b/packages/pulse-core/test/pulse-core.test.ts
@@ -377,4 +377,104 @@ describe("pulse-core EventEngine", () => {
       expect(otherHandler).not.toHaveBeenCalled();
     });
   });
+
+  describe("change_trust → trustline.*", () => {
+    function makeChangeTrustRecord(
+      overrides: Record<string, unknown>
+    ): Record<string, unknown> {
+      return {
+        type: "change_trust",
+        source_account: "GSRC",
+        asset_type: "credit_alphanum4",
+        asset_code: "USDC",
+        asset_issuer: "GISSUER",
+        limit: "922337203685.4775807",
+        created_at: "2026-04-24T10:00:00.000Z",
+        ...overrides,
+      };
+    }
+
+    it("emits trustline.added for max trustline limit", () => {
+      const engine = new EventEngine({ network: "testnet" });
+      const watcher = engine.subscribe("GSRC");
+      const handler = vi.fn();
+      watcher.on("trustline.added", handler);
+
+      engine.start();
+      latestStream().handlers.onmessage(makeChangeTrustRecord({}));
+
+      expect(handler).toHaveBeenCalledOnce();
+      expect(handler).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: "trustline.added",
+          account: "GSRC",
+          asset: "USDC:GISSUER",
+          limit: "922337203685.4775807",
+          timestamp: "2026-04-24T10:00:00.000Z",
+        })
+      );
+    });
+
+    it("emits trustline.removed when limit is zero", () => {
+      const engine = new EventEngine({ network: "testnet" });
+      const watcher = engine.subscribe("GSRC");
+      const handler = vi.fn();
+      watcher.on("trustline.removed", handler);
+
+      engine.start();
+      latestStream().handlers.onmessage(
+        makeChangeTrustRecord({ limit: "0.0000000" })
+      );
+
+      expect(handler).toHaveBeenCalledOnce();
+      expect(handler).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: "trustline.removed",
+          account: "GSRC",
+          asset: "USDC:GISSUER",
+          limit: "0.0000000",
+        })
+      );
+    });
+
+    it("emits trustline.updated when limit is non-zero and not max", () => {
+      const engine = new EventEngine({ network: "testnet" });
+      const watcher = engine.subscribe("GSRC");
+      const handler = vi.fn();
+      watcher.on("trustline.updated", handler);
+
+      engine.start();
+      latestStream().handlers.onmessage(
+        makeChangeTrustRecord({ limit: "2500.0000000" })
+      );
+
+      expect(handler).toHaveBeenCalledOnce();
+      expect(handler).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: "trustline.updated",
+          account: "GSRC",
+          asset: "USDC:GISSUER",
+          limit: "2500.0000000",
+        })
+      );
+    });
+
+    it("does not route trustline events to unrelated watchers", () => {
+      const engine = new EventEngine({ network: "testnet" });
+      const sourceWatcher = engine.subscribe("GSRC");
+      const otherWatcher = engine.subscribe("GOTHER");
+      const sourceHandler = vi.fn();
+      const otherHandler = vi.fn();
+      sourceWatcher.on("trustline.updated", sourceHandler);
+      otherWatcher.on("trustline.updated", otherHandler);
+
+      engine.start();
+      latestStream().handlers.onmessage(
+        makeChangeTrustRecord({ limit: "3000.0000000" })
+      );
+
+      expect(sourceHandler).toHaveBeenCalledOnce();
+      expect(otherHandler).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/packages/pulse-webhooks/src/index.ts
+++ b/packages/pulse-webhooks/src/index.ts
@@ -60,7 +60,6 @@ export class WebhookDelivery {
       } else {
         this.watcher.emit("webhook.failed", {
           ...event,
-          type: event.type,
           raw: {
             error: errorMessage,
             url: this.config.url,


### PR DESCRIPTION
Closes #75

## Summary
Normalizes `change_trust` operations emitted by Horizon in `pulse-core`, enabling clients to distinguish trustline add, remove, and limit update actions.

## Root Cause
`EventEngine` only normalized `payment` and `set_options` records. There was no `change_trust` normalization path, no trustline event type in the exported union, and no routing for trustline events to source-account watchers.

## Fix
- Added `TrustlineEvent` and `TrustlineEventType` to `pulse-core` exports
- Implemented `change_trust` normalization in `EventEngine` with payload fields: `account`, `asset`, `limit`, `timestamp`, `raw`
- Classified lifecycle event types:
  - `trustline.removed` — zero limit
  - `trustline.added` — Stellar max trustline limit
  - `trustline.updated` — otherwise
- Routed trustline events to the source-account watcher and wildcard channel
- Added unit tests covering added/removed/updated states and source-only routing
- Applied a minimal downstream typing compatibility fix in `pulse-webhooks` (no runtime behavior change)

## Testing
- ✅ `pulse-core` Vitest suite — 15 tests pass
- ✅ `pulse-core` typecheck passes
- ✅ Package CI-equivalent typechecks for `pulse-webhooks` and `pulse-notify` pass
- ✅ Recursive package tests pass

## CI
Changes validated against the same package-level checks used by the repository CI workflow: build, typecheck, and tests.