### PR TITLE
fix: drop redundant registry.clear() in EventEngine.stop() (#64)

### DIFF
--- a/packages/pulse-core/src/EventEngine.ts
+++ b/packages/pulse-core/src/EventEngine.ts
@@ -94,8 +94,6 @@ export class EventEngine {
     for (const watcher of this.registry.values()) {
       watcher.stop();
     }
-
-    this.registry.clear();
   }
 
   private openStream(isReconnect: boolean): void {

--- a/packages/pulse-core/test/pulse-core.test.ts
+++ b/packages/pulse-core/test/pulse-core.test.ts
@@ -102,6 +102,20 @@ describe("pulse-core EventEngine", () => {
     });
   });
 
+  it("empties the registry via stop handlers when stop() is called", () => {
+    const engine = new EventEngine({ network: "testnet" });
+    engine.subscribe("GABC");
+    engine.subscribe("GDEF");
+
+    const registry = (engine as unknown as { registry: Map<string, unknown> })
+      .registry;
+    expect(registry.size).toBe(2);
+
+    engine.stop();
+
+    expect(registry.size).toBe(0);
+  });
+
   it("removes stopped watchers from the registry and keeps stop idempotent", () => {
     const engine = new EventEngine({ network: "testnet" });
     const watcher = engine.subscribe("GABC");


### PR DESCRIPTION
What changed

Removed the trailing this.registry.clear() call from EventEngine.stop().

Why

Each watcher's stop handler already deletes its own entry from the registry — this is registered in subscribe() at line 60. The clear() call was dead code that made the lifecycle contract harder to reason about, implying the registry needed a manual sweep when it didn't.

Test

Added a unit test that subscribes two watchers, calls stop(), and asserts registry.size === 0 — confirming the invariant is upheld by the stop handlers alone, without any explicit clear.

Closes #64