### PR TITLE
feat: add support for claimable balance creation and claiming events …

### DIFF
--- a/packages/pulse-core/src/EventEngine.ts
+++ b/packages/pulse-core/src/EventEngine.ts
@@ -4,6 +4,9 @@ import type {
   AccountOptionsChanges,
   AccountOptionsEvent,
   AccountOptionsEventType,
+  ClaimableBalanceClaimant,
+  ClaimableClaimedEvent,
+  ClaimableCreatedEvent,
   CoreConfig,
   Network,
   NormalizedEvent,
@@ -15,7 +18,11 @@ import type {
 } from "./index.js";
 
 type PendingPaymentEvent = Omit<PaymentEvent, "type"> & { type: "unknown" };
-type NormalizedEventOrPending = PendingPaymentEvent | AccountOptionsEvent;
+type NormalizedEventOrPending =
+  | PendingPaymentEvent
+  | AccountOptionsEvent
+  | ClaimableCreatedEvent
+  | ClaimableClaimedEvent;
 
 type StreamCallbacks = {
   onmessage: (record: unknown) => void;
@@ -243,6 +250,14 @@ export class EventEngine {
       return this.normalizeSetOptions(r, record);
     }
 
+    if (r.type === "create_claimable_balance") {
+      return this.normalizeCreateClaimableBalance(r, record);
+    }
+
+    if (r.type === "claim_claimable_balance") {
+      return this.normalizeClaimClaimableBalance(r, record);
+    }
+
     return null;
   }
 
@@ -290,11 +305,130 @@ export class EventEngine {
     };
   }
 
