### PR TITLE
#194 4.34 — Error response standardization (RFC 7807)

### DIFF
--- a/apps/server/README.md
+++ b/apps/server/README.md
@@ -6,14 +6,14 @@ This is the binary that a self-hoster runs. Everything else in Orbital is a libr
 
 ## Endpoints
 
-| Method | Path | Description |
-|---|---|---|
-| `POST` | `/webhooks/register` | Register an address → webhook URL mapping |
-| `DELETE` | `/webhooks/:address` | Unregister an address |
-| `GET` | `/webhooks` | List registered webhooks (secrets stripped) |
-| `GET` | `/webhooks/:address` | Get a single registration |
-| `GET` | `/events/:address` | Server-Sent Events stream for live events |
-| `GET` | `/health` | Liveness probe |
+| Method   | Path                 | Description                                 |
+| -------- | -------------------- | ------------------------------------------- |
+| `POST`   | `/webhooks/register` | Register an address → webhook URL mapping   |
+| `DELETE` | `/webhooks/:address` | Unregister an address                       |
+| `GET`    | `/webhooks`          | List registered webhooks (secrets stripped) |
+| `GET`    | `/webhooks/:address` | Get a single registration                   |
+| `GET`    | `/events/:address`   | Server-Sent Events stream for live events   |
+| `GET`    | `/health`            | Liveness probe                              |
 
 All endpoints except `/health` require an API key — either `Authorization: Bearer <key>` (REST) or `?token=<key>` (SSE, since browsers cannot set headers on `EventSource`).
 
