### PR TITLE
fix: Remove unused Watcher.onStop field

### DIFF
--- a/packages/pulse-core/src/Watcher.ts
+++ b/packages/pulse-core/src/Watcher.ts
@@ -6,7 +6,6 @@ type WatcherEvent = NormalizedEvent | WatcherNotification;
 
 export class Watcher extends EventEmitter {
   readonly address: string;
-  onStop?: (address: string) => void;
   private _stopped: boolean = false;
   private stopHandlers: Set<() => void> = new Set();
 
@@ -32,7 +31,7 @@ export class Watcher extends EventEmitter {
   addStopHandler(handler: () => void): () => void {
     if (this._stopped) {
       handler();
-      return () => {};
+      return () => { };
     }
 
     this.stopHandlers.add(handler);
@@ -49,6 +48,5 @@ export class Watcher extends EventEmitter {
     }
     this.stopHandlers.clear();
     this.removeAllListeners();
-    this.onStop?.(this.address);
   }
 }


### PR DESCRIPTION
## Linked issue
Closes #63 

## What changed and why
Removes the unused `onStop` field from the `Watcher` class. This callback was superseded by the `addStopHandler()` registration API, which provides the same functionality with better ergonomics. The field was never set by any internal consumer in `apps/server`, `packages/pulse-webhooks`, or tests — it was dead surface area. The invocation of `this.onStop?.(this.address)` in `Watcher.stop()` has been removed alongside the declaration.

## Test plan
- [x] Existing tests pass (`pnpm test`)
- [ ] New tests added for new behaviour
- [x] Typechecks pass (`pnpm -r typecheck`)
- [ ] Manually tested against testnet / mainnet (describe what you tested)

## Breaking changes
Yes — `onStop` is removed from the public API of `Watcher`. Any external consumer that set `watcher.onStop = ...` will need to migrate to `watcher.addStopHandler(...)` instead.

## Notes for reviewers
The only reference to `onStop` outside of `Watcher.ts` itself was a comment in `packages/pulse-core/test/integration/horizon.test.ts` — updated to reference "stop handlers" instead. No actual call sites were found. The diff is a net -3 lines with no logic change.


<img width="473" height="288" alt="image" src="https://github.com/user-attachments/assets/3164e033-8602-4c24-8367-88a9d76f0ff4" />