+  private normalizeCreateClaimableBalance(
+    r: Record<string, unknown>,
+    raw: unknown
+  ): ClaimableCreatedEvent | null {
+    const requiredStringFields = [
+      "source_account",
+      "created_at",
+      "amount",
+      "balance_id",
+    ] as const;
+
+    for (const field of requiredStringFields) {
+      if (typeof r[field] !== "string" || r[field] === "") {
+        console.warn(
+          `[pulse-core] normalize() dropping create_claimable_balance record: field "${field}" is missing or not a non-empty string.`,
+          { record: raw }
+        );
+        return null;
+      }
+    }
+
+    if (
+      !Array.isArray(r.claimants) ||
+      r.claimants.length === 0 ||
+      !r.claimants.every(
+        (c: unknown) =>
+          typeof c === "object" &&
+          c !== null &&
+          typeof (c as Record<string, unknown>).destination === "string" &&
+          (c as Record<string, unknown>).destination !== ""
+      )
+    ) {
+      console.warn(
+        '[pulse-core] normalize() dropping create_claimable_balance record: field "claimants" is missing or invalid.',
+        { record: raw }
+      );
+      return null;
+    }
+
+    const asset =
+      r.asset_type === "native"
+        ? "XLM"
+        : `${r.asset_code}:${r.asset_issuer}`;
+
+    return {
+      type: "claimable.created",
+      sponsor: r.source_account as string,
+      balanceId: r.balance_id as string,
+      claimants: (r.claimants as Array<Record<string, unknown>>).map((c) => ({
+        destination: c.destination as string,
+        predicate: c.predicate,
+      })),
+      asset,
+      amount: r.amount as string,
+      timestamp: r.created_at as string,
+      raw,
+    };
+  }
+
+  private normalizeClaimClaimableBalance(
+    r: Record<string, unknown>,
+    raw: unknown
+  ): ClaimableClaimedEvent | null {
+    const requiredStringFields = [
+      "source_account",
+      "created_at",
+      "balance_id",
+    ] as const;
+
+    for (const field of requiredStringFields) {
+      if (typeof r[field] !== "string" || r[field] === "") {
+        console.warn(
+          `[pulse-core] normalize() dropping claim_claimable_balance record: field "${field}" is missing or not a non-empty string.`,
+          { record: raw }
+        );
+        return null;
+      }
+    }
+
+    return {
+      type: "claimable.claimed",
+      claimant: r.source_account as string,
+      balanceId: r.balance_id as string,
+      timestamp: r.created_at as string,
+      raw,
+    };
+  }
+
   private route(event: NormalizedEventOrPending): void {
     if (event.type === "account.options_changed") {
       const watcher = this.registry.get(event.source);
       if (watcher) {
         watcher.emit("account.options_changed", event);
+        watcher.emit("*", event);
+      }
+      return;
+    }
+
+    if (event.type === "claimable.created") {
+      const notified = new Set<string>();
+
+      for (const claimant of event.claimants) {
+        const watcher = this.registry.get(claimant.destination);
+        if (watcher && !notified.has(claimant.destination)) {
+          notified.add(claimant.destination);
+          watcher.emit("claimable.created", event);
+          watcher.emit("*", event);
+        }
+      }
+
+      if (!notified.has(event.sponsor)) {
+        const sponsorWatcher = this.registry.get(event.sponsor);
+        if (sponsorWatcher) {
+          sponsorWatcher.emit("claimable.created", event);
+          sponsorWatcher.emit("*", event);
+        }
+      }
+      return;
+    }
+
+    if (event.type === "claimable.claimed") {
+      const watcher = this.registry.get(event.claimant);
+      if (watcher) {
+        watcher.emit("claimable.claimed", event);
         watcher.emit("*", event);
       }
       return;

--- a/packages/pulse-core/src/index.ts
+++ b/packages/pulse-core/src/index.ts
@@ -6,6 +6,8 @@ export type Network = "mainnet" | "testnet";
 
 export type PaymentEventType = "payment.received" | "payment.sent";
 export type AccountOptionsEventType = "account.options_changed";
+export type ClaimableCreatedEventType = "claimable.created";
+export type ClaimableClaimedEventType = "claimable.claimed";
 export type WatcherNotificationType =
   | "engine.reconnecting"
   | "engine.reconnected";
@@ -45,7 +47,35 @@ export type AccountOptionsEvent = {
   raw: unknown;
 };
 
-export type NormalizedEvent = PaymentEvent | AccountOptionsEvent;
+export type ClaimableBalanceClaimant = {
+  destination: string;
+  predicate: unknown;
+};
+
+export type ClaimableCreatedEvent = {
+  type: ClaimableCreatedEventType;
+  sponsor: string;
+  balanceId: string;
+  claimants: ClaimableBalanceClaimant[];
+  asset: string;
+  amount: string;
+  timestamp: string;
+  raw: unknown;
+};
+
+export type ClaimableClaimedEvent = {
+  type: ClaimableClaimedEventType;
+  claimant: string;
+  balanceId: string;
+  timestamp: string;
+  raw: unknown;
+};
+
+export type NormalizedEvent =
+  | PaymentEvent
+  | AccountOptionsEvent
+  | ClaimableCreatedEvent
+  | ClaimableClaimedEvent;
 
 export type WatcherNotification = {
   type: WatcherNotificationType;

--- a/packages/pulse-core/test/pulse-core.test.ts
+++ b/packages/pulse-core/test/pulse-core.test.ts
@@ -440,4 +440,323 @@ describe("pulse-core EventEngine", () => {
       expect(otherHandler).not.toHaveBeenCalled();
     });
   });
+
+  describe("create_claimable_balance → claimable.created", () => {
+    function makeCreateClaimableRecord(
+      overrides: Record<string, unknown> = {}
+    ): Record<string, unknown> {
+      return {
+        type: "create_claimable_balance",
+        source_account: "GSPONSOR",
+        created_at: "2026-04-28T12:00:00.000Z",
+        amount: "100",
+        asset_type: "native",
+        balance_id: "00000000abc123",
+        claimants: [
+          { destination: "GCLAIMANT1", predicate: { unconditional: true } },
+        ],
+        ...overrides,
+      };
+    }
+
+    it("normalizes create_claimable_balance with native asset", () => {
+      const engine = new EventEngine({ network: "testnet" });
+      const normalize = (
+        engine as unknown as {
+          normalize(record: unknown): unknown;
+        }
+      ).normalize.bind(engine);
+
+      const result = normalize(makeCreateClaimableRecord());
+
+      expect(result).toEqual({
+        type: "claimable.created",
+        sponsor: "GSPONSOR",
+        balanceId: "00000000abc123",
+        claimants: [
+          { destination: "GCLAIMANT1", predicate: { unconditional: true } },
+        ],
+        asset: "XLM",
+        amount: "100",
+        timestamp: "2026-04-28T12:00:00.000Z",
+        raw: expect.any(Object),
+      });
+    });
+
+    it("normalizes create_claimable_balance with credit asset", () => {
+      const engine = new EventEngine({ network: "testnet" });
+      const normalize = (
+        engine as unknown as {
+          normalize(record: unknown): unknown;
+        }
+      ).normalize.bind(engine);
+
+      const result = normalize(
+        makeCreateClaimableRecord({
+          asset_type: "credit_alphanum4",
+          asset_code: "USDC",
+          asset_issuer: "GISSUER",
+        })
+      );
+
+      expect(result).toEqual(
+        expect.objectContaining({
+          type: "claimable.created",
+          asset: "USDC:GISSUER",
+        })
+      );
+    });
+
+    it("routes claimable.created to each claimant watcher (fan-out)", () => {
+      const engine = new EventEngine({ network: "testnet" });
+      const w1 = engine.subscribe("GCLAIMANT1");
+      const w2 = engine.subscribe("GCLAIMANT2");
+      const w3 = engine.subscribe("GCLAIMANT3");
+      const h1 = vi.fn();
+      const h2 = vi.fn();
+      const h3 = vi.fn();
+      w1.on("claimable.created", h1);
+      w2.on("claimable.created", h2);
+      // GCLAIMANT3 is subscribed but NOT in the claimants list
+      w3.on("claimable.created", h3);
+
+      engine.start();
+      latestStream().handlers.onmessage(
+        makeCreateClaimableRecord({
+          claimants: [
+            { destination: "GCLAIMANT1", predicate: { unconditional: true } },
+            { destination: "GCLAIMANT2", predicate: { unconditional: true } },
+          ],
+        })
+      );
+
+      expect(h1).toHaveBeenCalledOnce();
+      expect(h2).toHaveBeenCalledOnce();
+      expect(h3).not.toHaveBeenCalled();
+    });
+
+    it("routes claimable.created to the sponsor watcher", () => {
+      const engine = new EventEngine({ network: "testnet" });
+      const sponsorWatcher = engine.subscribe("GSPONSOR");
+      const handler = vi.fn();
+      sponsorWatcher.on("claimable.created", handler);
+
+      engine.start();
+      latestStream().handlers.onmessage(makeCreateClaimableRecord());
+
+      expect(handler).toHaveBeenCalledOnce();
+      expect(handler).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: "claimable.created",
+          sponsor: "GSPONSOR",
+        })
+      );
+    });
+
+    it("does not emit duplicate to sponsor when sponsor is also a claimant", () => {
+      const engine = new EventEngine({ network: "testnet" });
+      const watcher = engine.subscribe("GSPONSOR");
+      const handler = vi.fn();
+      watcher.on("claimable.created", handler);
+
+      engine.start();
+      latestStream().handlers.onmessage(
+        makeCreateClaimableRecord({
+          claimants: [
+            { destination: "GSPONSOR", predicate: { unconditional: true } },
+          ],
+        })
+      );
+
+      expect(handler).toHaveBeenCalledOnce();
+    });
+
+    it("does not route to unrelated watchers", () => {
+      const engine = new EventEngine({ network: "testnet" });
+      const unrelated = engine.subscribe("GUNRELATED");
+      const handler = vi.fn();
+      unrelated.on("claimable.created", handler);
+
+      engine.start();
+      latestStream().handlers.onmessage(makeCreateClaimableRecord());
+
+      expect(handler).not.toHaveBeenCalled();
+    });
+
+    it("drops record and warns when a required string field is missing", () => {
+      const engine = new EventEngine({ network: "testnet" });
+      const normalize = (
+        engine as unknown as {
+          normalize(record: unknown): unknown;
+        }
+      ).normalize.bind(engine);
+
+      const result = normalize(
+        makeCreateClaimableRecord({ balance_id: undefined })
+      );
+
+      expect(result).toBeNull();
+      expect(console.warn).toHaveBeenCalledWith(
+        '[pulse-core] normalize() dropping create_claimable_balance record: field "balance_id" is missing or not a non-empty string.',
+        expect.objectContaining({ record: expect.any(Object) })
+      );
+    });
+
+    it("drops record and warns when claimants array is missing", () => {
+      const engine = new EventEngine({ network: "testnet" });
+      const normalize = (
+        engine as unknown as {
+          normalize(record: unknown): unknown;
+        }
+      ).normalize.bind(engine);
+
+      const result = normalize(
+        makeCreateClaimableRecord({ claimants: undefined })
+      );
+
+      expect(result).toBeNull();
+      expect(console.warn).toHaveBeenCalledWith(
+        '[pulse-core] normalize() dropping create_claimable_balance record: field "claimants" is missing or invalid.',
+        expect.objectContaining({ record: expect.any(Object) })
+      );
+    });
+
+    it("drops record when claimants array is empty", () => {
+      const engine = new EventEngine({ network: "testnet" });
+      const normalize = (
+        engine as unknown as {
+          normalize(record: unknown): unknown;
+        }
+      ).normalize.bind(engine);
+
+      const result = normalize(makeCreateClaimableRecord({ claimants: [] }));
+
+      expect(result).toBeNull();
+    });
+
+    it("emits to the wildcard listener alongside claimable.created", () => {
+      const engine = new EventEngine({ network: "testnet" });
+      const watcher = engine.subscribe("GCLAIMANT1");
+      const specific = vi.fn();
+      const wildcard = vi.fn();
+      watcher.on("claimable.created", specific);
+      watcher.on("*", wildcard);
+
+      engine.start();
+      latestStream().handlers.onmessage(makeCreateClaimableRecord());
+
+      expect(specific).toHaveBeenCalledOnce();
+      expect(wildcard).toHaveBeenCalledOnce();
+      expect(wildcard).toHaveBeenCalledWith(
+        expect.objectContaining({ type: "claimable.created" })
+      );
+    });
+  });
+
+  describe("claim_claimable_balance → claimable.claimed", () => {
+    function makeClaimClaimableRecord(
+      overrides: Record<string, unknown> = {}
+    ): Record<string, unknown> {
+      return {
+        type: "claim_claimable_balance",
+        source_account: "GCLAIMANT",
+        created_at: "2026-04-28T13:00:00.000Z",
+        balance_id: "00000000abc123",
+        ...overrides,
+      };
+    }
+
+    it("normalizes claim_claimable_balance correctly", () => {
+      const engine = new EventEngine({ network: "testnet" });
+      const normalize = (
+        engine as unknown as {
+          normalize(record: unknown): unknown;
+        }
+      ).normalize.bind(engine);
+
+      const result = normalize(makeClaimClaimableRecord());
+
+      expect(result).toEqual({
+        type: "claimable.claimed",
+        claimant: "GCLAIMANT",
+        balanceId: "00000000abc123",
+        timestamp: "2026-04-28T13:00:00.000Z",
+        raw: expect.any(Object),
+      });
+    });
+
+    it("routes claimable.claimed to the claimant watcher", () => {
+      const engine = new EventEngine({ network: "testnet" });
+      const watcher = engine.subscribe("GCLAIMANT");
+      const handler = vi.fn();
+      watcher.on("claimable.claimed", handler);
+
+      engine.start();
+      latestStream().handlers.onmessage(makeClaimClaimableRecord());
+
+      expect(handler).toHaveBeenCalledOnce();
+      expect(handler).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: "claimable.claimed",
+          claimant: "GCLAIMANT",
+          balanceId: "00000000abc123",
+        })
+      );
+    });
+
+    it("does not route to unrelated watchers", () => {
+      const engine = new EventEngine({ network: "testnet" });
+      const unrelated = engine.subscribe("GUNRELATED");
+      const handler = vi.fn();
+      unrelated.on("claimable.claimed", handler);
+
+      engine.start();
+      latestStream().handlers.onmessage(makeClaimClaimableRecord());
+
+      expect(handler).not.toHaveBeenCalled();
+    });
+
+    it("drops record and warns when a required field is missing", () => {
+      const engine = new EventEngine({ network: "testnet" });
+      const normalize = (
+        engine as unknown as {
+          normalize(record: unknown): unknown;
+        }
+      ).normalize.bind(engine);
+
+      const missingFieldCases: Array<[string, Record<string, unknown>]> = [
+        ["source_account", makeClaimClaimableRecord({ source_account: undefined })],
+        ["created_at", makeClaimClaimableRecord({ created_at: undefined })],
+        ["balance_id", makeClaimClaimableRecord({ balance_id: undefined })],
+      ];
+
+      for (const [field, record] of missingFieldCases) {
+        vi.clearAllMocks();
+        const result = normalize(record);
+        expect(result).toBeNull();
+        expect(console.warn).toHaveBeenCalledWith(
+          `[pulse-core] normalize() dropping claim_claimable_balance record: field "${field}" is missing or not a non-empty string.`,
+          expect.objectContaining({ record: expect.any(Object) })
+        );
+      }
+    });
+
+    it("emits to the wildcard listener alongside claimable.claimed", () => {
+      const engine = new EventEngine({ network: "testnet" });
+      const watcher = engine.subscribe("GCLAIMANT");
+      const specific = vi.fn();
+      const wildcard = vi.fn();
+      watcher.on("claimable.claimed", specific);
+      watcher.on("*", wildcard);
+
+      engine.start();
+      latestStream().handlers.onmessage(makeClaimClaimableRecord());
+
+      expect(specific).toHaveBeenCalledOnce();
+      expect(wildcard).toHaveBeenCalledOnce();
+      expect(wildcard).toHaveBeenCalledWith(
+        expect.objectContaining({ type: "claimable.claimed" })
+      );
+    });
+  });
 });


### PR DESCRIPTION
Linked issue
Closes #79

What changed and why
This PR implements support for Claimable Balance events (CLAIMABLE_BALANCE_CREATED and CLAIMABLE_BALANCE_CLAIMED) within the core Event Engine. These changes allow the engine to normalize asset-locking actions and route them effectively to relevant participants.

The implementation features a multi-claimant fan-out strategy: when a claimable balance is created with multiple potential claimants, the engine generates routing for all parties involved. It includes deduplication logic (via a Set) to prevent redundant event delivery in cases where a sponsor is also a listed claimant.

Test plan
[x] Existing tests pass (pnpm test)

[x] New tests added for new behaviour

[x] Typechecks pass (pnpm -r typecheck)

[ ] Manually tested against testnet / mainnet (describe what you tested)

Added 17 new tests in pulse-core.test.ts covering normalization, routing, fan-out, and validation. Total test suite: 29 passing tests.

Breaking changes
None
