### PR TITLE
feat(pulse-core): add filter predicate to EventEngine.subscribe()

### DIFF
--- a/packages/pulse-core/src/EventEngine.ts
+++ b/packages/pulse-core/src/EventEngine.ts
@@ -10,6 +10,7 @@ import type {
   PaymentEvent,
   PaymentEventType,
   ReconnectConfig,
+  SubscribeOptions,
   WatcherNotification,
   WatcherNotificationType,
 } from "./index.js";
@@ -46,6 +47,7 @@ export class EventEngine {
   private pendingReconnectSuccessAttempt: number | null = null;
   private readonly reconnectConfig: Required<ReconnectConfig>;
   private isRunning = false;
+  private filters: Map<string, (event: NormalizedEvent) => boolean> = new Map();
 
   constructor(config: CoreConfig) {
     this.server = new Horizon.Server(HORIZON_URLS[config.network]);
@@ -55,15 +57,19 @@ export class EventEngine {
     };
   }
 
-  subscribe(address: string): Watcher {
+  subscribe(address: string, options?: SubscribeOptions): Watcher {
     const existingWatcher = this.registry.get(address);
     if (existingWatcher) {
       return existingWatcher;
     }
 
     const watcher = new Watcher(address);
+    if (options?.filter) {
+      this.filters.set(address, options.filter);
+    }
     watcher.addStopHandler(() => {
       this.registry.delete(address);
+      this.filters.delete(address);
     });
     this.registry.set(address, watcher);
     return watcher;
@@ -290,10 +296,25 @@ export class EventEngine {
     };
   }
 
+  private passesFilter(address: string, event: NormalizedEvent): boolean {
+    const filter = this.filters.get(address);
+    if (!filter) return true;
+
+    try {
+      return filter(event);
+    } catch (err) {
+      console.warn(
+        `[pulse-core] subscribe() filter threw for address ${address} — treating as reject.`,
+        err
+      );
+      return false;
+    }
+  }
+
   private route(event: NormalizedEventOrPending): void {
     if (event.type === "account.options_changed") {
       const watcher = this.registry.get(event.source);
-      if (watcher) {
+      if (watcher && this.passesFilter(event.source, event)) {
         watcher.emit("account.options_changed", event);
         watcher.emit("*", event);
       }
@@ -302,20 +323,20 @@ export class EventEngine {
 
     const toWatcher = this.registry.get(event.to);
     if (toWatcher) {
-      toWatcher.emit(
-        "payment.received",
-        this.withResolvedType(event, "payment.received")
-      );
-      toWatcher.emit("*", this.withResolvedType(event, "payment.received"));
+      const receivedEvent = this.withResolvedType(event, "payment.received");
+      if (this.passesFilter(event.to, receivedEvent)) {
+        toWatcher.emit("payment.received", receivedEvent);
+        toWatcher.emit("*", receivedEvent);
+      }
     }
 
     const fromWatcher = this.registry.get(event.from);
     if (fromWatcher) {
-      fromWatcher.emit(
-        "payment.sent",
-        this.withResolvedType(event, "payment.sent")
-      );
-      fromWatcher.emit("*", this.withResolvedType(event, "payment.sent"));
+      const sentEvent = this.withResolvedType(event, "payment.sent");
+      if (this.passesFilter(event.from, sentEvent)) {
+        fromWatcher.emit("payment.sent", sentEvent);
+        fromWatcher.emit("*", sentEvent);
+      }
     }
   }
 

--- a/packages/pulse-core/src/index.ts
+++ b/packages/pulse-core/src/index.ts
@@ -64,3 +64,10 @@ export type CoreConfig = {
   network: Network;
   reconnect?: ReconnectConfig;
 };
+
+export type SubscribeOptions = {
+  /** Optional predicate applied before each event is emitted to this watcher.
+   *  Return `false` to suppress delivery. If the predicate throws, the event
+   *  is suppressed and a warning is logged — the engine continues running. */
+  filter?: (event: NormalizedEvent) => boolean;
+};

--- a/packages/pulse-core/test/pulse-core.test.ts
+++ b/packages/pulse-core/test/pulse-core.test.ts
@@ -440,4 +440,75 @@ describe("pulse-core EventEngine", () => {
       expect(otherHandler).not.toHaveBeenCalled();
     });
   });
+
+  describe("subscribe() filter predicate", () => {
+    const PAYMENT_RECORD = {
+      type: "payment",
+      to: "GDEST",
+      from: "GSRC",
+      amount: "100",
+      asset_type: "native",
+      created_at: "2026-03-26T20:00:00.000Z",
+    };
+
+    it("delivers events to a watcher whose filter returns true", () => {
+      const engine = new EventEngine({ network: "testnet" });
+      const watcher = engine.subscribe("GDEST", {
+        filter: (e) => (e as { amount: string }).amount === "100",
+      });
+      const handler = vi.fn();
+      watcher.on("payment.received", handler);
+
+      engine.start();
+      latestStream().handlers.onmessage(PAYMENT_RECORD);
+
+      expect(handler).toHaveBeenCalledOnce();
+      expect(handler).toHaveBeenCalledWith(
+        expect.objectContaining({ type: "payment.received", amount: "100" })
+      );
+    });
+
+    it("suppresses events for a watcher whose filter returns false", () => {
+      const engine = new EventEngine({ network: "testnet" });
+      const watcher = engine.subscribe("GDEST", {
+        filter: (e) => (e as { amount: string }).amount !== "100",
+      });
+      const handler = vi.fn();
+      watcher.on("payment.received", handler);
+      watcher.on("*", handler);
+
+      engine.start();
+      latestStream().handlers.onmessage(PAYMENT_RECORD);
+
+      expect(handler).not.toHaveBeenCalled();
+    });
+
+    it("treats a throwing filter as a reject and logs a warning without crashing the engine", () => {
+      const engine = new EventEngine({ network: "testnet" });
+      const filterError = new Error("filter boom");
+      const watcher = engine.subscribe("GDEST", {
+        filter: () => {
+          throw filterError;
+        },
+      });
+      const handler = vi.fn();
+      watcher.on("payment.received", handler);
+
+      engine.start();
+      latestStream().handlers.onmessage(PAYMENT_RECORD);
+
+      expect(handler).not.toHaveBeenCalled();
+      expect(console.warn).toHaveBeenCalledWith(
+        "[pulse-core] subscribe() filter threw for address GDEST — treating as reject.",
+        filterError
+      );
+
+      // Engine must still be alive — subsequent unfiltered events should route fine
+      const unfiltered = engine.subscribe("GSRC");
+      const sentHandler = vi.fn();
+      unfiltered.on("payment.sent", sentHandler);
+      latestStream().handlers.onmessage(PAYMENT_RECORD);
+      expect(sentHandler).toHaveBeenCalledOnce();
+    });
+  });
 });


### PR DESCRIPTION
```markdown
# feat(pulse-core): EventEngine.subscribe() filter predicate

## Summary

Consumers that need only a subset of events (e.g. payments above a
threshold, only USDC transfers) previously had to receive every event
and discard unwanted ones in their own code. This change moves that gate
inside the engine so events that will never be consumed are suppressed
before they are emitted.

An optional [filter](cci:1://file:///home/jayking/projects/orbital_stellar/packages/pulse-core/test/pulse-core.test.ts:473:8-473:65) predicate can now be passed at subscribe time:

```ts
const watcher = engine.subscribe("GABC...", {
  filter: (event) =>
    event.type === "payment.received" && Number(event.amount) >= 100,
});
```

Only events for which [filter](cci:1://file:///home/jayking/projects/orbital_stellar/packages/pulse-core/test/pulse-core.test.ts:473:8-473:65) returns `true` are delivered to that
watcher. All watchers without a filter behave exactly as before.

## Changes

- **New [SubscribeOptions](cci:2://file:///home/jayking/projects/orbital_stellar/packages/pulse-core/src/index.ts:67:0-72:2) type** exported from the package — carries the
  optional [filter](cci:1://file:///home/jayking/projects/orbital_stellar/packages/pulse-core/test/pulse-core.test.ts:473:8-473:65) predicate so callers get full TypeScript support.
- **[subscribe(address, options?)](cci:1://file:///home/jayking/projects/orbital_stellar/packages/pulse-core/src/EventEngine.ts:59:2-75:3)** — extended signature stores the
  predicate in a per-address `filters` map; the existing stop handler
  now also removes the entry from that map when the watcher is stopped.
- **[passesFilter(address, event)](cci:1://file:///home/jayking/projects/orbital_stellar/packages/pulse-core/src/EventEngine.ts:298:2-311:3)** — private helper that invokes the
  predicate inside a try/catch. A throwing predicate is treated as a
  rejection and a `[pulse-core]` warning is logged; the engine keeps
  running.
- **[route()](cci:1://file:///home/jayking/projects/orbital_stellar/packages/pulse-core/src/EventEngine.ts:313:2-340:3)** — calls [passesFilter()](cci:1://file:///home/jayking/projects/orbital_stellar/packages/pulse-core/src/EventEngine.ts:298:2-311:3) once per watcher before
  emitting both the specific event type and the `*` wildcard. The
  payment-type resolution was also deduplicated as a minor side-effect.
- **Three new unit tests** covering all three required scenarios:
  filter accepts, filter rejects, and filter throws (engine survives).

## Testing

The full `@orbital/pulse-core` test suite was run with:

```bash
pnpm --filter @orbital/pulse-core test
```

**Result: 17 tests pass, 0 failures.**

New tests added under `describe("subscribe() filter predicate")`:

| Test | Scenario |
|---|---|
| delivers events to a watcher whose filter returns `true` | Happy path — matching event reaches the handler |
| suppresses events for a watcher whose filter returns `false` | Reject path — no handler fires, neither on specific type nor `*` |
| treats a throwing filter as a reject and logs a warning | Safety path — handler suppressed, warning logged, engine routes subsequent events normally |

Closes #83
```