### PR TITLE
feat: normalize DEX offer lifecycle events

### DIFF
--- a/packages/pulse-core/src/EventEngine.ts
+++ b/packages/pulse-core/src/EventEngine.ts
@@ -7,6 +7,8 @@ import type {
   CoreConfig,
   Network,
   NormalizedEvent,
+  OfferEvent,
+  OfferEventType,
   PaymentEvent,
   PaymentEventType,
   ReconnectConfig,
@@ -15,7 +17,10 @@ import type {
 } from "./index.js";
 
 type PendingPaymentEvent = Omit<PaymentEvent, "type"> & { type: "unknown" };
-type NormalizedEventOrPending = PendingPaymentEvent | AccountOptionsEvent;
+type NormalizedEventOrPending =
+  | PendingPaymentEvent
+  | AccountOptionsEvent
+  | OfferEvent;
 
 type StreamCallbacks = {
   onmessage: (record: unknown) => void;
@@ -243,7 +248,50 @@ export class EventEngine {
       return this.normalizeSetOptions(r, record);
     }
 
+    if (r.type === "manage_sell_offer" || r.type === "manage_buy_offer") {
+      return this.normalizeOffer(r, record);
+    }
+
     return null;
+  }
+
+  private normalizeOffer(
+    r: Record<string, unknown>,
+    raw: unknown
+  ): OfferEvent | null {
+    const offer_id = String(r.offer_id ?? "0");
+    const amount = String(r.amount ?? "0");
+
+    let type: OfferEventType;
+    if (amount === "0" || amount === "0.0000000") {
+      type = "offer.deleted";
+    } else if (offer_id === "0") {
+      type = "offer.created";
+    } else {
+      type = "offer.updated";
+    }
+
+    const buying_asset =
+      r.buying_asset_type === "native"
+        ? "XLM"
+        : `${r.buying_asset_code}:${r.buying_asset_issuer}`;
+
+    const selling_asset =
+      r.selling_asset_type === "native"
+        ? "XLM"
+        : `${r.selling_asset_code}:${r.selling_asset_issuer}`;
+
+    return {
+      type,
+      offer_id,
+      source: r.source_account as string,
+      buying_asset,
+      selling_asset,
+      amount,
+      price: r.price as string,
+      timestamp: r.created_at as string,
+      raw,
+    };
   }
 
   private normalizeSetOptions(
@@ -295,6 +343,19 @@ export class EventEngine {
       const watcher = this.registry.get(event.source);
       if (watcher) {
         watcher.emit("account.options_changed", event);
+        watcher.emit("*", event);
+      }
+      return;
+    }
+
+    if (
+      event.type === "offer.created" ||
+      event.type === "offer.updated" ||
+      event.type === "offer.deleted"
+    ) {
+      const watcher = this.registry.get(event.source);
+      if (watcher) {
+        watcher.emit(event.type, event);
         watcher.emit("*", event);
       }
       return;

--- a/packages/pulse-core/src/index.ts
+++ b/packages/pulse-core/src/index.ts
@@ -10,6 +10,8 @@ export type WatcherNotificationType =
   | "engine.reconnecting"
   | "engine.reconnected";
 
+export type OfferEventType = "offer.created" | "offer.updated" | "offer.deleted";
+
 export type SetOptionsSigner = {
   key: string;
   weight: number;
@@ -45,7 +47,19 @@ export type AccountOptionsEvent = {
   raw: unknown;
 };
 
-export type NormalizedEvent = PaymentEvent | AccountOptionsEvent;
+export type OfferEvent = {
+  type: OfferEventType;
+  offer_id: string;
+  source: string;
+  buying_asset: string;
+  selling_asset: string;
+  amount: string;
+  price: string;
+  timestamp: string;
+  raw: unknown;
+};
+
+export type NormalizedEvent = PaymentEvent | AccountOptionsEvent | OfferEvent;
 
 export type WatcherNotification = {
   type: WatcherNotificationType;

--- a/packages/pulse-core/test/pulse-core.test.ts
+++ b/packages/pulse-core/test/pulse-core.test.ts
@@ -440,4 +440,110 @@ describe("pulse-core EventEngine", () => {
       expect(otherHandler).not.toHaveBeenCalled();
     });
   });
+
+  describe("manage_sell_offer / manage_buy_offer → offer.*", () => {
+    function makeOfferRecord(
+      overrides: Record<string, unknown>
+    ): Record<string, unknown> {
+      return {
+        type: "manage_sell_offer",
+        source_account: "GSRC",
+        offer_id: "0",
+        amount: "100.0000000",
+        buying_asset_type: "native",
+        selling_asset_type: "credit_alphanum4",
+        selling_asset_code: "USDC",
+        selling_asset_issuer: "GISSUER",
+        price: "0.5",
+        created_at: "2026-04-28T14:00:00.000Z",
+        ...overrides,
+      };
+    }
+
+    it("emits offer.created when offer_id is 0 and amount > 0", () => {
+      const engine = new EventEngine({ network: "testnet" });
+      const watcher = engine.subscribe("GSRC");
+      const handler = vi.fn();
+      watcher.on("offer.created", handler);
+
+      engine.start();
+      latestStream().handlers.onmessage(
+        makeOfferRecord({ offer_id: "0", amount: "100" })
+      );
+
+      expect(handler).toHaveBeenCalledOnce();
+      expect(handler).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: "offer.created",
+          offer_id: "0",
+          source: "GSRC",
+          buying_asset: "XLM",
+          selling_asset: "USDC:GISSUER",
+          amount: "100",
+        })
+      );
+    });
+
+    it("emits offer.updated when offer_id > 0 and amount > 0", () => {
+      const engine = new EventEngine({ network: "testnet" });
+      const watcher = engine.subscribe("GSRC");
+      const handler = vi.fn();
+      watcher.on("offer.updated", handler);
+
+      engine.start();
+      latestStream().handlers.onmessage(
+        makeOfferRecord({ offer_id: "12345", amount: "200" })
+      );
+
+      expect(handler).toHaveBeenCalledOnce();
+      expect(handler).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: "offer.updated",
+          offer_id: "12345",
+          amount: "200",
+        })
+      );
+    });
+
+    it("emits offer.deleted when amount is 0", () => {
+      const engine = new EventEngine({ network: "testnet" });
+      const watcher = engine.subscribe("GSRC");
+      const handler = vi.fn();
+      watcher.on("offer.deleted", handler);
+
+      engine.start();
+      latestStream().handlers.onmessage(
+        makeOfferRecord({ offer_id: "12345", amount: "0" })
+      );
+
+      expect(handler).toHaveBeenCalledOnce();
+      expect(handler).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: "offer.deleted",
+          offer_id: "12345",
+          amount: "0",
+        })
+      );
+    });
+
+    it("works for manage_buy_offer as well", () => {
+      const engine = new EventEngine({ network: "testnet" });
+      const watcher = engine.subscribe("GSRC");
+      const handler = vi.fn();
+      watcher.on("offer.created", handler);
+
+      engine.start();
+      latestStream().handlers.onmessage(
+        makeOfferRecord({ type: "manage_buy_offer", offer_id: "0", amount: "50" })
+      );
+
+      expect(handler).toHaveBeenCalledOnce();
+      expect(handler).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: "offer.created",
+          amount: "50",
+        })
+      );
+    });
+  });
 });


