### PR TITLE
warn when listeners are added after watcher stop closes #66

### DIFF
--- a/packages/pulse-core/README.md
+++ b/packages/pulse-core/README.md
@@ -52,6 +52,8 @@ Open or close the SSE stream. Idempotent — calling `start()` twice logs a warn
 
 Returns a `Watcher` for the given Stellar public key. Watchers are deduplicated — calling `subscribe` twice with the same address returns the same instance.
 
+Once a watcher has been stopped, it will not accept new listeners. Calling `watcher.on(...)` after `watcher.stop()` logs a warning and leaves the listener unregistered. If you construct a watcher directly with `{ strictStoppedListeners: true }`, the same call throws instead.
+
 ### `engine.unsubscribe(address)`
 
 Stops and removes the watcher for the given address.

--- a/packages/pulse-core/src/Watcher.ts
+++ b/packages/pulse-core/src/Watcher.ts
@@ -4,19 +4,40 @@ import type { NormalizedEvent, WatcherNotification } from "./index.js";
 
 type WatcherEvent = NormalizedEvent | WatcherNotification;
 
+type WatcherLogger = Pick<Console, "warn">;
+
+export type WatcherOptions = {
+  strictStoppedListeners?: boolean;
+  logger?: WatcherLogger;
+};
+
 export class Watcher extends EventEmitter {
   readonly address: string;
   onStop?: (address: string) => void;
   private _stopped: boolean = false;
+  private readonly strictStoppedListeners: boolean;
+  private readonly logger: WatcherLogger;
   private stopHandlers: Set<() => void> = new Set();
 
-  constructor(address: string) {
+  constructor(address: string, options: WatcherOptions = {}) {
     super();
     this.address = address;
+    this.strictStoppedListeners = options.strictStoppedListeners ?? false;
+    this.logger = options.logger ?? console;
   }
 
   on(eventType: string, handler: (event: WatcherEvent) => void): this {
-    if (this._stopped) return this;
+    if (this._stopped) {
+      const message = `[pulse-core] Watcher.on("${eventType}") called after stop() for address ${this.address}. Listener was not registered.`;
+
+      if (this.strictStoppedListeners) {
+        throw new Error(message);
+      }
+
+      this.logger.warn(message);
+      return this;
+    }
+
     return super.on(eventType, handler);
   }
 

--- a/packages/pulse-core/test/pulse-core.test.ts
+++ b/packages/pulse-core/test/pulse-core.test.ts
@@ -39,6 +39,7 @@ vi.mock("@stellar/stellar-sdk", () => {
 });
 
 import { EventEngine } from "../src/EventEngine.js";
+import { Watcher } from "../src/Watcher.js";
 
 function latestStream(): MockStreamInstance {
   const stream = streamInstances.at(-1);
@@ -180,6 +181,27 @@ describe("pulse-core EventEngine", () => {
       (engine as unknown as { registry: Map<string, unknown> }).registry.has("GABC")
     ).toBe(false);
     expect(engine.subscribe("GABC")).not.toBe(watcher);
+  });
+
+  it("warns when registering listeners after a watcher is stopped", () => {
+    const watcher = new Watcher("GABC");
+
+    watcher.stop();
+    watcher.on("payment.received", vi.fn());
+
+    expect(console.warn).toHaveBeenCalledWith(
+      '[pulse-core] Watcher.on("payment.received") called after stop() for address GABC. Listener was not registered.'
+    );
+  });
+
+  it("throws in strict mode when registering listeners after stop", () => {
+    const watcher = new Watcher("GABC", { strictStoppedListeners: true });
+
+    watcher.stop();
+
+    expect(() => watcher.on("payment.received", vi.fn())).toThrow(
+      '[pulse-core] Watcher.on("payment.received") called after stop() for address GABC. Listener was not registered.'
+    );
   });
 
   it("guards start() so duplicate live streams are not opened", () => {


### PR DESCRIPTION
fix(pulse-core): warn when listeners are added after watcher stop

Prevent Watcher.on() from failing silently after stop() has been called.
Adding a listener to a stopped watcher now logs a clear warning by
default, and direct Watcher construction can opt into strict mode to
throw instead.

Also document the post-stop listener contract in the pulse-core README
and add tests covering both warning and strict-mode behavior.

closes #66
<img width="612" height="261" alt="Screenshot 2026-04-28 at 1 55 21 PM" src="https://github.com/user-attachments/assets/b5c90563-db52-40ef-b509-492022583f04" />
