### PR TITLE
feat: implement rate limiting handling for Horizon 429 responses in E…

### DIFF
--- a/packages/pulse-core/README.md
+++ b/packages/pulse-core/README.md
@@ -65,6 +65,7 @@ Stops and removes the watcher for the given address.
 | `*` | `NormalizedEvent` | Any event on this address |
 | `engine.reconnecting` | `WatcherNotification` | The engine is retrying its upstream connection |
 | `engine.reconnected` | `WatcherNotification` | Reconnect succeeded |
+| `engine.rate_limited` | `WatcherNotification` | The engine was rate limited and will retry after the delay |
 
 ### `NormalizedEvent` shape
 

--- a/packages/pulse-core/src/EventEngine.ts
+++ b/packages/pulse-core/src/EventEngine.ts
@@ -129,7 +129,7 @@ export class EventEngine {
       },
       onerror: (error) => {
         console.error("[pulse-core] SSE error:", error);
-        this.handleStreamError();
+        this.handleStreamError(error);
       },
     };
 
@@ -139,7 +139,7 @@ export class EventEngine {
       .stream(callbacks);
   }
 
-  private handleStreamError(): void {
+  private handleStreamError(error: unknown): void {
     if (this.reconnectTimer) {
       return;
     }
@@ -158,25 +158,125 @@ export class EventEngine {
 
     this.reconnectAttempt = nextAttempt;
 
-    const delayMs = Math.min(
-      this.reconnectConfig.initialDelayMs * 2 ** (nextAttempt - 1),
-      this.reconnectConfig.maxDelayMs
-    );
+    const isRateLimited = this.isRateLimitError(error);
+    const retryAfterMs = isRateLimited ? this.parseRetryAfterMs(error) : null;
+    const delayMs = isRateLimited
+      ? retryAfterMs ?? 60000
+      : Math.min(
+          this.reconnectConfig.initialDelayMs * 2 ** (nextAttempt - 1),
+          this.reconnectConfig.maxDelayMs
+        );
 
-    console.warn(
-      `[pulse-core] SSE reconnect attempt ${nextAttempt} scheduled in ${delayMs}ms.`
-    );
-    this.notifyWatchers("engine.reconnecting", {
-      type: "engine.reconnecting",
-      attempt: nextAttempt,
-      delayMs,
-      timestamp: new Date().toISOString(),
-    });
+    if (isRateLimited) {
+      console.warn(
+        `[pulse-core] SSE rate limited by Horizon, reconnect scheduled in ${delayMs}ms.`
+      );
+      this.notifyWatchers("engine.rate_limited", {
+        type: "engine.rate_limited",
+        attempt: nextAttempt,
+        delayMs,
+        timestamp: new Date().toISOString(),
+      });
+    } else {
+      console.warn(
+        `[pulse-core] SSE reconnect attempt ${nextAttempt} scheduled in ${delayMs}ms.`
+      );
+      this.notifyWatchers("engine.reconnecting", {
+        type: "engine.reconnecting",
+        attempt: nextAttempt,
+        delayMs,
+        timestamp: new Date().toISOString(),
+      });
+    }
 
     this.reconnectTimer = setTimeout(() => {
       this.reconnectTimer = null;
       this.openStream(true);
     }, delayMs);
+  }
+
+  private isRateLimitError(error: unknown): boolean {
+    const status = this.extractStatus(error);
+    return status === 429;
+  }
+
+  private extractStatus(error: unknown): number | undefined {
+    const e = error as Record<string, unknown>;
+    if (typeof e.status === "number") {
+      return e.status;
+    }
+    if (typeof e.statusCode === "number") {
+      return e.statusCode;
+    }
+
+    const response = e.response as Record<string, unknown> | undefined;
+    if (response) {
+      if (typeof response.status === "number") {
+        return response.status;
+      }
+      if (typeof response.statusCode === "number") {
+        return response.statusCode;
+      }
+    }
+
+    return undefined;
+  }
+
+  private parseRetryAfterMs(error: unknown): number | null {
+    const header = this.getHeaderValue(error, "Retry-After");
+    if (!header) {
+      return null;
+    }
+
+    const seconds = Number.parseInt(header, 10);
+    if (!Number.isNaN(seconds)) {
+      return seconds * 1000;
+    }
+
+    const date = new Date(header).getTime();
+    return Number.isNaN(date) ? null : Math.max(date - Date.now(), 0);
+  }
+
+  private getHeaderValue(error: unknown, headerName: string): string | null {
+    const e = error as Record<string, unknown>;
+    const directHeader = typeof e[headerName.toLowerCase()] === "string"
+      ? (e[headerName.toLowerCase()] as string)
+      : typeof e[headerName] === "string"
+      ? (e[headerName] as string)
+      : null;
+    if (directHeader) {
+      return directHeader;
+    }
+
+    const response = e.response as Record<string, unknown> | undefined;
+    const candidates = [e.headers, response?.headers];
+
+    for (const headers of candidates) {
+      if (!headers || typeof headers !== "object") {
+        continue;
+      }
+
+      if (typeof (headers as any).get === "function") {
+        const value = (headers as any).get(headerName) ??
+          (headers as any).get(headerName.toLowerCase());
+        if (typeof value === "string") {
+          return value;
+        }
+      }
+
+      const value =
+        typeof (headers as any)[headerName] === "string"
+          ? (headers as any)[headerName]
+          : typeof (headers as any)[headerName.toLowerCase()] === "string"
+          ? (headers as any)[headerName.toLowerCase()]
+          : null;
+
+      if (typeof value === "string") {
+        return value;
+      }
+    }
+
+    return null;
   }
 
   private closeStream(): void {

--- a/packages/pulse-core/src/index.ts
+++ b/packages/pulse-core/src/index.ts
@@ -8,7 +8,8 @@ export type PaymentEventType = "payment.received" | "payment.sent";
 export type AccountOptionsEventType = "account.options_changed";
 export type WatcherNotificationType =
   | "engine.reconnecting"
-  | "engine.reconnected";
+  | "engine.reconnected"
+  | "engine.rate_limited";
 
 export type SetOptionsSigner = {
   key: string;

--- a/packages/pulse-core/test/pulse-core.test.ts
+++ b/packages/pulse-core/test/pulse-core.test.ts
@@ -278,6 +278,69 @@ describe("pulse-core EventEngine", () => {
     );
   });
 
+  it("honors 429 Retry-After and emits engine.rate_limited", () => {
+    const engine = new EventEngine({ network: "testnet" });
+    const watcher = engine.subscribe("GABC");
+    const rateLimited = vi.fn();
+    const reconnecting = vi.fn();
+
+    watcher.on("engine.rate_limited", rateLimited);
+    watcher.on("engine.reconnecting", reconnecting);
+
+    engine.start();
+
+    latestStream().handlers.onerror({
+      status: 429,
+      headers: {
+        get: (name: string) =>
+          name.toLowerCase() === "retry-after" ? "5" : null,
+      },
+    });
+
+    expect(rateLimited).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "engine.rate_limited",
+        attempt: 1,
+        delayMs: 5000,
+      })
+    );
+    expect(reconnecting).not.toHaveBeenCalled();
+    expect(console.warn).toHaveBeenCalledWith(
+      "[pulse-core] SSE rate limited by Horizon, reconnect scheduled in 5000ms."
+    );
+
+    vi.advanceTimersByTime(5000);
+    expect(streamInstances).toHaveLength(2);
+  });
+
+  it("backs off at least 60 seconds when Horizon returns 429 without Retry-After", () => {
+    const engine = new EventEngine({ network: "testnet" });
+    const watcher = engine.subscribe("GABC");
+    const rateLimited = vi.fn();
+
+    watcher.on("engine.rate_limited", rateLimited);
+
+    engine.start();
+
+    latestStream().handlers.onerror({
+      status: 429,
+      headers: {
+        get: () => null,
+      },
+    });
+
+    expect(rateLimited).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "engine.rate_limited",
+        attempt: 1,
+        delayMs: 60000,
+      })
+    );
+    expect(console.warn).toHaveBeenCalledWith(
+      "[pulse-core] SSE rate limited by Horizon, reconnect scheduled in 60000ms."
+    );
+  });
+
   describe("set_options → account.options_changed", () => {
     function makeSetOptionsRecord(
       overrides: Record<string, unknown>


### PR DESCRIPTION
Closes #88 

- Add Horizon `429` rate-limit handling in EventEngine.ts
- Honor `Retry-After` when present, otherwise wait at least `60000ms`
- Emit new watcher notification `engine.rate_limited`
- Update index.ts and docs
- Add tests for `429` with and without `Retry-After`