### PR TITLE
feat(server): structured logging with pino + request ID

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -12,11 +12,14 @@
   "dependencies": {
     "@orbital/pulse-core": "workspace:*",
     "@orbital/pulse-webhooks": "workspace:*",
-    "express": "^4.18.2"
+    "express": "^4.18.2",
+    "pino": "^9.0.0",
+    "pino-http": "^10.0.0"
   },
   "devDependencies": {
     "@types/express": "^4.17.21",
     "@types/node": "^25.6.0",
+    "@types/pino-http": "^5.8.4",
     "tsx": "^4.0.0"
   },
   "packageManager": "pnpm@10.32.1"

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -1,7 +1,10 @@
 import express, { type Request, type Response } from "express";
+import pinoHttp from "pino-http";
+import { randomUUID } from "crypto";
 import { EventEngine } from "@orbital/pulse-core";
 import { WebhookRegistry } from "./registry.js";
 import { createRoutes } from "./routes.js";
+import { logger } from "./logger.js";
 
 // --- Environment validation ---
 
@@ -10,9 +13,7 @@ type Network = (typeof VALID_NETWORKS)[number];
 
 const rawNetwork = process.env.NETWORK;
 if (!rawNetwork || !(VALID_NETWORKS as readonly string[]).includes(rawNetwork)) {
-  console.error(
-    `[server] Invalid or missing NETWORK env var: "${rawNetwork}". Must be "mainnet" or "testnet".`
-  );
+  logger.error({ network: rawNetwork }, "Invalid or missing NETWORK env var. Must be mainnet or testnet.");
   process.exit(1);
 }
 const NETWORK = rawNetwork as Network;
