### PR TITLE
feat(pulse-core): normalize allow_trust and set_trust_line_flags into…

### DIFF
--- a/packages/pulse-core/src/EventEngine.ts
+++ b/packages/pulse-core/src/EventEngine.ts
@@ -10,12 +10,14 @@ import type {
   PaymentEvent,
   PaymentEventType,
   ReconnectConfig,
+  TrustlineEvent,
+  TrustlineEventType,
   WatcherNotification,
   WatcherNotificationType,
 } from "./index.js";
 
 type PendingPaymentEvent = Omit<PaymentEvent, "type"> & { type: "unknown" };
-type NormalizedEventOrPending = PendingPaymentEvent | AccountOptionsEvent;
+type NormalizedEventOrPending = PendingPaymentEvent | AccountOptionsEvent | TrustlineEvent;
 
 type StreamCallbacks = {
   onmessage: (record: unknown) => void;
@@ -258,6 +260,14 @@ export class EventEngine {
       return this.normalizeSetOptions(r, record);
     }
 
+    if (r.type === "allow_trust") {
+      return this.normalizeAllowTrust(r, record);
+    }
+
+    if (r.type === "set_trust_line_flags") {
+      return this.normalizeSetTrustLineFlags(r, record);
+    }
+
     return null;
   }
 
@@ -305,6 +315,78 @@ export class EventEngine {
     };
   }
 
