### PR TITLE
fix: EventEngine.start() returns boolean and supports strict mode (#61)

### DIFF
--- a/packages/pulse-core/src/EventEngine.ts
+++ b/packages/pulse-core/src/EventEngine.ts
@@ -1,5 +1,8 @@
 import { Horizon } from "@stellar/stellar-sdk";
 import { Watcher } from "./Watcher.js";
+import {
+  EngineAlreadyStartedError,
+} from "./index.js";
 import type {
   AccountOptionsChanges,
   AccountOptionsEvent,
@@ -10,6 +13,7 @@ import type {
   PaymentEvent,
   PaymentEventType,
   ReconnectConfig,
+  StartOptions,
   WatcherNotification,
   WatcherNotificationType,
 } from "./index.js";
@@ -73,15 +77,19 @@ export class EventEngine {
     this.registry.get(address)?.stop();
   }
 
-  start(): void {
+  start(options?: StartOptions): boolean {
     if (this.isRunning || this.reconnectTimer) {
+      if (options?.strict) {
+        throw new EngineAlreadyStartedError();
+      }
       console.warn(
         "[pulse-core] EventEngine.start() called while the SSE stream is already active."
       );
-      return;
+      return false;
     }
 
     this.openStream(false);
+    return true;
   }
 
   stop(): void {

--- a/packages/pulse-core/src/index.ts
+++ b/packages/pulse-core/src/index.ts
@@ -2,6 +2,17 @@ export { EventEngine } from "./EventEngine.js";
 export { Watcher } from "./Watcher.js";
 export { StrKey } from "@stellar/stellar-sdk";
 
+export class EngineAlreadyStartedError extends Error {
+  constructor() {
+    super("[pulse-core] EventEngine.start() called while the SSE stream is already active.");
+    this.name = "EngineAlreadyStartedError";
+  }
+}
+
+export type StartOptions = {
+  strict?: boolean;
+};
+
 export type Network = "mainnet" | "testnet";
 
 export type PaymentEventType = "payment.received" | "payment.sent";

--- a/packages/pulse-core/test/pulse-core.test.ts
+++ b/packages/pulse-core/test/pulse-core.test.ts
@@ -38,7 +38,7 @@ vi.mock("@stellar/stellar-sdk", () => {
   };
 });
 
-import { EventEngine } from "../src/EventEngine.js";
+import { EventEngine, EngineAlreadyStartedError } from "../src/index.js";
 
 function latestStream(): MockStreamInstance {
   const stream = streamInstances.at(-1);
@@ -192,6 +192,22 @@ describe("pulse-core EventEngine", () => {
     expect(console.warn).toHaveBeenCalledWith(
       "[pulse-core] EventEngine.start() called while the SSE stream is already active."
     );
+  });
+
+  it("start() returns true on first call and false on duplicate", () => {
+    const engine = new EventEngine({ network: "testnet" });
+
+    expect(engine.start()).toBe(true);
+    expect(engine.start()).toBe(false);
+  });
+
+  it("start({ strict: true }) throws EngineAlreadyStartedError on duplicate", () => {
+    const engine = new EventEngine({ network: "testnet" });
+
+    engine.start();
+
+    expect(() => engine.start({ strict: true })).toThrow(EngineAlreadyStartedError);
+    expect(console.warn).not.toHaveBeenCalled();
   });
 
   it("reconnects with exponential backoff and emits watcher notifications", () => {


### PR DESCRIPTION
## Linked issue

Closes #

## What changed and why








pr closes #61 

## Test plan

<!-- How did you verify this works? Check everything that applies. -->

- [ ] Existing tests pass (`pnpm test`)
- [ ] New tests added for new behaviour
- [ ] Typechecks pass (`pnpm -r typecheck`)
- [ ] Manually tested against testnet / mainnet (describe what you tested)

## Breaking changes

<!-- Does this change any public API? If yes, describe the migration path. -->

None / Yes (describe below)

## Notes for reviewers

<!-- Anything the reviewer should pay special attention to, or context that isn't obvious from the diff. -->