@@ -57,12 +57,47 @@ useStellarEvent({
 
 ## Environment variables
 
-| Variable | Required | Description |
-|---|---|---|
-| `NETWORK` | yes | `mainnet` or `testnet` |
-| `API_KEY` | yes | Bearer token clients must present |
-| `PORT` | no | HTTP port (default `3000`) |
-| `WEBHOOK_SECRET` | no | HMAC key used to hash stored webhook secrets |
+| Variable         | Required | Description                                  |
+| ---------------- | -------- | -------------------------------------------- |
+| `NETWORK`        | yes      | `mainnet` or `testnet`                       |
+| `API_KEY`        | yes      | Bearer token clients must present            |
+| `PORT`           | no       | HTTP port (default `3000`)                   |
+| `WEBHOOK_SECRET` | no       | HMAC key used to hash stored webhook secrets |
+
+## Error responses
+
+All error responses follow [RFC 7807](https://tools.ietf.org/html/rfc7807) (Problem Details for HTTP APIs) and are returned with `Content-Type: application/problem+json`.
+
+### Error response shape
+
+```json
+{
+  "type": "https://api.orbital.dev/errors/invalid-stellar-key",
+  "title": "Invalid Stellar Key",
+  "status": 400,
+  "detail": "address must be a valid Stellar public key",
+  "instance": "https://api.orbital.dev/requests/550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+| Field      | Type   | Description                                             |
+| ---------- | ------ | ------------------------------------------------------- |
+| `type`     | string | A machine-readable error identifier (typically a URI)   |
+| `title`    | string | A short, human-readable error summary                   |
+| `status`   | number | The HTTP status code                                    |
+| `detail`   | string | A specific explanation for this occurrence              |
+| `instance` | string | Optional: A unique identifier for this error occurrence |
+
+### Common error responses
+
+| Status | Title                        | Description                                    |
+| ------ | ---------------------------- | ---------------------------------------------- |
+| 400    | `Missing Required Fields`    | Request body is missing required fields        |
+| 400    | `Invalid Field Types`        | Field types do not match expectations          |
+| 400    | `Invalid Stellar Key`        | Address is not a valid Stellar public key      |
+| 400    | `Invalid Webhook URL`        | URL must be HTTPS and not point to private IPs |
+| 409    | `Address Already Registered` | This address already has an active webhook     |
+| 404    | `Not Found`                  | The requested address is not registered        |
 
 ## Security defaults
 

--- a/apps/server/src/errors.ts
+++ b/apps/server/src/errors.ts
@@ -1,0 +1,62 @@
+import type { Response } from "express";
+
+/**
+ * RFC 7807 Problem Details for HTTP APIs
+ * https://tools.ietf.org/html/rfc7807
+ *
+ * A standard error response shape for APIs that:
+ * - Makes errors machine-readable
+ * - Allows clients to handle errors consistently
+ * - Follows the industry standard
+ */
+export interface ProblemDetails {
+  /** A URI reference identifying the problem type (e.g., "https://api.orbital.dev/errors/invalid-key") */
+  type: string;
+  /** A short, human-readable summary of the problem (e.g., "Invalid Stellar Key") */
+  title: string;
+  /** The HTTP status code */
+  status: number;
+  /** A human-readable explanation specific to this occurrence */
+  detail: string;
+  /** Optional: A URI reference identifying this specific occurrence */
+  instance?: string;
+}
+
+/**
+ * Send an RFC 7807 Problem Details response.
+ *
+ * @param res Express response object
+ * @param statusCode HTTP status code
+ * @param title Short title (e.g., "Invalid Request")
+ * @param detail Specific detail about the error
+ * @param options Optional type and instance URIs
+ */
+export function sendProblem(
+  res: Response,
+  statusCode: number,
+  title: string,
+  detail: string,
+  options?: { type?: string; instance?: string },
+): void {
+  const problem: ProblemDetails = {
+    type:
+      options?.type ?? `https://api.orbital.dev/errors/${toKebabCase(title)}`,
+    title,
+    status: statusCode,
+    detail,
+    ...(options?.instance && { instance: options.instance }),
+  };
+
+  res.status(statusCode).contentType("application/problem+json").json(problem);
+}
+
+/**
+ * Convert a title string to kebab-case for use in error type URIs.
+ * e.g., "Invalid Stellar Key" -> "invalid-stellar-key"
+ */
+function toKebabCase(str: string): string {
+  return str
+    .toLowerCase()
+    .replace(/\s+/g, "-")
+    .replace(/[^a-z0-9-]/g, "");
+}

--- a/apps/server/src/routes.ts
+++ b/apps/server/src/routes.ts
@@ -2,6 +2,7 @@ import { Router, type Request, type Response } from "express";
 import { StrKey, type EventEngine } from "@orbital/pulse-core";
 import type { WebhookRegistry } from "./registry.js";
 import { requireApiKey } from "./auth.js";
+import { sendProblem } from "./errors.js";
 
 // --- SSRF-safe URL validation ---
 
@@ -33,7 +34,10 @@ function validateWebhookUrl(raw: string): string | null {
 
 // --- Routes ---
 
-export function createRoutes(registry: WebhookRegistry, engine: EventEngine): Router {
+export function createRoutes(
+  registry: WebhookRegistry,
+  engine: EventEngine,
+): Router {
   const router = Router();
 
   // Apply auth to every route in this router
@@ -44,30 +48,54 @@ export function createRoutes(registry: WebhookRegistry, engine: EventEngine): Ro
     const { address, url, secret } = req.body as Record<string, unknown>;
 
     if (!address || !url || !secret) {
-      res.status(400).json({ error: "address, url and secret are required" });
+      sendProblem(
+        res,
+        400,
+        "Missing Required Fields",
+        "address, url and secret are required",
+      );
       return;
     }
 
-    if (typeof address !== "string" || typeof url !== "string" || typeof secret !== "string") {
-      res.status(400).json({ error: "address, url and secret must be strings" });
+    if (
+      typeof address !== "string" ||
+      typeof url !== "string" ||
+      typeof secret !== "string"
+    ) {
+      sendProblem(
+        res,
+        400,
+        "Invalid Field Types",
+        "address, url and secret must be strings",
+      );
       return;
     }
 
     // Validate Stellar public key
     if (!StrKey.isValidEd25519PublicKey(address)) {
-      res.status(400).json({ error: "address must be a valid Stellar public key" });
+      sendProblem(
+        res,
+        400,
+        "Invalid Stellar Key",
+        "address must be a valid Stellar public key",
+      );
       return;
     }
 
     // Validate webhook URL (HTTPS, no SSRF)
     const urlError = validateWebhookUrl(url);
     if (urlError) {
-      res.status(400).json({ error: urlError });
+      sendProblem(res, 400, "Invalid Webhook URL", urlError);
       return;
     }
 
     if (registry.has(address)) {
-      res.status(409).json({ error: "Address already registered" });
+      sendProblem(
+        res,
+        409,
+        "Address Already Registered",
+        "This address already has a registered webhook",
+      );
       return;
     }
 
@@ -76,17 +104,25 @@ export function createRoutes(registry: WebhookRegistry, engine: EventEngine): Ro
   });
 
   // Unregister a webhook
-  router.delete("/webhooks/:address", (req: Request<{ address: string }>, res: Response) => {
-    const { address } = req.params;
-    const removed = registry.unregister(address);
+  router.delete(
+    "/webhooks/:address",
+    (req: Request<{ address: string }>, res: Response) => {
+      const { address } = req.params;
+      const removed = registry.unregister(address);
 
-    if (!removed) {
-      res.status(404).json({ error: "Address not registered" });
-      return;
-    }
+      if (!removed) {
+        sendProblem(
+          res,
+          404,
+          "Not Found",
+          `Address ${address} is not registered`,
+        );
+        return;
+      }
 
-    res.status(200).json({ message: `Unregistered ${address}` });
-  });
+      res.status(200).json({ message: `Unregistered ${address}` });
+    },
+  );
 
   // List all registrations — secrets are never included
   router.get("/webhooks", (_req: Request, res: Response) => {
@@ -94,48 +130,59 @@ export function createRoutes(registry: WebhookRegistry, engine: EventEngine): Ro
   });
 
   // Get a single registration
-  router.get("/webhooks/:address", (req: Request<{ address: string }>, res: Response) => {
-    const { address } = req.params;
-    if (!registry.has(address)) {
-      res.status(404).json({ error: "Address not registered" });
-      return;
-    }
-    // list() already strips secrets; find the one entry
-    const entry = registry.list().find((r) => r.address === address);
-    res.status(200).json(entry);
-  });
+  router.get(
+    "/webhooks/:address",
+    (req: Request<{ address: string }>, res: Response) => {
+      const { address } = req.params;
+      if (!registry.has(address)) {
+        sendProblem(
+          res,
+          404,
+          "Not Found",
+          `Address ${address} is not registered`,
+        );
+        return;
+      }
+      // list() already strips secrets; find the one entry
+      const entry = registry.list().find((r) => r.address === address);
+      res.status(200).json(entry);
+    },
+  );
 
   // SSE endpoint — browser connects here to receive live events
-  router.get("/events/:address", (req: Request<{ address: string }>, res: Response) => {
-    const { address } = req.params;
+  router.get(
+    "/events/:address",
+    (req: Request<{ address: string }>, res: Response) => {
+      const { address } = req.params;
 
-    res.setHeader("Content-Type", "text/event-stream");
-    res.setHeader("Cache-Control", "no-cache");
-    res.setHeader("Connection", "keep-alive");
-    res.flushHeaders();
+      res.setHeader("Content-Type", "text/event-stream");
+      res.setHeader("Cache-Control", "no-cache");
+      res.setHeader("Connection", "keep-alive");
+      res.flushHeaders();
 
-    const watcher = engine.subscribe(address);
+      const watcher = engine.subscribe(address);
 
-    const handler = (event: unknown) => {
-      res.write(`data: ${JSON.stringify(event)}\n\n`);
-    };
+      const handler = (event: unknown) => {
+        res.write(`data: ${JSON.stringify(event)}\n\n`);
+      };
 
-    watcher.on("*", handler);
+      watcher.on("*", handler);
 
-    const heartbeat = setInterval(() => {
-      res.write(`: heartbeat\n\n`);
-    }, 30000);
+      const heartbeat = setInterval(() => {
+        res.write(`: heartbeat\n\n`);
+      }, 30000);
 
-    req.on("close", () => {
-      clearInterval(heartbeat);
-      watcher.removeListener("*", handler);
-      // Fully remove the watcher from the engine so no dead watchers remain
-      engine.unsubscribe(address);
-      console.log(`[sse] Client disconnected from ${address}`);
-    });
+      req.on("close", () => {
+        clearInterval(heartbeat);
+        watcher.removeListener("*", handler);
+        // Fully remove the watcher from the engine so no dead watchers remain
+        engine.unsubscribe(address);
+        console.log(`[sse] Client disconnected from ${address}`);
+      });
 
-    console.log(`[sse] Client connected to ${address}`);
-  });
+      console.log(`[sse] Client connected to ${address}`);
+    },
+  );
 
   return router;
 }


### PR DESCRIPTION
## Linked issue

Closes #194 


### Changes

#### New File: errors.ts
- Created `ProblemDetails` interface with fields:
  - `type`: Machine-readable error identifier (URI)
  - `title`: Short human-readable summary
  - `status`: HTTP status code
  - `detail`: Specific explanation for this occurrence
  - `instance`: Optional unique identifier for this error
- Implemented `sendProblem()` helper function that:
  - Sets `Content-Type: application/problem+json`
  - Auto-generates type URIs (e.g., "invalid-stellar-key" from "Invalid Stellar Key")
  - Allows custom type and instance URIs if needed

#### Modified: routes.ts
- Added import of `sendProblem` helper
- Replaced all 7 error sites with RFC 7807 responses:
  - `POST /webhooks/register`: Missing/invalid fields, invalid Stellar key, invalid URL, duplicate address
  - `DELETE /webhooks/:address`: Address not found
  - `GET /webhooks/:address`: Address not found

#### Modified: README.md
- Added "Error responses" section documenting:
  - RFC 7807 compliance
  - Error response shape with field descriptions
  - Example error response
  - Table of common error responses with status codes and descriptions

### Done When
✅ All error responses follow RFC 7807 with `Content-Type: application/problem+json`
✅ Consistent error structure across all endpoints
✅ Machine-readable error types for client-side handling
✅ Error responses documented in README

### Files Changed
- errors.ts (new)
- routes.ts (modified)
- README.md (modified)

thank you!