### PR TITLE
fix(pulse-core): start() returns boolean and throws on strict duplica…

### DIFF
--- a/packages/pulse-core/src/EventEngine.ts
+++ b/packages/pulse-core/src/EventEngine.ts
@@ -1,5 +1,6 @@
 import { Horizon } from "@stellar/stellar-sdk";
 import { Watcher } from "./Watcher.js";
+import { EngineAlreadyStartedError } from "./errors.js";
 import type {
   AccountOptionsChanges,
   AccountOptionsEvent,
@@ -73,15 +74,19 @@ export class EventEngine {
     this.registry.get(address)?.stop();
   }
 
-  start(): void {
+  start(options?: { strict?: boolean }): boolean {
     if (this.isRunning || this.reconnectTimer) {
+      if (options?.strict) {
+        throw new EngineAlreadyStartedError();
+      }
       console.warn(
         "[pulse-core] EventEngine.start() called while the SSE stream is already active."
       );
-      return;
+      return false;
     }
 
     this.openStream(false);
+    return true;
   }
 
   stop(): void {

--- a/packages/pulse-core/src/errors.ts
+++ b/packages/pulse-core/src/errors.ts
@@ -1,0 +1,6 @@
+export class EngineAlreadyStartedError extends Error {
+  constructor() {
+    super("[pulse-core] EventEngine.start() called while the SSE stream is already active.");
+    this.name = "EngineAlreadyStartedError";
+  }
+}

--- a/packages/pulse-core/src/index.ts
+++ b/packages/pulse-core/src/index.ts
@@ -1,5 +1,6 @@
 export { EventEngine } from "./EventEngine.js";
 export { Watcher } from "./Watcher.js";
+export { EngineAlreadyStartedError } from "./errors.js";
 export { StrKey } from "@stellar/stellar-sdk";
 
 export type Network = "mainnet" | "testnet";

--- a/packages/pulse-core/test/pulse-core.test.ts
+++ b/packages/pulse-core/test/pulse-core.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { EngineAlreadyStartedError } from "../src/errors.js";
 
 type StreamHandlers = {
   onmessage: (record: unknown) => void;
@@ -185,13 +186,24 @@ describe("pulse-core EventEngine", () => {
   it("guards start() so duplicate live streams are not opened", () => {
     const engine = new EventEngine({ network: "testnet" });
 
-    engine.start();
-    engine.start();
+    const first = engine.start();
+    const second = engine.start();
 
+    expect(first).toBe(true);
+    expect(second).toBe(false);
     expect(streamInstances).toHaveLength(1);
     expect(console.warn).toHaveBeenCalledWith(
       "[pulse-core] EventEngine.start() called while the SSE stream is already active."
     );
+  });
+
+  it("start({ strict: true }) throws EngineAlreadyStartedError on duplicate start", () => {
+    const engine = new EventEngine({ network: "testnet" });
+
+    engine.start();
+
+    expect(() => engine.start({ strict: true })).toThrowError(EngineAlreadyStartedError);
+    expect(streamInstances).toHaveLength(1);
   });
 
   it("reconnects with exponential backoff and emits watcher notifications", () => {


### PR DESCRIPTION
pr closes #61 

## Linked issue

Closes #

## What changed and why

<!-- One paragraph. What does this PR do, and why is the change needed? -->

## Test plan

<!-- How did you verify this works? Check everything that applies. -->

- [ ] Existing tests pass (`pnpm test`)
- [ ] New tests added for new behaviour
- [ ] Typechecks pass (`pnpm -r typecheck`)
- [ ] Manually tested against testnet / mainnet (describe what you tested)

## Breaking changes

<!-- Does this change any public API? If yes, describe the migration path. -->

None / Yes (describe below)

## Notes for reviewers

<!-- Anything the reviewer should pay special attention to, or context that isn't obvious from the diff. -->