### PR DESCRIPTION
Linked issue
Closes #74 

What changed and why
This

PR normalizes Stellar DEX offer operations (manage_sell_offer and manage_buy_offer) into high-level lifecycle events: offer.created, offer.updated, and offer.deleted. This change is needed because DEX-aware consumers (market makers, analytics dashboards) currently cannot use Pulse to track offer lifecycles without manually polling Horizon. By mapping these operations based on offer_id and amount, Pulse can now emit real-time notifications for DEX activity directly to source account watchers.

Test plan
 Existing tests pass (pnpm test)
 New tests added for new behaviour
 Typechecks pass (pnpm -r typecheck)
 Manually tested against testnet / mainnet (describe what you tested)
Note: Verified via unit tests in packages/pulse-core/test/pulse-core.test.ts where all 18 tests (including 4 new offer tests) passed.

Breaking changes
None. This PR adds new event types to the NormalizedEvent union and does not modify existing payment or account.options_changed logic.

Notes for reviewers
The normalization logic follows the standard Stellar pattern:

An amount of "0" or "0.0000000" signals an offer deletion.
An offer_id of "0" signals a new offer creation.
A non-zero offer_id with a positive amount signals an offer update.
Routing is handled by emitting to the source account's watcher, ensuring that users monitoring their own accounts receive these DEX events automatically.