### PR TITLE
add jsdoc on all exported types

### DIFF
--- a/packages/pulse-core/src/EventEngine.ts
+++ b/packages/pulse-core/src/EventEngine.ts
@@ -47,6 +47,10 @@ export class EventEngine {
   private readonly reconnectConfig: Required<ReconnectConfig>;
   private isRunning = false;
 
+  /**
+   * Creates a new EventEngine instance.
+   * @param config - The core configuration for the engine.
+   */
   constructor(config: CoreConfig) {
     this.server = new Horizon.Server(HORIZON_URLS[config.network]);
     this.reconnectConfig = {
@@ -55,6 +59,12 @@ export class EventEngine {
     };
   }
 
+  /**
+   * Subscribes to events for a given Stellar address.
+   * Returns an existing Watcher if one already exists for the address.
+   * @param address - The Stellar address to watch.
+   * @returns The Watcher instance for the address.
+   */
   subscribe(address: string): Watcher {
     const existingWatcher = this.registry.get(address);
     if (existingWatcher) {
@@ -69,10 +79,18 @@ export class EventEngine {
     return watcher;
   }
 
+  /**
+   * Unsubscribes from events for a given Stellar address and stops its watcher.
+   * @param address - The Stellar address to stop watching.
+   */
   unsubscribe(address: string): void {
     this.registry.get(address)?.stop();
   }
 
+  /**
+   * Starts the SSE stream to listen for Stellar network events.
+   * No-op if the stream is already running.
+   */
   start(): void {
     if (this.isRunning || this.reconnectTimer) {
       console.warn(
@@ -84,6 +102,10 @@ export class EventEngine {
     this.openStream(false);
   }
 
+  /**
+   * Stops the SSE stream and all active watchers.
+   * Cleans up all resources and resets reconnection state.
+   */
   stop(): void {
     this.clearReconnectTimer();
     this.pendingReconnectSuccessAttempt = null;

--- a/packages/pulse-core/src/Watcher.ts
+++ b/packages/pulse-core/src/Watcher.ts
@@ -4,31 +4,66 @@ import type { NormalizedEvent, WatcherNotification } from "./index.js";
 
 type WatcherEvent = NormalizedEvent | WatcherNotification;
 
+/**
+ * Watches for Stellar network events related to a specific address.
+ * Extends EventEmitter to provide event-driven notifications.
+ *
+ * @example
+ * const watcher = engine.subscribe("G...");
+ * watcher.on("payment.received", (event) => {
+ *   console.log("Received payment:", event.amount, event.asset);
+ * });
+ */
 export class Watcher extends EventEmitter {
   readonly address: string;
   onStop?: (address: string) => void;
   private _stopped: boolean = false;
   private stopHandlers: Set<() => void> = new Set();
 
+  /**
+   * Creates a new Watcher for the given Stellar address.
+   * @param address - The Stellar address to watch.
+   */
   constructor(address: string) {
     super();
     this.address = address;
   }
 
+  /**
+   * Registers an event handler for the given event type.
+   * If the watcher is stopped, this is a no-op.
+   * @param eventType - The event type to listen to (e.g., "payment.received", "account.options_changed", "engine.reconnecting", "*").
+   * @param handler - The callback to invoke when the event occurs.
+   * @returns This watcher instance for chaining.
+   */
   on(eventType: string, handler: (event: WatcherEvent) => void): this {
     if (this._stopped) return this;
     return super.on(eventType, handler);
   }
 
+  /**
+   * Emits an event to all registered handlers.
+   * If the watcher is stopped, this returns false without emitting.
+   * @param eventType - The event type to emit.
+   * @param event - The event data.
+   * @returns True if the event had listeners, false otherwise.
+   */
   emit(eventType: string, event: WatcherEvent): boolean {
     if (this._stopped) return false;
     return super.emit(eventType, event);
   }
 
+  /** Whether this watcher has been stopped. */
   get stopped(): boolean {
     return this._stopped;
   }
 
+  /**
+   * Registers a callback to be invoked when the watcher is stopped.
+   * If the watcher is already stopped, the handler is invoked immediately.
+   * @param handler - The callback to invoke on stop.
+   * @returns A function to unregister the handler.
+   */
   addStopHandler(handler: () => void): () => void {
     if (this._stopped) {
       handler();
@@ -41,6 +76,11 @@ export class Watcher extends EventEmitter {
     };
   }
 
+  /**
+   * Stops the watcher and cleans up all resources.
+   * Removes all event listeners and invokes all stop handlers.
+   * No-op if already stopped.
+   */
   stop(): void {
     if (this._stopped) return;
     this._stopped = true;

--- a/packages/pulse-core/src/index.ts
+++ b/packages/pulse-core/src/index.ts
@@ -2,65 +2,135 @@ export { EventEngine } from "./EventEngine.js";
 export { Watcher } from "./Watcher.js";
 export { StrKey } from "@stellar/stellar-sdk";
 
+/** The Stellar network to connect to. */
 export type Network = "mainnet" | "testnet";
 
+/** Event types for payment-related events (received or sent). */
 export type PaymentEventType = "payment.received" | "payment.sent";
+/** Event type for account options changes. */
 export type AccountOptionsEventType = "account.options_changed";
+/** Notification types emitted by the EventEngine during reconnection. */
 export type WatcherNotificationType =
   | "engine.reconnecting"
   | "engine.reconnected";
 
+/**
+ * Represents a signer in Stellar account options.
+ */
 export type SetOptionsSigner = {
+  /** The public key of the signer. */
   key: string;
+  /** The weight of the signer for multi-signature transactions. */
   weight: number;
 };
 
+/**
+ * Changes to an account's options detected by the EventEngine.
+ */
 export type AccountOptionsChanges = {
+  /** Signer that was added to the account. */
   signer_added?: SetOptionsSigner;
+  /** Signer that was removed from the account. */
   signer_removed?: SetOptionsSigner;
+  /** Updated threshold values for the account. */
   thresholds?: {
+    /** Low threshold for the account. */
     low_threshold?: number;
+    /** Medium threshold for the account. */
     med_threshold?: number;
+    /** High threshold for the account. */
     high_threshold?: number;
+    /** Weight of the master key. */
     master_key_weight?: number;
   };
+  /** Updated home domain of the account. */
   home_domain?: string;
 };
 
+/**
+ * A normalized payment event from the Stellar network.
+ */
 export type PaymentEvent = {
+  /** The type of payment event (received or sent). */
   type: PaymentEventType;
+  /** The destination address of the payment. */
   to: string;
+  /** The source address of the payment. */
   from: string;
+  /** The amount of the payment as a string. */
   amount: string;
+  /** The asset being transferred (e.g., "XLM" or "ASSET:issuer"). */
   asset: string;
+  /** ISO 8601 timestamp of the payment. */
   timestamp: string;
+  /** The original raw record from the Horizon API. */
   raw: unknown;
 };
 
+/**
+ * A normalized account options change event from the Stellar network.
+ */
 export type AccountOptionsEvent = {
+  /** The type of account options event. */
   type: AccountOptionsEventType;
+  /** The Stellar account whose options changed. */
   source: string;
+  /** The specific changes made to the account options. */
   changes: AccountOptionsChanges;
+  /** ISO 8601 timestamp of the options change. */
   timestamp: string;
+  /** The original raw record from the Horizon API. */
   raw: unknown;
 };
 
+/**
+ * A union of all normalized events supported by pulse-core.
+ */
 export type NormalizedEvent = PaymentEvent | AccountOptionsEvent;
 
+/**
+ * A notification emitted by the EventEngine during reconnection attempts.
+ *
+ * @example
+ * watcher.on("engine.reconnecting", (notification) => {
+ *   console.log(`Reconnect attempt ${notification.attempt} in ${notification.delayMs}ms`);
+ * });
+ */
 export type WatcherNotification = {
+  /** The type of reconnection notification. */
   type: WatcherNotificationType;
+  /** The current reconnection attempt number. */
   attempt: number;
+  /** The delay in milliseconds before the next reconnection attempt (for "engine.reconnecting" events). */
   delayMs?: number;
+  /** ISO 8601 timestamp of the notification. */
   timestamp: string;
 };
 
+/**
+ * Configuration for automatic reconnection logic in EventEngine.
+ */
 export type ReconnectConfig = {
+  /** Initial delay in milliseconds before the first reconnection attempt. Defaults to 1000. */
   initialDelayMs?: number;
+  /** Maximum delay in milliseconds between reconnection attempts. Defaults to 30000. */
   maxDelayMs?: number;
+  /** Maximum number of reconnection attempts. Defaults to Infinity. */
   maxRetries?: number;
 };
 
+/**
+ * Core configuration for initializing the EventEngine.
+ *
+ * @example
+ * const config: CoreConfig = {
+ *   network: "testnet",
+ *   reconnect: { initialDelayMs: 2000, maxRetries: 5 }
+ * };
+ */
 export type CoreConfig = {
+  /** The Stellar network to connect to. */
   network: Network;
+  /** Optional reconnection configuration. */
   reconnect?: ReconnectConfig;
 };


### PR DESCRIPTION
Add a JSDoc block to each exported type and field.
Include @example blocks where useful.

closes #96 