### PR TITLE
Fix self-payment dedupe in pulse-core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## Unreleased
+
+- `@orbital/pulse-core`: self-payments where `from === to` now emit a single
+  `payment.self` event instead of separate `payment.received` and
+  `payment.sent` events. Consumers that subscribe only to `payment.received` or
+  `payment.sent` should also subscribe to `payment.self` if they need
+  self-payment activity.

--- a/packages/pulse-core/README.md
+++ b/packages/pulse-core/README.md
@@ -31,6 +31,9 @@ watcher.on("payment.received", (event) => {
 watcher.on("payment.sent", (event) => {
   console.log(`Sent ${event.amount} ${event.asset} to ${event.to}`);
 });
+watcher.on("payment.self", (event) => {
+  console.log(`Self-payment of ${event.amount} ${event.asset}`);
+});
 ```
 
 ## API
@@ -62,6 +65,7 @@ Stops and removes the watcher for the given address.
 |---|---|---|
 | `payment.received` | `NormalizedEvent` | The address is the recipient of a payment |
 | `payment.sent` | `NormalizedEvent` | The address is the sender of a payment |
+| `payment.self` | `NormalizedEvent` | The address is both sender and recipient of a payment |
 | `*` | `NormalizedEvent` | Any event on this address |
 | `engine.reconnecting` | `WatcherNotification` | The engine is retrying its upstream connection |
 | `engine.reconnected` | `WatcherNotification` | Reconnect succeeded |
@@ -70,7 +74,7 @@ Stops and removes the watcher for the given address.
 
 ```ts
 type NormalizedEvent = {
-  type: "payment.received" | "payment.sent";
+  type: "payment.received" | "payment.sent" | "payment.self";
   to: string;       // Stellar public key
   from: string;     // Stellar public key
   amount: string;   // Decimal string (never a JS number)

--- a/packages/pulse-core/src/EventEngine.ts
+++ b/packages/pulse-core/src/EventEngine.ts
@@ -315,6 +315,16 @@ export class EventEngine {
       return;
     }
 
+    if (event.from === event.to) {
+      const watcher = this.registry.get(event.to);
+      if (watcher) {
+        const selfPayment = this.withResolvedType(event, "payment.self");
+        watcher.emit("payment.self", selfPayment);
+        watcher.emit("*", selfPayment);
+      }
+      return;
+    }
+
     const toWatcher = this.registry.get(event.to);
     if (toWatcher) {
       toWatcher.emit(

--- a/packages/pulse-core/src/index.ts
+++ b/packages/pulse-core/src/index.ts
@@ -5,8 +5,11 @@ export { StrKey } from "@stellar/stellar-sdk";
 /** The Stellar network to connect to. */
 export type Network = "mainnet" | "testnet";
 
-/** Event types for payment-related events (received or sent). */
-export type PaymentEventType = "payment.received" | "payment.sent";
+/** Event types for payment-related events (received, sent, or self-payment). */
+export type PaymentEventType =
+  | "payment.received"
+  | "payment.sent"
+  | "payment.self";
 /** Event type for account options changes. */
 export type AccountOptionsEventType = "account.options_changed";
 /** Notification types emitted by the EventEngine during reconnection. */

--- a/packages/pulse-core/test/pulse-core.test.ts
+++ b/packages/pulse-core/test/pulse-core.test.ts
@@ -198,6 +198,46 @@ describe("pulse-core EventEngine", () => {
     );
   });
 
+  it("routes self-payments as payment.self exactly once", () => {
+    const engine = new EventEngine({ network: "testnet" });
+    const watcher = engine.subscribe("GSELF");
+    const selfHandler = vi.fn();
+    const receivedHandler = vi.fn();
+    const sentHandler = vi.fn();
+    const wildcardHandler = vi.fn();
+
+    watcher.on("payment.self", selfHandler);
+    watcher.on("payment.received", receivedHandler);
+    watcher.on("payment.sent", sentHandler);
+    watcher.on("*", wildcardHandler);
+
+    engine.start();
+    latestStream().handlers.onmessage({
+      type: "payment",
+      to: "GSELF",
+      from: "GSELF",
+      amount: "25",
+      asset_type: "native",
+      created_at: "2026-04-28T13:00:00.000Z",
+    });
+
+    expect(selfHandler).toHaveBeenCalledOnce();
+    expect(selfHandler).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "payment.self",
+        to: "GSELF",
+        from: "GSELF",
+        amount: "25",
+      })
+    );
+    expect(receivedHandler).not.toHaveBeenCalled();
+    expect(sentHandler).not.toHaveBeenCalled();
+    expect(wildcardHandler).toHaveBeenCalledOnce();
+    expect(wildcardHandler).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "payment.self" })
+    );
+  });
+
   it("reconnects with exponential backoff and emits watcher notifications", () => {
     const engine = new EventEngine({
       network: "testnet",


### PR DESCRIPTION
## Summary
- Route self-payments as a single `payment.self` event.
- Add regression coverage for named and wildcard self-payment emissions.
- Document the new event type and consumer-facing changelog note.

Fixes determined-001/orbital_stellar#67

## Testing
- Not run: Node.js/pnpm are not installed in this environment.