### PR TITLE
Rename internal timestamp on engine

### DIFF
--- a/packages/pulse-core/CHANGELOG.md
+++ b/packages/pulse-core/CHANGELOG.md
@@ -1,0 +1,6 @@
+# pulse-core Changelog
+
+## Unreleased
+
+### Breaking Changes
+- **WatcherNotification API**: The `timestamp` field on `WatcherNotification` (`engine.reconnecting` and `engine.reconnected` events) has been renamed to `emittedAt` to distinguish it from the on-chain `created_at` timestamp used in other events like `payment.received`.

--- a/packages/pulse-core/src/EventEngine.ts
+++ b/packages/pulse-core/src/EventEngine.ts
@@ -165,7 +165,7 @@ export class EventEngine {
           this.notifyWatchers("engine.reconnected", {
             type: "engine.reconnected",
             attempt,
-            timestamp: new Date().toISOString(),
+            emittedAt: new Date().toISOString(),
           });
         }
 
@@ -216,7 +216,7 @@ export class EventEngine {
       type: "engine.reconnecting",
       attempt: nextAttempt,
       delayMs,
-      timestamp: new Date().toISOString(),
+      emittedAt: new Date().toISOString(),
     });
 
     this.reconnectTimer = setTimeout(() => {

--- a/packages/pulse-core/src/index.ts
+++ b/packages/pulse-core/src/index.ts
@@ -151,8 +151,8 @@ export type WatcherNotification = {
   attempt: number;
   /** The delay in milliseconds before the next reconnection attempt (for "engine.reconnecting" events). */
   delayMs?: number;
-  /** ISO 8601 timestamp of the notification. */
-  timestamp: string;
+  /** ISO 8601 timestamp of when this notification was emitted. */
+  emittedAt: string;
 };
 
 /**

--- a/packages/pulse-core/test/pulse-core.test.ts
+++ b/packages/pulse-core/test/pulse-core.test.ts
@@ -312,6 +312,7 @@ describe("pulse-core EventEngine", () => {
         type: "engine.reconnecting",
         attempt: 1,
         delayMs: expect.any(Number),
+        emittedAt: expect.any(String),
       })
     );
     expect(log.warn).toHaveBeenCalledWith(
@@ -331,6 +332,7 @@ describe("pulse-core EventEngine", () => {
         type: "engine.reconnecting",
         attempt: 2,
         delayMs: expect.any(Number),
+        emittedAt: expect.any(String),
       })
     );
     expect(log.warn).toHaveBeenLastCalledWith(
@@ -354,6 +356,7 @@ describe("pulse-core EventEngine", () => {
       expect.objectContaining({
         type: "engine.reconnected",
         attempt: 2,
+        emittedAt: expect.any(String),
       })
     );
     expect(log.info).toHaveBeenCalledWith(
@@ -367,6 +370,7 @@ describe("pulse-core EventEngine", () => {
         type: "engine.reconnecting",
         attempt: 1,
         delayMs: expect.any(Number),
+        emittedAt: expect.any(String),
       })
     );
   });


### PR DESCRIPTION
# Rename internal timestamp on engine notifications

- Closes #62

## Description
This PR renames the `timestamp` field to `emittedAt` on internal engine notifications (`engine.reconnecting` and `engine.reconnected`). 

Previously, both internal notifications and on-chain events (`payment.received`, etc.) used the `timestamp` field. This caused confusion for consumers logging `event.timestamp` across all listeners, as it silently mixed wall-clock emission time with on-chain `created_at` time.

## Changes
- Renamed `WatcherNotification.timestamp` -> `WatcherNotification.emittedAt` in `index.ts`.
- Updated `EventEngine.openStream` and `handleStreamError` to set `emittedAt` when notifying watchers.
- Added a `CHANGELOG.md` entry to document this breaking change for consumers.