+  private normalizeAllowTrust(
+    r: Record<string, unknown>,
+    raw: unknown
+  ): TrustlineEvent | null {
+    const trustor = r.trustor;
+    const trustee = r.trustee ?? r.source_account;
+    const authorize = r.authorize;
+
+    if (typeof trustor !== "string" || trustor === "") return null;
+    if (typeof trustee !== "string" || trustee === "") return null;
+    if (typeof authorize !== "boolean") return null;
+
+    const asset = this.buildAsset(r);
+    const type: TrustlineEventType = authorize ? "trustline.authorized" : "trustline.deauthorized";
+
+    return {
+      type,
+      trustor,
+      issuer: trustee as string,
+      asset,
+      timestamp: r.created_at as string,
+      operation: "allow_trust",
+      raw,
+    };
+  }
+
+  private normalizeSetTrustLineFlags(
+    r: Record<string, unknown>,
+    raw: unknown
+  ): TrustlineEvent | null {
+    const trustor = r.trustor;
+    const source = r.source_account;
+
+    if (typeof trustor !== "string" || trustor === "") return null;
+    if (typeof source !== "string" || source === "") return null;
+
+    const asset = this.buildAsset(r);
+    const type = this.resolveTrustlineType(r);
+    if (type === null) return null;
+
+    return {
+      type,
+      trustor,
+      issuer: source as string,
+      asset,
+      timestamp: r.created_at as string,
+      operation: "set_trust_line_flags",
+      raw,
+    };
+  }
+
+  private buildAsset(r: Record<string, unknown>): string {
+    if (r.asset_type === "native") return "XLM";
+    const code = r.asset_code ?? "";
+    const issuer = r.asset_issuer ?? "";
+    return `${code}:${issuer}`;
+  }
+
+  private resolveTrustlineType(r: Record<string, unknown>): TrustlineEventType | null {
+    const setFlagsS = r.set_flags_s as string[] | undefined;
+    const clearFlagsS = r.clear_flags_s as string[] | undefined;
+
+    const isSettingAuth = setFlagsS?.includes("authorized");
+    const isClearingAuth = clearFlagsS?.includes("authorized");
+
+    if (isSettingAuth && !isClearingAuth) return "trustline.authorized";
+    if (isClearingAuth && !isSettingAuth) return "trustline.deauthorized";
+    if (isSettingAuth && isClearingAuth) return null;
+
+    return null;
+  }
+
   private route(event: NormalizedEventOrPending): void {
     if (event.type === "account.options_changed") {
       const watcher = this.registry.get(event.source);
@@ -315,22 +397,39 @@ export class EventEngine {
       return;
     }
 
-    const toWatcher = this.registry.get(event.to);
+    if (event.type === "trustline.authorized" || event.type === "trustline.deauthorized") {
+      const issuerWatcher = this.registry.get(event.issuer);
+      if (issuerWatcher) {
+        issuerWatcher.emit(event.type, event);
+        issuerWatcher.emit("*", event);
+      }
+
+      const trustorWatcher = this.registry.get(event.trustor);
+      if (trustorWatcher) {
+        trustorWatcher.emit(event.type, event);
+        trustorWatcher.emit("*", event);
+      }
+      return;
+    }
+
+    const payment = event as PendingPaymentEvent;
+
+    const toWatcher = this.registry.get(payment.to);
     if (toWatcher) {
       toWatcher.emit(
         "payment.received",
-        this.withResolvedType(event, "payment.received")
+        this.withResolvedType(payment, "payment.received")
       );
-      toWatcher.emit("*", this.withResolvedType(event, "payment.received"));
+      toWatcher.emit("*", this.withResolvedType(payment, "payment.received"));
     }
 
-    const fromWatcher = this.registry.get(event.from);
+    const fromWatcher = this.registry.get(payment.from);
     if (fromWatcher) {
       fromWatcher.emit(
         "payment.sent",
-        this.withResolvedType(event, "payment.sent")
+        this.withResolvedType(payment, "payment.sent")
       );
-      fromWatcher.emit("*", this.withResolvedType(event, "payment.sent"));
+      fromWatcher.emit("*", this.withResolvedType(payment, "payment.sent"));
     }
   }
 

--- a/packages/pulse-core/src/index.ts
+++ b/packages/pulse-core/src/index.ts
@@ -9,6 +9,8 @@ export type Network = "mainnet" | "testnet";
 export type PaymentEventType = "payment.received" | "payment.sent";
 /** Event type for account options changes. */
 export type AccountOptionsEventType = "account.options_changed";
+/** Event types for trustline authorization changes. */
+export type TrustlineEventType = "trustline.authorized" | "trustline.deauthorized";
 /** Notification types emitted by the EventEngine during reconnection. */
 export type WatcherNotificationType =
   | "engine.reconnecting"
@@ -86,7 +88,27 @@ export type AccountOptionsEvent = {
 /**
  * A union of all normalized events supported by pulse-core.
  */
-export type NormalizedEvent = PaymentEvent | AccountOptionsEvent;
+export type NormalizedEvent = PaymentEvent | AccountOptionsEvent | TrustlineEvent;
+
+/**
+ * A normalized trustline authorization change event from the Stellar network.
+ */
+export type TrustlineEvent = {
+  /** The type of trustline event (authorized or deauthorized). */
+  type: TrustlineEventType;
+  /** The Stellar account that holds the trustline. */
+  trustor: string;
+  /** The asset issuer (source of the operation). */
+  issuer: string;
+  /** The asset being authorized (e.g., "XLM" or "ASSET:issuer"). */
+  asset: string;
+  /** ISO 8601 timestamp of the authorization change. */
+  timestamp: string;
+  /** The original Horizon operation type ("allow_trust" or "set_trust_line_flags"). */
+  operation: string;
+  /** The original raw record from the Horizon API. */
+  raw: unknown;
+};
 
 /**
  * A notification emitted by the EventEngine during reconnection attempts.

--- a/packages/pulse-core/test/pulse-core.test.ts
+++ b/packages/pulse-core/test/pulse-core.test.ts
@@ -445,4 +445,248 @@ describe("pulse-core EventEngine", () => {
       expect(otherHandler).not.toHaveBeenCalled();
     });
   });
+
+  describe("allow_trust → trustline.authorized / trustline.deauthorized", () => {
+    function makeAllowTrustRecord(
+      overrides: Record<string, unknown>
+    ): Record<string, unknown> {
+      return {
+        type: "allow_trust",
+        source_account: "GISSUER",
+        trustee: "GISSUER",
+        trustor: "GTRUSTOR",
+        asset_type: "credit_alphanum4",
+        asset_code: "USDC",
+        asset_issuer: "GISSUER",
+        created_at: "2026-04-24T10:00:00.000Z",
+        ...overrides,
+      };
+    }
+
+    it("emits trustline.authorized when authorize is true", () => {
+      const engine = new EventEngine({ network: "testnet" });
+      const issuerWatcher = engine.subscribe("GISSUER");
+      const trustorWatcher = engine.subscribe("GTRUSTOR");
+      const issuerHandler = vi.fn();
+      const trustorHandler = vi.fn();
+      issuerWatcher.on("trustline.authorized", issuerHandler);
+      trustorWatcher.on("trustline.authorized", trustorHandler);
+
+      engine.start();
+      latestStream().handlers.onmessage(
+        makeAllowTrustRecord({ authorize: true })
+      );
+
+      expect(issuerHandler).toHaveBeenCalledOnce();
+      expect(trustorHandler).toHaveBeenCalledOnce();
+      expect(issuerHandler).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: "trustline.authorized",
+          trustor: "GTRUSTOR",
+          issuer: "GISSUER",
+          asset: "USDC:GISSUER",
+          operation: "allow_trust",
+          timestamp: "2026-04-24T10:00:00.000Z",
+        })
+      );
+    });
+
+    it("emits trustline.deauthorized when authorize is false", () => {
+      const engine = new EventEngine({ network: "testnet" });
+      const issuerWatcher = engine.subscribe("GISSUER");
+      const trustorWatcher = engine.subscribe("GTRUSTOR");
+      const issuerHandler = vi.fn();
+      const trustorHandler = vi.fn();
+      issuerWatcher.on("trustline.deauthorized", issuerHandler);
+      trustorWatcher.on("trustline.deauthorized", trustorHandler);
+
+      engine.start();
+      latestStream().handlers.onmessage(
+        makeAllowTrustRecord({ authorize: false })
+      );
+
+      expect(issuerHandler).toHaveBeenCalledOnce();
+      expect(trustorHandler).toHaveBeenCalledOnce();
+      expect(issuerHandler).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: "trustline.deauthorized",
+          trustor: "GTRUSTOR",
+          issuer: "GISSUER",
+          asset: "USDC:GISSUER",
+          operation: "allow_trust",
+        })
+      );
+    });
+
+    it("does not emit to unrelated watchers", () => {
+      const engine = new EventEngine({ network: "testnet" });
+      engine.subscribe("GISSUER");
+      const otherWatcher = engine.subscribe("GOTHER");
+      const otherHandler = vi.fn();
+      otherWatcher.on("trustline.authorized", otherHandler);
+
+      engine.start();
+      latestStream().handlers.onmessage(
+        makeAllowTrustRecord({ authorize: true })
+      );
+
+      expect(otherHandler).not.toHaveBeenCalled();
+    });
+
+    it("handles native asset correctly", () => {
+      const engine = new EventEngine({ network: "testnet" });
+      const issuerWatcher = engine.subscribe("GISSUER");
+      const handler = vi.fn();
+      issuerWatcher.on("trustline.authorized", handler);
+
+      engine.start();
+      latestStream().handlers.onmessage(
+        makeAllowTrustRecord({
+          asset_type: "native",
+          asset_code: undefined,
+          asset_issuer: undefined,
+          authorize: true,
+        })
+      );
+
+      expect(handler).toHaveBeenCalledOnce();
+      expect(handler).toHaveBeenCalledWith(
+        expect.objectContaining({
+          asset: "XLM",
+        })
+      );
+    });
+  });
+
+  describe("set_trust_line_flags → trustline.authorized / trustline.deauthorized", () => {
+    function makeSetTrustLineFlagsRecord(
+      overrides: Record<string, unknown>
+    ): Record<string, unknown> {
+      return {
+        type: "set_trust_line_flags",
+        source_account: "GISSUER",
+        trustor: "GTRUSTOR",
+        asset_type: "credit_alphanum4",
+        asset_code: "USDC",
+        asset_issuer: "GISSUER",
+        set_flags_s: [],
+        clear_flags_s: [],
+        created_at: "2026-04-24T10:00:00.000Z",
+        ...overrides,
+      };
+    }
+
+    it("emits trustline.authorized when authorized flag is set", () => {
+      const engine = new EventEngine({ network: "testnet" });
+      const issuerWatcher = engine.subscribe("GISSUER");
+      const trustorWatcher = engine.subscribe("GTRUSTOR");
+      const issuerHandler = vi.fn();
+      const trustorHandler = vi.fn();
+      issuerWatcher.on("trustline.authorized", issuerHandler);
+      trustorWatcher.on("trustline.authorized", trustorHandler);
+
+      engine.start();
+      latestStream().handlers.onmessage(
+        makeSetTrustLineFlagsRecord({
+          set_flags_s: ["authorized"],
+          clear_flags_s: [],
+        })
+      );
+
+      expect(issuerHandler).toHaveBeenCalledOnce();
+      expect(trustorHandler).toHaveBeenCalledOnce();
+      expect(issuerHandler).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: "trustline.authorized",
+          trustor: "GTRUSTOR",
+          issuer: "GISSUER",
+          asset: "USDC:GISSUER",
+          operation: "set_trust_line_flags",
+          timestamp: "2026-04-24T10:00:00.000Z",
+        })
+      );
+    });
+
+    it("emits trustline.deauthorized when authorized flag is cleared", () => {
+      const engine = new EventEngine({ network: "testnet" });
+      const issuerWatcher = engine.subscribe("GISSUER");
+      const trustorWatcher = engine.subscribe("GTRUSTOR");
+      const issuerHandler = vi.fn();
+      const trustorHandler = vi.fn();
+      issuerWatcher.on("trustline.deauthorized", issuerHandler);
+      trustorWatcher.on("trustline.deauthorized", trustorHandler);
+
+      engine.start();
+      latestStream().handlers.onmessage(
+        makeSetTrustLineFlagsRecord({
+          set_flags_s: [],
+          clear_flags_s: ["authorized"],
+        })
+      );
+
+      expect(issuerHandler).toHaveBeenCalledOnce();
+      expect(trustorHandler).toHaveBeenCalledOnce();
+      expect(issuerHandler).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: "trustline.deauthorized",
+          trustor: "GTRUSTOR",
+          issuer: "GISSUER",
+          asset: "USDC:GISSUER",
+          operation: "set_trust_line_flags",
+        })
+      );
+    });
+
+    it("does not emit when authorized flag is both set and cleared", () => {
+      const engine = new EventEngine({ network: "testnet" });
+      const issuerWatcher = engine.subscribe("GISSUER");
+      const handler = vi.fn();
+      issuerWatcher.on("trustline.authorized", handler);
+
+      engine.start();
+      latestStream().handlers.onmessage(
+        makeSetTrustLineFlagsRecord({
+          set_flags_s: ["authorized"],
+          clear_flags_s: ["authorized"],
+        })
+      );
+
+      expect(handler).not.toHaveBeenCalled();
+    });
+
+    it("does not emit when no authorization flag changes", () => {
+      const engine = new EventEngine({ network: "testnet" });
+      const issuerWatcher = engine.subscribe("GISSUER");
+      const handler = vi.fn();
+      issuerWatcher.on("trustline.authorized", handler);
+
+      engine.start();
+      latestStream().handlers.onmessage(
+        makeSetTrustLineFlagsRecord({
+          set_flags_s: ["clawback_enabled"],
+          clear_flags_s: [],
+        })
+      );
+
+      expect(handler).not.toHaveBeenCalled();
+    });
+
+    it("does not route to unrelated watchers", () => {
+      const engine = new EventEngine({ network: "testnet" });
+      engine.subscribe("GISSUER");
+      const otherWatcher = engine.subscribe("GOTHER");
+      const otherHandler = vi.fn();
+      otherWatcher.on("trustline.authorized", otherHandler);
+
+      engine.start();
+      latestStream().handlers.onmessage(
+        makeSetTrustLineFlagsRecord({
+          set_flags_s: ["authorized"],
+          clear_flags_s: [],
+        })
+      );
+
+      expect(otherHandler).not.toHaveBeenCalled();
+    });
+  });
 });


### PR DESCRIPTION
… trustline events

Both legacy allow_trust and modern set_trust_line_flags operations now emit consistent trustline.authorized and trustline.deauthorized events. Events are routed to both the issuer (source) and trustor watchers.

Closes #76 


