### PR TITLE
implemented eventEngine.status()"

### DIFF
--- a/packages/pulse-core/src/EventEngine.ts
+++ b/packages/pulse-core/src/EventEngine.ts
@@ -5,6 +5,7 @@ import type {
   AccountOptionsChanges,
   AccountOptionsEvent,
   CoreConfig,
+  EngineStatus,
   Network,
   NormalizedEvent,
   PaymentEvent,
@@ -58,6 +59,7 @@ export class EventEngine {
   private readonly reconnectConfig: Required<ReconnectConfig>;
   private isRunning = false;
   private log: Required<NonNullable<CoreConfig["logger"]>>;
+  private lastEventAt: string | null = null;
 
   /**
    * Creates a new EventEngine instance.
@@ -131,6 +133,15 @@ export class EventEngine {
     this.openStream(false);
   }
 
+  status(): EngineStatus {
+    return {
+      running: this.isRunning,
+      watcherCount: this.registry.size,
+      lastEventAt: this.lastEventAt,
+      reconnectAttempt: this.reconnectAttempt,
+    };
+  }
+
   /**
    * Stops the SSE stream and all active watchers.
    * Cleans up all resources and resets reconnection state.
@@ -139,6 +150,7 @@ export class EventEngine {
     this.clearReconnectTimer();
     this.pendingReconnectSuccessAttempt = null;
     this.reconnectAttempt = 0;
+    this.lastEventAt = null;
     this.closeStream();
     this.isRunning = false;
 
@@ -157,6 +169,7 @@ export class EventEngine {
 
     const callbacks: StreamCallbacks = {
       onmessage: (record) => {
+        this.lastEventAt = new Date().toISOString();
         if (this.pendingReconnectSuccessAttempt !== null) {
           const attempt = this.pendingReconnectSuccessAttempt;
           this.pendingReconnectSuccessAttempt = null;

--- a/packages/pulse-core/src/index.ts
+++ b/packages/pulse-core/src/index.ts
@@ -198,3 +198,10 @@ export class UnknownNetworkError extends Error {
     this.name = "UnknownNetworkError";
   }
 }
+
+export type EngineStatus = {
+  running: boolean;
+  watcherCount: number;
+  lastEventAt: string | null;
+  reconnectAttempt: number;
+};

--- a/packages/pulse-core/test/pulse-core.test.ts
+++ b/packages/pulse-core/test/pulse-core.test.ts
@@ -861,4 +861,74 @@ describe("pulse-core EventEngine", () => {
       expect(otherHandler).not.toHaveBeenCalled();
     });
   });
+
+  describe("status()", () => {
+    it("returns accurate snapshot in initial state", () => {
+      const engine = new EventEngine({ network: "testnet" });
+      expect(engine.status()).toEqual({
+        running: false,
+        watcherCount: 0,
+        lastEventAt: null,
+        reconnectAttempt: 0,
+      });
+    });
+
+    it("returns accurate snapshot after start()", () => {
+      const engine = new EventEngine({ network: "testnet" });
+      engine.subscribe("GABC");
+      engine.start();
+
+      expect(engine.status()).toEqual({
+        running: true,
+        watcherCount: 1,
+        lastEventAt: null,
+        reconnectAttempt: 0,
+      });
+    });
+
+    it("updates lastEventAt after a message", () => {
+      const engine = new EventEngine({ network: "testnet" });
+      engine.start();
+
+      const now = "2026-04-27T10:00:00.000Z";
+      vi.setSystemTime(new Date(now));
+
+      latestStream().handlers.onmessage({});
+
+      expect(engine.status().lastEventAt).toBe(now);
+    });
+
+    it("reflects reconnect attempts and running: false during backoff", () => {
+      const engine = new EventEngine({
+        network: "testnet",
+        reconnect: { initialDelayMs: 1000 },
+      });
+      engine.start();
+
+      latestStream().handlers.onerror(new Error("disconnect"));
+
+      expect(engine.status()).toEqual({
+        running: false,
+        watcherCount: 0,
+        lastEventAt: null,
+        reconnectAttempt: 1,
+      });
+    });
+
+    it("resets state when stop() is called", () => {
+      const engine = new EventEngine({ network: "testnet" });
+      engine.subscribe("GABC");
+      engine.start();
+      latestStream().handlers.onmessage({});
+
+      engine.stop();
+
+      expect(engine.status()).toEqual({
+        running: false,
+        watcherCount: 0,
+        lastEventAt: null,
+        reconnectAttempt: 0,
+      });
+    });
+  });
 });


### PR DESCRIPTION


Closes #85

This PR introduces a new EventEngine.status() method to provide a programmatic health snapshot of the engine.

Previously, consumers relied on internal field access or log inspection to infer engine state. This change exposes a structured and reliable interface for monitoring, improving both developer experience and observability.
