### PR TITLE
feat(pulse-core): implement AWS Full Jitter and add backoff unit tests

### DIFF
--- a/packages/pulse-core/src/EventEngine.ts
+++ b/packages/pulse-core/src/EventEngine.ts
@@ -158,10 +158,11 @@ export class EventEngine {
 
     this.reconnectAttempt = nextAttempt;
 
-    const delayMs = Math.min(
+    const exponentialDelay = Math.min(
       this.reconnectConfig.initialDelayMs * 2 ** (nextAttempt - 1),
       this.reconnectConfig.maxDelayMs
     );
+    const delayMs = Math.floor(Math.random() * exponentialDelay);
 
     console.warn(
       `[pulse-core] SSE reconnect attempt ${nextAttempt} scheduled in ${delayMs}ms.`

--- a/packages/pulse-core/test/pulse-core.test.ts
+++ b/packages/pulse-core/test/pulse-core.test.ts
@@ -56,6 +56,7 @@ describe("pulse-core EventEngine", () => {
     vi.spyOn(console, "error").mockImplementation(() => undefined);
     vi.spyOn(console, "info").mockImplementation(() => undefined);
     vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    vi.spyOn(Math, "random").mockReturnValue(1); // Default to max for existing tests
   });
 
   afterEach(() => {
@@ -218,11 +219,11 @@ describe("pulse-core EventEngine", () => {
       expect.objectContaining({
         type: "engine.reconnecting",
         attempt: 1,
-        delayMs: 1000,
+        delayMs: expect.any(Number),
       })
     );
     expect(console.warn).toHaveBeenCalledWith(
-      "[pulse-core] SSE reconnect attempt 1 scheduled in 1000ms."
+      expect.stringMatching(/\[pulse-core\] SSE reconnect attempt 1 scheduled in \d+ms\./)
     );
     expect(streamInstances).toHaveLength(1);
 
@@ -237,11 +238,11 @@ describe("pulse-core EventEngine", () => {
       expect.objectContaining({
         type: "engine.reconnecting",
         attempt: 2,
-        delayMs: 2000,
+        delayMs: expect.any(Number),
       })
     );
     expect(console.warn).toHaveBeenLastCalledWith(
-      "[pulse-core] SSE reconnect attempt 2 scheduled in 2000ms."
+      expect.stringMatching(/\[pulse-core\] SSE reconnect attempt 2 scheduled in \d+ms\./)
     );
 
     vi.advanceTimersByTime(2000);
@@ -273,9 +274,147 @@ describe("pulse-core EventEngine", () => {
       expect.objectContaining({
         type: "engine.reconnecting",
         attempt: 1,
-        delayMs: 1000,
+        delayMs: expect.any(Number),
       })
     );
+  });
+
+  describe("backoff invariants", () => {
+    it("delay reaches maxDelayMs cap on attempt N", () => {
+      const engine = new EventEngine({
+        network: "testnet",
+        reconnect: {
+          initialDelayMs: 1000,
+          maxDelayMs: 5000,
+        },
+      });
+      engine.subscribe("GABC");
+      engine.start();
+
+      vi.spyOn(Math, "random").mockReturnValue(0.999999);
+
+      // Attempt 1: 1000ms
+      latestStream().handlers.onerror(new Error("err"));
+      expect(console.warn).toHaveBeenLastCalledWith(
+        expect.stringContaining("scheduled in 999ms.")
+      );
+
+      vi.advanceTimersByTime(1000);
+      // Attempt 2: 2000ms
+      latestStream().handlers.onerror(new Error("err"));
+      expect(console.warn).toHaveBeenLastCalledWith(
+        expect.stringContaining("scheduled in 1999ms.")
+      );
+
+      vi.advanceTimersByTime(2000);
+      // Attempt 3: 4000ms
+      latestStream().handlers.onerror(new Error("err"));
+      expect(console.warn).toHaveBeenLastCalledWith(
+        expect.stringContaining("scheduled in 3999ms.")
+      );
+
+      vi.advanceTimersByTime(4000);
+      // Attempt 4: 8000ms base, capped at 5000ms
+      latestStream().handlers.onerror(new Error("err"));
+      expect(console.warn).toHaveBeenLastCalledWith(
+        expect.stringContaining("scheduled in 4999ms.")
+      );
+    });
+
+    it("max-retries terminates the loop", () => {
+      const engine = new EventEngine({
+        network: "testnet",
+        reconnect: {
+          initialDelayMs: 100,
+          maxRetries: 2,
+        },
+      });
+      engine.subscribe("GABC");
+      engine.start();
+
+      // Attempt 1
+      latestStream().handlers.onerror(new Error("err"));
+      expect(console.warn).toHaveBeenCalledWith(
+        expect.stringContaining("attempt 1 scheduled")
+      );
+      vi.advanceTimersByTime(1000);
+
+      // Attempt 2
+      latestStream().handlers.onerror(new Error("err"));
+      expect(console.warn).toHaveBeenCalledWith(
+        expect.stringContaining("attempt 2 scheduled")
+      );
+      vi.advanceTimersByTime(1000);
+
+      // Attempt 3 -> Should fail
+      latestStream().handlers.onerror(new Error("err"));
+      expect(console.error).toHaveBeenLastCalledWith(
+        "[pulse-core] SSE reconnect stopped after 2 failed attempts."
+      );
+    });
+
+    it("attempt counter resets after engine.reconnected", () => {
+      const engine = new EventEngine({
+        network: "testnet",
+        reconnect: { initialDelayMs: 1000 },
+      });
+      engine.subscribe("GABC");
+      engine.start();
+
+      vi.spyOn(Math, "random").mockReturnValue(0.999999);
+
+      // Attempt 1
+      latestStream().handlers.onerror(new Error("err"));
+      expect(console.warn).toHaveBeenLastCalledWith(
+        expect.stringContaining("attempt 1 scheduled in 999ms")
+      );
+      vi.advanceTimersByTime(1000);
+
+      // Attempt 2
+      latestStream().handlers.onerror(new Error("err"));
+      expect(console.warn).toHaveBeenLastCalledWith(
+        expect.stringContaining("attempt 2 scheduled in 1999ms")
+      );
+      vi.advanceTimersByTime(2000);
+
+      // Reconnect success
+      latestStream().handlers.onmessage({ type: "payment", to: "GABC", from: "X", amount: "1", created_at: "now" });
+      expect(console.info).toHaveBeenCalledWith(
+        "[pulse-core] SSE reconnect succeeded on attempt 2."
+      );
+
+      // Next error should be attempt 1 again
+      latestStream().handlers.onerror(new Error("err"));
+      expect(console.warn).toHaveBeenLastCalledWith(
+        expect.stringContaining("attempt 1 scheduled in 999ms")
+      );
+    });
+
+    it("jitter test using a seeded-like mock", () => {
+      const engine = new EventEngine({
+        network: "testnet",
+        reconnect: { initialDelayMs: 1000 },
+      });
+      engine.subscribe("GABC");
+      engine.start();
+
+      // Mock random to 0.5
+      vi.spyOn(Math, "random").mockReturnValue(0.5);
+      latestStream().handlers.onerror(new Error("err"));
+      // 1000 * 0.5 = 500
+      expect(console.warn).toHaveBeenLastCalledWith(
+        expect.stringContaining("scheduled in 500ms.")
+      );
+
+      vi.advanceTimersByTime(500);
+      // Mock random to 0.1
+      vi.spyOn(Math, "random").mockReturnValue(0.1);
+      latestStream().handlers.onerror(new Error("err"));
+      // 2000 * 0.1 = 200
+      expect(console.warn).toHaveBeenLastCalledWith(
+        expect.stringContaining("scheduled in 200ms.")
+      );
+    });
   });
 
   describe("set_options → account.options_changed", () => {


### PR DESCRIPTION
Closes #99.

Implements AWS Full Jitter strategy for reconnection backoff and adds unit tests for backoff invariants:
- Delay reaches maxDelayMs cap
- Max-retries terminates the loop
- Attempt counter resets after engine.reconnected
- Jitter verification using mocked Math.random