### PR TITLE
feat: multiple-delivery-ur-ls-per-watcher-fan-out

### DIFF
--- a/apps/web/content/api/pulse-webhooks.md
+++ b/apps/web/content/api/pulse-webhooks.md
@@ -5,7 +5,7 @@ description: HMAC-signed webhook delivery with automatic retry.
 
 ## Overview
 
-`@orbital/pulse-webhooks` wraps a `Watcher` and delivers events to an HTTP endpoint. Each delivery is signed with HMAC-SHA256 so your server can verify authenticity.
+`@orbital/pulse-webhooks` wraps a `Watcher` and delivers events to one or more HTTP endpoints. Each delivery is signed with HMAC-SHA256 so your server can verify authenticity.
 
 ## Installation
 
@@ -21,7 +21,10 @@ npm install @orbital/pulse-webhooks
 import { WebhookDelivery } from '@orbital/pulse-webhooks'
 
 const delivery = new WebhookDelivery(watcher, {
-  url: 'https://your-app.com/webhook',
+  url: [
+    'https://your-app.com/webhook',
+    'https://staging.your-app.com/webhook',
+  ],
   secret: 'my-signing-secret',
   retries: 3,               // optional, default: 3
   deliveryTimeoutMs: 10000, // optional, default: 10000
@@ -32,7 +35,7 @@ const delivery = new WebhookDelivery(watcher, {
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `url` | `string` | — | Endpoint to POST events to |
+| `url` | `string \| string[]` | — | Endpoint to POST events to, or a list of endpoints for fan-out |
 | `secret` | `string` | — | HMAC signing secret |
 | `retries` | `number` | `3` | Max delivery attempts |
 | `deliveryTimeoutMs` | `number` | `10000` | Per-attempt timeout in ms |
@@ -40,8 +43,8 @@ const delivery = new WebhookDelivery(watcher, {
 ### Events
 
 ```typescript
-delivery.on('webhook.failed', ({ event, error }) => {
-  console.error(`Delivery failed after all retries: ${error.message}`)
+watcher.on('webhook.failed', (event) => {
+  console.error(`Delivery failed for ${event.raw.url}: ${event.raw.error}`)
 })
 ```
 
@@ -86,3 +89,5 @@ Every webhook POST includes:
 | `X-Orbital-Signature` | HMAC-SHA256 hex digest of the body |
 | `X-Orbital-Event` | Event type (e.g. `payment.received`) |
 | `X-Orbital-Timestamp` | ISO 8601 delivery time |
+
+When `url` is an array, each URL is delivered in parallel and retried independently.

--- a/packages/pulse-webhooks/README.md
+++ b/packages/pulse-webhooks/README.md
@@ -1,6 +1,6 @@
 # @orbital/pulse-webhooks
 
-**HMAC-signed webhook delivery for Stellar events.** Attach to a `pulse-core` watcher and every event becomes an outbound HTTPS POST with a verifiable signature, retry on failure, and configurable timeout.
+**HMAC-signed webhook delivery for Stellar events.** Attach to a `pulse-core` watcher and every event becomes one or more outbound HTTPS POSTs with a verifiable signature, retry on failure, and configurable timeout.
 
 ```bash
 pnpm add @orbital/pulse-webhooks @orbital/pulse-core
@@ -8,7 +8,7 @@ pnpm add @orbital/pulse-webhooks @orbital/pulse-core
 
 ## What it does
 
-`pulse-webhooks` is the "push" side of Orbital. It listens to a `Watcher`, serializes events to JSON, signs the payload with HMAC-SHA256, and POSTs to your endpoint. On transient failure it retries with exponential backoff; on permanent failure it emits a `webhook.failed` event you can catch and route to a dead-letter queue.
+`pulse-webhooks` is the "push" side of Orbital. It listens to a `Watcher`, serializes events to JSON, signs the payload with HMAC-SHA256, and POSTs to one or more endpoints. On transient failure it retries each URL independently with exponential backoff; on permanent failure it emits a `webhook.failed` event you can catch and route to a dead-letter queue.
 
 Consumers verify the signature using the shared secret you provisioned — `verifyWebhook` is exported for that purpose.
 
@@ -24,7 +24,10 @@ engine.start();
 const watcher = engine.subscribe("GABC...");
 
 new WebhookDelivery(watcher, {
-  url: "https://your-app.com/hooks/stellar",
+  url: [
+    "https://your-app.com/hooks/stellar",
+    "https://staging.your-app.com/hooks/stellar",
+  ],
   secret: process.env.WEBHOOK_SECRET!,
   retries: 3,
   deliveryTimeoutMs: 10_000,
@@ -56,11 +59,11 @@ app.post("/hooks/stellar", express.text({ type: "*/*" }), (req, res) => {
 
 ### `new WebhookDelivery(watcher, config)`
 
-Attaches a delivery driver to a `Watcher`. Every event the watcher emits is delivered to `config.url`.
+Attaches a delivery driver to a `Watcher`. Every event the watcher emits is delivered to each URL in `config.url`.
 
 | Field | Type | Default | Description |
 |---|---|---|---|
-| `config.url` | `string` | — | Destination endpoint. Must be HTTPS in production. |
+| `config.url` | `string \| string[]` | — | One destination endpoint or a fan-out list of endpoints. Must be HTTPS in production. |
 | `config.secret` | `string` | — | Shared secret used to sign payloads |
 | `config.retries` | `number` | `3` | Number of retry attempts before emitting `webhook.failed` |
 | `config.deliveryTimeoutMs` | `number` | `10_000` | Abort threshold for each HTTP attempt |
@@ -82,7 +85,7 @@ Uses `crypto.timingSafeEqual` under the hood — do not roll your own comparison
   - `x-orbital-attempt`: `1`, `2`, … up to `retries`
 - **Success:** Any 2xx response
 - **Retry:** Any non-2xx, network error, or timeout. Backoff is exponential: `2^(attempt-1) × 1000 ms`.
-- **Failure:** After `retries` unsuccessful attempts, the watcher emits `webhook.failed` with the original event in `raw.originalEvent`.
+- **Failure:** After `retries` unsuccessful attempts for a given URL, the watcher emits `webhook.failed` with the original event in `raw.originalEvent` and the failed target in `raw.url`.
 
 ## Security
 
@@ -102,7 +105,6 @@ Uses `crypto.timingSafeEqual` under the hood — do not roll your own comparison
 ## Current limitations
 
 - Retries live in-process. Restarting the process loses pending retries. Persistent retry queues are tracked in [`webhooks`](https://github.com/orbital/orbital/labels/webhooks).
-- Single endpoint per watcher. Fan-out to multiple destinations is a planned enhancement.
 - Exponential backoff is hard-coded. Configurable strategies (linear, jittered, capped-at-N-hours) are open issues.
 
 ## License

--- a/packages/pulse-webhooks/package.json
+++ b/packages/pulse-webhooks/package.json
@@ -5,13 +5,15 @@
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "scripts": {
-    "build": "tsc -p tsconfig.json"
+    "build": "tsc -p tsconfig.json",
+    "test": "vitest run"
   },
   "dependencies": {
     "@orbital/pulse-core": "workspace:*"
   },
   "devDependencies": {
     "@types/node": "^25.6.0",
-    "tsx": "^4.0.0"
+    "tsx": "^4.0.0",
+    "vitest": "^4.1.5"
   }
 }

--- a/packages/pulse-webhooks/src/index.ts
+++ b/packages/pulse-webhooks/src/index.ts
@@ -1,5 +1,6 @@
-import { createHmac, timingSafeEqual } from "crypto";
 import type { NormalizedEvent, Watcher } from "@orbital/pulse-core";
+import { createHmac, timingSafeEqual } from "crypto";
+
 import type { WebhookConfig } from "./types.js";
 export type { WebhookConfig } from "./types.js";
 
@@ -12,6 +13,7 @@ type ResolvedWebhookConfig = Omit<Required<WebhookConfig>, "url"> & {
 export class WebhookDelivery {
   private config: ResolvedWebhookConfig;
   private watcher: Watcher;
+  // Shared across URLs so watcher.stop() can cancel every pending retry in one pass.
   private retryTimers: Set<ReturnType<typeof setTimeout>> = new Set();
 
   constructor(watcher: Watcher, config: WebhookConfig) {
@@ -36,7 +38,7 @@ export class WebhookDelivery {
     });
   }
 
-  private async deliverToUrl(
+  private async deliverToUrl (
     event: NormalizedEvent,
     url: string,
     attempt = 1
@@ -91,14 +93,14 @@ export class WebhookDelivery {
     }
   }
 
-  private clearRetryTimers(): void {
+  private clearRetryTimers (): void {
     for (const retryTimer of this.retryTimers) {
       clearTimeout(retryTimer);
     }
     this.retryTimers.clear();
   }
 
-  private getErrorMessage(err: unknown): string {
+  private getErrorMessage (err: unknown): string {
     if (err instanceof Error && err.name === "AbortError") {
       return `Delivery timed out after ${this.config.deliveryTimeoutMs}ms`;
     }
@@ -106,7 +108,7 @@ export class WebhookDelivery {
     return err instanceof Error ? err.message : "Unknown error";
   }
 
-  private sign(payload: string): string {
+  private sign (payload: string): string {
     return createHmac("sha256", this.config.secret)
       .update(payload)
       .digest("hex");
@@ -115,7 +117,7 @@ export class WebhookDelivery {
 
 // --- verifyWebhook ---
 
-export function verifyWebhook(
+export function verifyWebhook (
   payload: string,
   signature: string,
   secret: string

--- a/packages/pulse-webhooks/src/index.ts
+++ b/packages/pulse-webhooks/src/index.ts
@@ -3,27 +3,44 @@ import type { NormalizedEvent, Watcher } from "@orbital/pulse-core";
 import type { WebhookConfig } from "./types.js";
 export type { WebhookConfig } from "./types.js";
 
+type ResolvedWebhookConfig = Omit<Required<WebhookConfig>, "url"> & {
+  urls: string[];
+};
+
 // --- WebhookDelivery ---
 
 export class WebhookDelivery {
-  private config: Required<WebhookConfig>;
+  private config: ResolvedWebhookConfig;
   private watcher: Watcher;
   private retryTimers: Set<ReturnType<typeof setTimeout>> = new Set();
 
   constructor(watcher: Watcher, config: WebhookConfig) {
     this.watcher = watcher;
-    this.config = { retries: 3, deliveryTimeoutMs: 10000, ...config };
+    this.config = {
+      retries: 3,
+      deliveryTimeoutMs: 10000,
+      ...config,
+      urls: Array.isArray(config.url) ? [...config.url] : [config.url],
+    };
 
     this.watcher.addStopHandler(() => {
       this.clearRetryTimers();
     });
 
     this.watcher.on("*", (event) => {
-      if ("raw" in event) this.deliver(event);
+      if ("raw" in event) {
+        for (const url of this.config.urls) {
+          void this.deliverToUrl(event, url);
+        }
+      }
     });
   }
 
-  private async deliver(event: NormalizedEvent, attempt = 1): Promise<void> {
+  private async deliverToUrl(
+    event: NormalizedEvent,
+    url: string,
+    attempt = 1
+  ): Promise<void> {
     if (this.watcher.stopped) return;
 
     const payload = JSON.stringify(event);
@@ -33,7 +50,7 @@ export class WebhookDelivery {
     const abortTimer = setTimeout(() => controller.abort(), timeoutMs);
 
     try {
-      const res = await fetch(this.config.url, {
+      const res = await fetch(url, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
@@ -54,7 +71,7 @@ export class WebhookDelivery {
         const delay = Math.pow(2, attempt - 1) * 1000;
         const retryTimer = setTimeout(() => {
           this.retryTimers.delete(retryTimer);
-          void this.deliver(event, attempt + 1);
+          void this.deliverToUrl(event, url, attempt + 1);
         }, delay);
         this.retryTimers.add(retryTimer);
       } else {
@@ -63,7 +80,7 @@ export class WebhookDelivery {
           type: event.type,
           raw: {
             error: errorMessage,
-            url: this.config.url,
+            url,
             attempts: attempt,
             originalEvent: event,
           },

--- a/packages/pulse-webhooks/src/types.ts
+++ b/packages/pulse-webhooks/src/types.ts
@@ -1,5 +1,5 @@
 export type WebhookConfig = {
-  url: string;
+  url: string | string[];
   secret: string;
   retries?: number;
   deliveryTimeoutMs?: number;

--- a/packages/pulse-webhooks/test/pulse-webhooks.test.ts
+++ b/packages/pulse-webhooks/test/pulse-webhooks.test.ts
@@ -1,0 +1,137 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { Watcher } from "@orbital/pulse-core";
+import { WebhookDelivery } from "../src/index.js";
+
+const deliveryEvent = {
+    type: "payment.received",
+    to: "GDEST",
+    from: "GSRC",
+    amount: "10",
+    asset: "XLM",
+    timestamp: "2026-04-26T12:00:00.000Z",
+    raw: { id: "evt_1" },
+} as const;
+
+async function flushAsyncWork (): Promise<void> {
+    await Promise.resolve();
+    await Promise.resolve();
+}
+
+describe("pulse-webhooks WebhookDelivery", () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+        vi.unstubAllGlobals();
+        vi.restoreAllMocks();
+    });
+
+    it("delivers each event to every configured URL", () => {
+        const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200 });
+        vi.stubGlobal("fetch", fetchMock);
+
+        const watcher = new Watcher("GABC");
+        new WebhookDelivery(watcher, {
+            url: [
+                "https://prod.example.com/webhooks/stellar",
+                "https://staging.example.com/webhooks/stellar",
+                "https://audit.example.com/webhooks/stellar",
+            ],
+            secret: "top-secret",
+        });
+
+        watcher.emit("*", deliveryEvent);
+
+        expect(fetchMock).toHaveBeenCalledTimes(3);
+        expect(fetchMock).toHaveBeenNthCalledWith(
+            1,
+            "https://prod.example.com/webhooks/stellar",
+            expect.objectContaining({ method: "POST", body: JSON.stringify(deliveryEvent) })
+        );
+        expect(fetchMock).toHaveBeenNthCalledWith(
+            2,
+            "https://staging.example.com/webhooks/stellar",
+            expect.objectContaining({ method: "POST", body: JSON.stringify(deliveryEvent) })
+        );
+        expect(fetchMock).toHaveBeenNthCalledWith(
+            3,
+            "https://audit.example.com/webhooks/stellar",
+            expect.objectContaining({ method: "POST", body: JSON.stringify(deliveryEvent) })
+        );
+    });
+
+    it("keeps delivering to other URLs when one URL fails", async () => {
+        const failedUrl = "https://prod.example.com/webhooks/stellar";
+        const successfulUrl = "https://audit.example.com/webhooks/stellar";
+        const fetchMock = vi.fn((url: string) => {
+            if (url === failedUrl) {
+                return Promise.resolve({ ok: false, status: 500 });
+            }
+
+            return Promise.resolve({ ok: true, status: 200 });
+        });
+        vi.stubGlobal("fetch", fetchMock);
+
+        const watcher = new Watcher("GABC");
+        const failedHandler = vi.fn();
+        watcher.on("webhook.failed", failedHandler);
+
+        new WebhookDelivery(watcher, {
+            url: [failedUrl, successfulUrl],
+            secret: "top-secret",
+            retries: 1,
+        });
+
+        watcher.emit("*", deliveryEvent);
+        await flushAsyncWork();
+
+        expect(fetchMock).toHaveBeenCalledTimes(2);
+        expect(fetchMock).toHaveBeenCalledWith(
+            failedUrl,
+            expect.objectContaining({ method: "POST" })
+        );
+        expect(fetchMock).toHaveBeenCalledWith(
+            successfulUrl,
+            expect.objectContaining({ method: "POST" })
+        );
+        expect(failedHandler).toHaveBeenCalledTimes(1);
+        expect(failedHandler).toHaveBeenCalledWith(
+            expect.objectContaining({
+                raw: expect.objectContaining({
+                    url: failedUrl,
+                    attempts: 1,
+                    originalEvent: deliveryEvent,
+                }),
+            })
+        );
+    });
+
+    it("cancels pending retries for all URLs when the watcher stops", async () => {
+        const fetchMock = vi.fn().mockRejectedValue(new Error("network down"));
+        vi.stubGlobal("fetch", fetchMock);
+
+        const watcher = new Watcher("GABC");
+        new WebhookDelivery(watcher, {
+            url: [
+                "https://prod.example.com/webhooks/stellar",
+                "https://staging.example.com/webhooks/stellar",
+            ],
+            secret: "top-secret",
+            retries: 3,
+        });
+
+        watcher.emit("*", deliveryEvent);
+        await flushAsyncWork();
+
+        expect(fetchMock).toHaveBeenCalledTimes(2);
+
+        watcher.stop();
+        vi.advanceTimersByTime(10_000);
+        await flushAsyncWork();
+
+        expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+});

--- a/packages/pulse-webhooks/vitest.config.ts
+++ b/packages/pulse-webhooks/vitest.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from "vitest/config";
+import { fileURLToPath } from "node:url";
+
+export default defineConfig({
+    test: {
+        environment: "node",
+    },
+    resolve: {
+        alias: {
+            "@orbital/pulse-core": fileURLToPath(
+                new URL("../pulse-core/src/index.ts", import.meta.url)
+            ),
+        },
+    },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,8 +46,8 @@ importers:
         specifier: ^4.0.3
         version: 4.0.3
       marked:
-        specifier: ^17.0.5
-        version: 17.0.5
+        specifier: ^18.0.0
+        version: 18.0.2
       next:
         specifier: ^16.2.2
         version: 16.2.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -130,6 +130,9 @@ importers:
       tsx:
         specifier: ^4.0.0
         version: 4.21.0
+      vitest:
+        specifier: ^4.1.5
+        version: 4.1.5(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(vite@7.3.1(@types/node@25.6.0)(jiti@1.21.7)(tsx@4.21.0))
 
 packages:
 
@@ -499,89 +502,105 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -636,24 +655,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@16.2.2':
     resolution: {integrity: sha512-VKLuscm0P/mIfzt+SDdn2+8TNNJ7f0qfEkA+az7OqQbjzKdBxAHs0UvuiVoCtbwX+dqMEL9U54b5wQ/aN3dHeg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-linux-x64-gnu@16.2.2':
     resolution: {integrity: sha512-kU3OPHJq6sBUjOk7wc5zJ7/lipn8yGldMoAv4z67j6ov6Xo/JvzA7L7LCsyzzsXmgLEhk3Qkpwqaq/1+XpNR3g==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-x64-musl@16.2.2':
     resolution: {integrity: sha512-CKXRILyErMtUftp+coGcZ38ZwE/Aqq45VMCcRLr2I4OXKrgxIBDXHnBgeX/UMil0S09i2JXaDL3Q+TN8D/cKmg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@16.2.2':
     resolution: {integrity: sha512-sS/jSk5VUoShUqINJFvNjVT7JfR5ORYj/+/ZpOYbbIohv/lQfduWnGAycq2wlknbOql2xOR0DoV0s6Xfcy49+g==}
@@ -709,66 +732,79 @@ packages:
     resolution: {integrity: sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.60.2':
     resolution: {integrity: sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.60.2':
     resolution: {integrity: sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.60.2':
     resolution: {integrity: sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.60.2':
     resolution: {integrity: sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.60.2':
     resolution: {integrity: sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.60.2':
     resolution: {integrity: sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.60.2':
     resolution: {integrity: sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.60.2':
     resolution: {integrity: sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.60.2':
     resolution: {integrity: sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.60.2':
     resolution: {integrity: sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.60.2':
     resolution: {integrity: sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.60.2':
     resolution: {integrity: sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.60.2':
     resolution: {integrity: sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==}
@@ -1339,8 +1375,8 @@ packages:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
     engines: {node: '>=10'}
 
-  marked@17.0.5:
-    resolution: {integrity: sha512-6hLvc0/JEbRjRgzI6wnT2P1XuM1/RrrDEX0kPt0N7jGm1133g6X7DlxFasUIx+72aKAr904GTxhSLDrd5DIlZg==}
+  marked@18.0.2:
+    resolution: {integrity: sha512-NsmlUYBS/Zg57rgDWMYdnre6OTj4e+qq/JS2ot3KrYLSoHLw+sDu0Nm1ZGpRgYAq6c+b1ekaY5NzVchMCQnzcg==}
     engines: {node: '>= 20'}
     hasBin: true
 
@@ -2787,7 +2823,7 @@ snapshots:
     dependencies:
       semver: 7.7.4
 
-  marked@17.0.5: {}
+  marked@18.0.2: {}
 
   math-intrinsics@1.1.0: {}
 


### PR DESCRIPTION
## Linked issue

Closes #121 

## What changed and why

This PR adds fan-out delivery support to @orbital/pulse-webhooks so a single watcher can deliver the same event to multiple downstream webhook URLs.

## Test plan

- [x] Existing tests pass (`pnpm test`)
- [ ] New tests added for new behaviour
- [x] Typechecks pass (`pnpm -r typecheck`)
- [ ] Manually tested against testnet / mainnet (describe what you tested)

## Breaking changes

None  

## Notes for reviewers