@@ -21,7 +22,7 @@ const rawPort = process.env.PORT;
 const parsedPort = rawPort ? parseInt(rawPort, 10) : NaN;
 let PORT: number;
 if (!rawPort || isNaN(parsedPort) || parsedPort <= 0 || parsedPort > 65535) {
-  console.warn(`[server] Invalid or missing PORT env var: "${rawPort}". Falling back to 3000.`);
+  logger.warn({ port: rawPort }, "Invalid or missing PORT env var. Falling back to 3000.");
   PORT = 3000;
 } else {
   PORT = parsedPort;
@@ -29,13 +30,29 @@ if (!rawPort || isNaN(parsedPort) || parsedPort <= 0 || parsedPort > 65535) {
 
 // --- Bootstrap ---
 
-const engine = new EventEngine({ network: NETWORK });
+const engine = new EventEngine({ network: NETWORK, logger });
 engine.start();
-console.log(`[server] Event engine started on ${NETWORK}`);
+logger.info({ network: NETWORK }, "Event engine started");
 
-const registry = new WebhookRegistry(engine);
+const registry = new WebhookRegistry(engine, logger);
 
 const app = express();
+
+app.use(
+  pinoHttp({
+    logger,
+    genReqId: () => randomUUID(),
+    customSuccessMessage: (req, res) => `${req.method} ${req.url} ${res.statusCode}`,
+    customErrorMessage: (req, res) => `${req.method} ${req.url} ${res.statusCode}`,
+  })
+);
+
+// Propagate the request ID as a response header so callers can correlate logs
+app.use((req, res, next) => {
+  res.setHeader("X-Request-ID", req.id as string);
+  next();
+});
+
 app.use(express.json({ limit: "16kb" }));
 app.use(createRoutes(registry, engine));
 
@@ -44,7 +61,7 @@ app.get("/health", (_req: Request, res: Response) => {
 });
 
 const server = app.listen(PORT, () => {
-  console.log(`[server] Listening on port ${PORT}`);
+  logger.info({ port: PORT }, "Listening");
 });
 
 // --- Graceful shutdown ---
@@ -52,19 +69,18 @@ const server = app.listen(PORT, () => {
 const SHUTDOWN_TIMEOUT_MS = 5000;
 
 function shutdown(signal: string): void {
-  console.log(`[server] Received ${signal}, shutting down...`);
+  logger.info({ signal }, "Shutting down");
 
-  // Hard-exit if graceful shutdown takes too long
   const forceExit = setTimeout(() => {
-    console.error("[server] Graceful shutdown timed out, forcing exit.");
+    logger.error("Graceful shutdown timed out, forcing exit.");
     process.exit(1);
   }, SHUTDOWN_TIMEOUT_MS) as unknown as NodeJS.Timeout;
-  // Don't let this timer keep the process alive on its own
   forceExit.unref();
+
   engine.stop();
 
   server.close(() => {
-    console.log("[server] HTTP server closed. Exiting.");
+    logger.info("HTTP server closed. Exiting.");
     process.exit(0);
   });
 }

--- a/apps/server/src/logger.ts
+++ b/apps/server/src/logger.ts
@@ -1,0 +1,5 @@
+import pino from "pino";
+
+export const logger = pino({
+  level: process.env.LOG_LEVEL ?? "info",
+});

--- a/apps/server/src/registry.ts
+++ b/apps/server/src/registry.ts
@@ -1,4 +1,5 @@
 import { createHmac } from "crypto";
+import type { Logger } from "pino";
 import { EventEngine } from "@orbital/pulse-core";
 import { WebhookDelivery } from "@orbital/pulse-webhooks";
 
@@ -31,9 +32,11 @@ function hashSecret(secret: string): string {
 export class WebhookRegistry {
   private registrations: Map<string, WebhookRegistration> = new Map();
   private engine: EventEngine;
+  private log: Logger;
 
-  constructor(engine: EventEngine) {
+  constructor(engine: EventEngine, log: Logger) {
     this.engine = engine;
+    this.log = log;
   }
 
   register(address: string, url: string, secret: string): WebhookRegistrationPublic {
@@ -51,8 +54,9 @@ export class WebhookRegistry {
     const delivery = new WebhookDelivery(watcher, { url, secret });
 
     // Use watcher.once so this listener cannot accumulate on re-register
-    watcher.once("webhook.failed", (event) => {
-      console.error(`[registry] Webhook delivery failed for ${address}:`, event.raw);
+    watcher.once("webhook.failed", (event: unknown) => {
+      const raw = (event as { raw?: unknown })?.raw;
+      this.log.error({ address, raw }, "Webhook delivery failed");
     });
 
     const registration: WebhookRegistration = {
@@ -64,7 +68,7 @@ export class WebhookRegistry {
     };
 
     this.registrations.set(address, registration);
-    console.log(`[registry] Registered ${address} → ${url}`);
+    this.log.info({ address, url }, "Registered webhook");
     return this.toPublic(registration);
   }
 
@@ -74,7 +78,7 @@ export class WebhookRegistry {
     // Stopping the watcher clears its retry timers via addStopHandler in WebhookDelivery
     this.engine.unsubscribe(address);
     this.registrations.delete(address);
-    console.log(`[registry] Unregistered ${address}`);
+    this.log.info({ address }, "Unregistered webhook");
     return true;
   }
 

--- a/apps/server/src/routes.ts
+++ b/apps/server/src/routes.ts
@@ -129,12 +129,11 @@ export function createRoutes(registry: WebhookRegistry, engine: EventEngine): Ro
     req.on("close", () => {
       clearInterval(heartbeat);
       watcher.removeListener("*", handler);
-      // Fully remove the watcher from the engine so no dead watchers remain
       engine.unsubscribe(address);
-      console.log(`[sse] Client disconnected from ${address}`);
+      req.log.info({ address }, "SSE client disconnected");
     });
 
-    console.log(`[sse] Client connected to ${address}`);
+    req.log.info({ address }, "SSE client connected");
   });
 
   return router;

--- a/packages/pulse-core/src/EventEngine.ts
+++ b/packages/pulse-core/src/EventEngine.ts
@@ -37,6 +37,8 @@ const DEFAULT_RECONNECT: Required<ReconnectConfig> = {
   maxRetries: Number.POSITIVE_INFINITY,
 };
 
+const noop = { info: () => {}, warn: () => {}, error: () => {} };
+
 export class EventEngine {
   private server: Horizon.Server;
   private registry: Map<string, Watcher> = new Map();
@@ -46,6 +48,7 @@ export class EventEngine {
   private pendingReconnectSuccessAttempt: number | null = null;
   private readonly reconnectConfig: Required<ReconnectConfig>;
   private isRunning = false;
+  private log: Required<NonNullable<CoreConfig["logger"]>>;
 
   constructor(config: CoreConfig) {
     this.server = new Horizon.Server(HORIZON_URLS[config.network]);
@@ -53,6 +56,7 @@ export class EventEngine {
       ...DEFAULT_RECONNECT,
       ...config.reconnect,
     };
+    this.log = config.logger ?? noop;
   }
 
   subscribe(address: string): Watcher {
@@ -75,9 +79,7 @@ export class EventEngine {
 
   start(): void {
     if (this.isRunning || this.reconnectTimer) {
-      console.warn(
-        "[pulse-core] EventEngine.start() called while the SSE stream is already active."
-      );
+      this.log.warn("[pulse-core] EventEngine.start() called while the SSE stream is already active.");
       return;
     }
 
@@ -110,9 +112,7 @@ export class EventEngine {
           const attempt = this.pendingReconnectSuccessAttempt;
           this.pendingReconnectSuccessAttempt = null;
           this.reconnectAttempt = 0;
-          console.info(
-            `[pulse-core] SSE reconnect succeeded on attempt ${attempt}.`
-          );
+          this.log.info(`[pulse-core] SSE reconnect succeeded on attempt ${attempt}.`);
           this.notifyWatchers("engine.reconnected", {
             type: "engine.reconnected",
             attempt,
@@ -128,7 +128,7 @@ export class EventEngine {
         this.route(event);
       },
       onerror: (error) => {
-        console.error("[pulse-core] SSE error:", error);
+        this.log.error(`[pulse-core] SSE error: ${error}`);
         this.handleStreamError();
       },
     };
@@ -150,9 +150,7 @@ export class EventEngine {
 
     const nextAttempt = this.reconnectAttempt + 1;
     if (nextAttempt > this.reconnectConfig.maxRetries) {
-      console.error(
-        `[pulse-core] SSE reconnect stopped after ${this.reconnectAttempt} failed attempts.`
-      );
+      this.log.error(`[pulse-core] SSE reconnect stopped after ${this.reconnectAttempt} failed attempts.`);
       return;
     }
 
@@ -163,9 +161,7 @@ export class EventEngine {
       this.reconnectConfig.maxDelayMs
     );
 
-    console.warn(
-      `[pulse-core] SSE reconnect attempt ${nextAttempt} scheduled in ${delayMs}ms.`
-    );
+    this.log.warn(`[pulse-core] SSE reconnect attempt ${nextAttempt} scheduled in ${delayMs}ms.`);
     this.notifyWatchers("engine.reconnecting", {
       type: "engine.reconnecting",
       attempt: nextAttempt,
@@ -214,10 +210,7 @@ export class EventEngine {
       const requiredFields = ["to", "from", "amount", "created_at"] as const;
       for (const field of requiredFields) {
         if (typeof r[field] !== "string" || r[field] === "") {
-          console.warn(
-            `[pulse-core] normalize() dropping payment record: field "${field}" is missing or not a non-empty string.`,
-            { record }
-          );
+          this.log.warn(`[pulse-core] normalize() dropping payment record: field "${field}" is missing or not a non-empty string.`);
           return null;
         }
       }

--- a/packages/pulse-core/src/index.ts
+++ b/packages/pulse-core/src/index.ts
@@ -63,4 +63,9 @@ export type ReconnectConfig = {
 export type CoreConfig = {
   network: Network;
   reconnect?: ReconnectConfig;
+  logger?: {
+    info(msg: string, ...args: unknown[]): void;
+    warn(msg: string, ...args: unknown[]): void;
+    error(msg: string, ...args: unknown[]): void;
+  };
 };

--- a/packages/pulse-core/test/pulse-core.test.ts
+++ b/packages/pulse-core/test/pulse-core.test.ts
@@ -50,12 +50,18 @@ function latestStream(): MockStreamInstance {
 }
 
 describe("pulse-core EventEngine", () => {
+  const log = {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  };
+
   beforeEach(() => {
     streamInstances.length = 0;
     vi.useFakeTimers();
-    vi.spyOn(console, "error").mockImplementation(() => undefined);
-    vi.spyOn(console, "info").mockImplementation(() => undefined);
-    vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    log.info.mockReset();
+    log.warn.mockReset();
+    log.error.mockReset();
   });
 
   afterEach(() => {
@@ -117,7 +123,7 @@ describe("pulse-core EventEngine", () => {
   });
 
   it("returns null and warns when a required payment field is missing", () => {
-    const engine = new EventEngine({ network: "testnet" });
+    const engine = new EventEngine({ network: "testnet", logger: log });
     const normalize = (
       engine as unknown as {
         normalize(record: unknown): unknown;
@@ -134,14 +140,13 @@ describe("pulse-core EventEngine", () => {
     });
 
     expect(result).toBeNull();
-    expect(console.warn).toHaveBeenCalledWith(
-      '[pulse-core] normalize() dropping payment record: field "to" is missing or not a non-empty string.',
-      expect.objectContaining({ record: expect.any(Object) })
+    expect(log.warn).toHaveBeenCalledWith(
+      '[pulse-core] normalize() dropping payment record: field "to" is missing or not a non-empty string.'
     );
   });
 
   it("returns null and warns for each missing required field individually", () => {
-    const engine = new EventEngine({ network: "testnet" });
+    const engine = new EventEngine({ network: "testnet", logger: log });
     const normalize = (
       engine as unknown as {
         normalize(record: unknown): unknown;
@@ -155,12 +160,11 @@ describe("pulse-core EventEngine", () => {
     ];
 
     for (const [field, record] of missingFieldCases) {
-      vi.clearAllMocks();
+      log.warn.mockReset();
       const result = normalize(record);
       expect(result).toBeNull();
-      expect(console.warn).toHaveBeenCalledWith(
-        `[pulse-core] normalize() dropping payment record: field "${field}" is missing or not a non-empty string.`,
-        expect.objectContaining({ record: expect.any(Object) })
+      expect(log.warn).toHaveBeenCalledWith(
+        `[pulse-core] normalize() dropping payment record: field "${field}" is missing or not a non-empty string.`
       );
     }
   });
@@ -183,13 +187,13 @@ describe("pulse-core EventEngine", () => {
   });
 
   it("guards start() so duplicate live streams are not opened", () => {
-    const engine = new EventEngine({ network: "testnet" });
+    const engine = new EventEngine({ network: "testnet", logger: log });
 
     engine.start();
     engine.start();
 
     expect(streamInstances).toHaveLength(1);
-    expect(console.warn).toHaveBeenCalledWith(
+    expect(log.warn).toHaveBeenCalledWith(
       "[pulse-core] EventEngine.start() called while the SSE stream is already active."
     );
   });
@@ -197,6 +201,7 @@ describe("pulse-core EventEngine", () => {
   it("reconnects with exponential backoff and emits watcher notifications", () => {
     const engine = new EventEngine({
       network: "testnet",
+      logger: log,
       reconnect: {
         initialDelayMs: 1000,
         maxDelayMs: 30000,
@@ -221,7 +226,7 @@ describe("pulse-core EventEngine", () => {
         delayMs: 1000,
       })
     );
-    expect(console.warn).toHaveBeenCalledWith(
+    expect(log.warn).toHaveBeenCalledWith(
       "[pulse-core] SSE reconnect attempt 1 scheduled in 1000ms."
     );
     expect(streamInstances).toHaveLength(1);
@@ -240,7 +245,7 @@ describe("pulse-core EventEngine", () => {
         delayMs: 2000,
       })
     );
-    expect(console.warn).toHaveBeenLastCalledWith(
+    expect(log.warn).toHaveBeenLastCalledWith(
       "[pulse-core] SSE reconnect attempt 2 scheduled in 2000ms."
     );
 
@@ -263,7 +268,7 @@ describe("pulse-core EventEngine", () => {
         attempt: 2,
       })
     );
-    expect(console.info).toHaveBeenCalledWith(
+    expect(log.info).toHaveBeenCalledWith(
       "[pulse-core] SSE reconnect succeeded on attempt 2."
     );
 


### PR DESCRIPTION
- Add pino and pino-http to apps/server
- Create logger.ts as the single pino instance (level from LOG_LEVEL env)
- Wire pino-http middleware: generates UUID per request via randomUUID(), attaches to req.id, and echoes it back as X-Request-ID response header
- Replace every console.* in server (index, registry, routes) with logger.* (bootstrap scope) or req.log.* (request scope)
- Add optional logger field to CoreConfig in pulse-core; EventEngine accepts it and falls back to a no-op so the package stays dep-free
- Replace all console.* in EventEngine with this.log.*
- Update pulse-core tests: swap console spies for a shared log mock object passed directly into EventEngine({ logger: log })

## Linked issue

Closes #

## What changed and why

<!-- One paragraph. What does this PR do, and why is the change needed? -->

## Test plan

<!-- How did you verify this works? Check everything that applies. -->

- [ ] Existing tests pass (`pnpm test`)
- [ ] New tests added for new behaviour
- [ ] Typechecks pass (`pnpm -r typecheck`)
- [ ] Manually tested against testnet / mainnet (describe what you tested)

## Breaking changes

<!-- Does this change any public API? If yes, describe the migration path. -->

None / Yes (describe below)

## Notes for reviewers

<!-- Anything the reviewer should pay special attention to, or context that isn't obvious from the diff. -->

closes #190