### PR TITLE
feat: support custom Horizon URL override in CoreConfig (#86)

### DIFF
--- a/packages/pulse-core/README.md
+++ b/packages/pulse-core/README.md
@@ -40,6 +40,7 @@ watcher.on("payment.sent", (event) => {
 | Field | Type | Description |
 |---|---|---|
 | `config.network` | `"mainnet" \| "testnet"` | Which Stellar network to connect to |
+| `config.horizonUrl` | `string` | Override the Horizon server URL (e.g. private node, regional mirror, futurenet). When set, `network` is still used for chain context but the connection is made to this URL |
 | `config.reconnect.initialDelayMs` | `number` | First retry delay (default `1000`) |
 | `config.reconnect.maxDelayMs` | `number` | Backoff ceiling (default `30_000`) |
 | `config.reconnect.maxRetries` | `number` | Retry budget (default `Infinity`) |

--- a/packages/pulse-core/src/EventEngine.ts
+++ b/packages/pulse-core/src/EventEngine.ts
@@ -48,7 +48,21 @@ export class EventEngine {
   private isRunning = false;
 
   constructor(config: CoreConfig) {
-    this.server = new Horizon.Server(HORIZON_URLS[config.network]);
+    const horizonUrl = config.horizonUrl ?? HORIZON_URLS[config.network];
+    if (config.horizonUrl !== undefined) {
+      try {
+        const parsed = new URL(horizonUrl);
+        if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+          throw new Error("must be an http or https URL");
+        }
+      } catch (err) {
+        throw new Error(
+          `Invalid horizonUrl: ${(err as Error).message}`
+        );
+      }
+    }
+
+    this.server = new Horizon.Server(horizonUrl);
     this.reconnectConfig = {
       ...DEFAULT_RECONNECT,
       ...config.reconnect,

--- a/packages/pulse-core/src/index.ts
+++ b/packages/pulse-core/src/index.ts
@@ -62,5 +62,6 @@ export type ReconnectConfig = {
 
 export type CoreConfig = {
   network: Network;
+  horizonUrl?: string;
   reconnect?: ReconnectConfig;
 };

--- a/packages/pulse-core/test/pulse-core.test.ts
+++ b/packages/pulse-core/test/pulse-core.test.ts
@@ -11,10 +11,13 @@ type MockStreamInstance = {
 };
 
 const streamInstances: MockStreamInstance[] = [];
+const serverUrls: string[] = [];
 
 vi.mock("@stellar/stellar-sdk", () => {
   class MockServer {
-    constructor(_url: string) {}
+    constructor(url: string) {
+      serverUrls.push(url);
+    }
 
     operations() {
       return {
@@ -52,6 +55,7 @@ function latestStream(): MockStreamInstance {
 describe("pulse-core EventEngine", () => {
   beforeEach(() => {
     streamInstances.length = 0;
+    serverUrls.length = 0;
     vi.useFakeTimers();
     vi.spyOn(console, "error").mockImplementation(() => undefined);
     vi.spyOn(console, "info").mockImplementation(() => undefined);
@@ -180,6 +184,49 @@ describe("pulse-core EventEngine", () => {
       (engine as unknown as { registry: Map<string, unknown> }).registry.has("GABC")
     ).toBe(false);
     expect(engine.subscribe("GABC")).not.toBe(watcher);
+  });
+
+  describe("horizonUrl override", () => {
+    it("uses a custom horizon URL when provided in config", () => {
+      new EventEngine({
+        network: "testnet",
+        horizonUrl: "https://custom-horizon.example.com",
+      });
+      expect(serverUrls[0]).toBe("https://custom-horizon.example.com");
+    });
+
+    it("throws on an invalid horizon URL", () => {
+      expect(
+        () =>
+          new EventEngine({
+            network: "testnet",
+            horizonUrl: "not-a-url",
+          })
+      ).toThrow("Invalid horizonUrl");
+    });
+
+    it("throws on a non-http(s) horizon URL", () => {
+      expect(
+        () =>
+          new EventEngine({
+            network: "testnet",
+            horizonUrl: "ftp://horizon.example.com",
+          })
+      ).toThrow("Invalid horizonUrl");
+    });
+
+    it("falls back to network-derived URL when horizonUrl is not set", () => {
+      new EventEngine({ network: "testnet" });
+      expect(serverUrls[0]).toBe("https://horizon-testnet.stellar.org");
+    });
+
+    it("falls back to network-derived URL when horizonUrl is explicitly undefined", () => {
+      new EventEngine({
+        network: "testnet",
+        horizonUrl: undefined,
+      });
+      expect(serverUrls[0]).toBe("https://horizon-testnet.stellar.org");
+    });
   });
 
   it("guards start() so duplicate live streams are not opened", () => {


### PR DESCRIPTION
## Linked issue

Closes #86

## What changed and why

Adds optional `horizonUrl` to `CoreConfig` so operators with a private Horizon node, regional mirror, or futurenet deployment can override the hardcoded network-derived URL. The URL is validated at construction (must be a valid http/https URL). The `network` field is retained for downstream chain-context reasoning.

## Test plan

- [x] Existing tests pass (`pnpm test`)
- [x] New tests added for new behaviour
- [x] Typechecks pass (`pnpm -r typecheck`)

### New tests

- `horizonUrl override > uses a custom horizon URL when provided in config`
- `horizonUrl override > throws on an invalid horizon URL`
- `horizonUrl override > throws on a non-http(s) horizon URL`
- `horizonUrl override > falls back to network-derived URL when horizonUrl is not set`
- `horizonUrl override > falls back to network-derived URL when horizonUrl is explicitly undefined`

## Breaking changes

None — `horizonUrl` is optional and defaults to the existing network-derived URL.

## Notes for reviewers

The validation uses `new URL()` which throws on malformed strings. Non-http(s) protocols are explicitly rejected. This is consistent with how Horizon SDK itself validates URLs downstream.
