### PR TITLE
Add Cloudflare Worker webhook verification support

### DIFF
--- a/packages/pulse-webhooks/README.md
+++ b/packages/pulse-webhooks/README.md
@@ -47,7 +47,12 @@ app.post("/hooks/stellar", express.text({ type: "*/*" }), (req, res) => {
   const timestamp = req.header("x-orbital-timestamp");
   if (!signature || !timestamp) return res.sendStatus(400);
 
-  const event = verifyWebhook(req.body, signature, process.env.WEBHOOK_SECRET!, timestamp);
+  const event = verifyWebhook(
+    req.body,
+    signature,
+    process.env.WEBHOOK_SECRET!,
+    timestamp,
+  );
   if (!event) return res.sendStatus(401);
 
   // event is a verified NormalizedEvent
@@ -56,25 +61,79 @@ app.post("/hooks/stellar", express.text({ type: "*/*" }), (req, res) => {
 });
 ```
 
+## Verifying in Cloudflare Workers
+
+Cloudflare Workers don't have Node.js crypto — they use Web Crypto API. Use `verifyWebhookEdge` for edge runtime compatibility:
+
+```js
+import { verifyWebhookEdge } from "@orbital/pulse-webhooks";
+
+export default {
+  async fetch(request, env, ctx) {
+    if (request.method !== "POST") {
+      return new Response("Method not allowed", { status: 405 });
+    }
+
+    const signature = request.headers.get("x-orbital-signature");
+    const timestamp = request.headers.get("x-orbital-timestamp");
+
+    if (!signature || !timestamp) {
+      return new Response("Missing headers", { status: 400 });
+    }
+
+    const payload = await request.text();
+    const event = await verifyWebhookEdge(
+      payload,
+      signature,
+      env.WEBHOOK_SECRET,
+      timestamp,
+    );
+
+    if (!event) {
+      return new Response("Invalid signature", { status: 401 });
+    }
+
+    // event is a verified NormalizedEvent
+    console.log(`Verified payment: ${event.amount} ${event.asset}`);
+
+    // Process the webhook...
+    return new Response("Webhook processed", { status: 200 });
+  },
+};
+```
+
+**Key differences for Workers:**
+
+- Use `verifyWebhookEdge` instead of `verifyWebhook`
+- Function is async (returns Promise)
+- Uses Web Crypto API instead of Node.js crypto
+- Works in Cloudflare Workers, Deno, and browsers
+
 ## API
 
 ### `new WebhookDelivery(watcher, config)`
 
 Attaches a delivery driver to a `Watcher`. Every event the watcher emits is delivered to each URL in `config.url`.
 
-| Field | Type | Default | Description |
-|---|---|---|---|
-| `config.url` | `string \| string[]` | — | One destination endpoint or a fan-out list of endpoints. Must be HTTPS in production. |
-| `config.secret` | `string` | — | Shared secret used to sign payloads |
-| `config.retries` | `number` | `3` | Number of retry attempts before emitting `webhook.failed` |
-| `config.deliveryTimeoutMs` | `number` | `10_000` | Abort threshold for each HTTP attempt |
-| `config.allowPrivateNetworks` | `boolean` | `false` | If true, bypass SSRF checks for local/private IP ranges |
+| Field                         | Type                 | Default  | Description                                                                           |
+| ----------------------------- | -------------------- | -------- | ------------------------------------------------------------------------------------- |
+| `config.url`                  | `string \| string[]` | —        | One destination endpoint or a fan-out list of endpoints. Must be HTTPS in production. |
+| `config.secret`               | `string`             | —        | Shared secret used to sign payloads                                                   |
+| `config.retries`              | `number`             | `3`      | Number of retry attempts before emitting `webhook.failed`                             |
+| `config.deliveryTimeoutMs`    | `number`             | `10_000` | Abort threshold for each HTTP attempt                                                 |
+| `config.allowPrivateNetworks` | `boolean`            | `false`  | If true, bypass SSRF checks for local/private IP ranges                               |
 
 ### `verifyWebhook(payload, signature, secret, timestamp)` → `NormalizedEvent | null`
 
 Verifies that `payload` was signed with `secret` using `timestamp + "." + payload`. Returns the parsed event on success, `null` on any failure (bad signature, malformed JSON, invalid timestamp, length mismatch).
 
 Uses `crypto.timingSafeEqual` under the hood — do not roll your own comparison.
+
+### `verifyWebhookEdge(payload, signature, secret, timestamp)` → `Promise<NormalizedEvent | null>`
+
+Edge-compatible version of `verifyWebhook` using Web Crypto API. Works in Cloudflare Workers, Deno, and browsers. Returns a Promise that resolves to the parsed event on success, `null` on any failure.
+
+Uses constant-time comparison and Web Crypto for HMAC-SHA256 verification.
 
 ## Delivery contract
 

--- a/packages/pulse-webhooks/src/edge.ts
+++ b/packages/pulse-webhooks/src/edge.ts
@@ -1,0 +1,66 @@
+import type { NormalizedEvent } from "@orbital/pulse-core";
+
+/**
+ * Verifies webhook signatures using Web Crypto API (compatible with Cloudflare Workers, Deno, and browsers)
+ *
+ * @param payload - The raw request body
+ * @param signature - The x-orbital-signature header value
+ * @param secret - Your webhook secret
+ * @param timestamp - The x-orbital-timestamp header value
+ * @returns Parsed NormalizedEvent if verification succeeds, null otherwise
+ */
+export async function verifyWebhookEdge(
+  payload: string,
+  signature: string,
+  secret: string,
+  timestamp: string,
+): Promise<NormalizedEvent | null> {
+  // Validate timestamp format
+  if (!/^\d+$/.test(timestamp)) return null;
+
+  try {
+    // Import the secret key
+    const keyData = new TextEncoder().encode(secret);
+    const key = await crypto.subtle.importKey(
+      "raw",
+      keyData,
+      { name: "HMAC", hash: "SHA-256" },
+      false,
+      ["sign"],
+    );
+
+    // Create the expected signature
+    const signedPayload = `${timestamp}.${payload}`;
+    const expectedBuffer = await crypto.subtle.sign(
+      "HMAC",
+      key,
+      new TextEncoder().encode(signedPayload),
+    );
+
+    // Convert expected signature to hex
+    const expectedHex = Array.from(new Uint8Array(expectedBuffer))
+      .map((b) => b.toString(16).padStart(2, "0"))
+      .join("");
+
+    // Convert received signature to bytes
+    const signatureBytes = new Uint8Array(
+      signature.match(/.{1,2}/g)?.map((byte) => parseInt(byte, 16)) || [],
+    );
+
+    // Constant-time comparison
+    const expectedBytes = new Uint8Array(expectedBuffer);
+    if (expectedBytes.length !== signatureBytes.length) return null;
+
+    let result = 0;
+    for (let i = 0; i < expectedBytes.length; i++) {
+      result |= (expectedBytes[i] || 0) ^ (signatureBytes[i] || 0);
+    }
+
+    if (result !== 0) return null;
+
+    // Parse the payload
+    return JSON.parse(payload) as NormalizedEvent;
+  } catch {
+    return null;
+  }
+}

--- a/packages/pulse-webhooks/src/index.ts
+++ b/packages/pulse-webhooks/src/index.ts
@@ -2,6 +2,7 @@ import type { NormalizedEvent, Watcher } from "@orbital/pulse-core";
 import { createHmac, timingSafeEqual } from "crypto";
 
 import type { WebhookConfig } from "./types.js";
+export { verifyWebhookEdge } from "./edge.js";
 export type { WebhookConfig } from "./types.js";
 
 type ResolvedWebhookConfig = Omit<Required<WebhookConfig>, "url"> & {
@@ -38,10 +39,10 @@ export class WebhookDelivery {
     });
   }
 
-  private async deliverToUrl (
+  private async deliverToUrl(
     event: NormalizedEvent,
     url: string,
-    attempt = 1
+    attempt = 1,
   ): Promise<void> {
     if (this.watcher.stopped) return;
 
@@ -94,14 +95,14 @@ export class WebhookDelivery {
     }
   }
 
-  private clearRetryTimers (): void {
+  private clearRetryTimers(): void {
     for (const retryTimer of this.retryTimers) {
       clearTimeout(retryTimer);
     }
     this.retryTimers.clear();
   }
 
-  private getErrorMessage (err: unknown): string {
+  private getErrorMessage(err: unknown): string {
     if (err instanceof Error && err.name === "AbortError") {
       return `Delivery timed out after ${this.config.deliveryTimeoutMs}ms`;
     }
@@ -109,7 +110,7 @@ export class WebhookDelivery {
     return err instanceof Error ? err.message : "Unknown error";
   }
 
-  private sign (payload: string, timestamp: string): string {
+  private sign(payload: string, timestamp: string): string {
     const signedPayload = `${timestamp}.${payload}`;
 
     return createHmac("sha256", this.config.secret)
@@ -120,11 +121,11 @@ export class WebhookDelivery {
 
 // --- verifyWebhook ---
 
-export function verifyWebhook (
+export function verifyWebhook(
   payload: string,
   signature: string,
   secret: string,
-  timestamp: string
+  timestamp: string,
 ): NormalizedEvent | null {
   if (!/^\d+$/.test(timestamp)) return null;
 

--- a/packages/pulse-webhooks/test/pulse-webhooks.test.ts
+++ b/packages/pulse-webhooks/test/pulse-webhooks.test.ts
@@ -1,195 +1,284 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createHmac } from "crypto";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { Watcher } from "@orbital/pulse-core";
-import { verifyWebhook, WebhookDelivery } from "../src/index.js";
+import {
+  verifyWebhook,
+  verifyWebhookEdge,
+  WebhookDelivery,
+} from "../src/index.js";
 
 const deliveryEvent = {
-    type: "payment.received",
-    to: "GDEST",
-    from: "GSRC",
-    amount: "10",
-    asset: "XLM",
-    timestamp: "2026-04-26T12:00:00.000Z",
-    raw: { id: "evt_1" },
+  type: "payment.received",
+  to: "GDEST",
+  from: "GSRC",
+  amount: "10",
+  asset: "XLM",
+  timestamp: "2026-04-26T12:00:00.000Z",
+  raw: { id: "evt_1" },
 } as const;
 
-async function flushAsyncWork (): Promise<void> {
-    await Promise.resolve();
-    await Promise.resolve();
+async function flushAsyncWork(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
 }
 
-function signWebhookPayload (secret: string, payload: string, timestamp: string): string {
-    return createHmac("sha256", secret)
-        .update(`${timestamp}.${payload}`)
-        .digest("hex");
+function signWebhookPayload(
+  secret: string,
+  payload: string,
+  timestamp: string,
+): string {
+  return createHmac("sha256", secret)
+    .update(`${timestamp}.${payload}`)
+    .digest("hex");
 }
 
 describe("pulse-webhooks WebhookDelivery", () => {
-    beforeEach(() => {
-        vi.useFakeTimers();
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("delivers each event to every configured URL", () => {
+    vi.setSystemTime(new Date("2026-04-27T00:00:00.000Z"));
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200 });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const secret = "top-secret";
+    const payload = JSON.stringify(deliveryEvent);
+    const timestamp = Date.now().toString();
+    const expectedSignature = signWebhookPayload(secret, payload, timestamp);
+
+    const watcher = new Watcher("GABC");
+    new WebhookDelivery(watcher, {
+      url: [
+        "https://prod.example.com/webhooks/stellar",
+        "https://staging.example.com/webhooks/stellar",
+        "https://audit.example.com/webhooks/stellar",
+      ],
+      secret,
     });
 
-    afterEach(() => {
-        vi.useRealTimers();
-        vi.unstubAllGlobals();
-        vi.restoreAllMocks();
+    watcher.emit("*", deliveryEvent);
+
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      1,
+      "https://prod.example.com/webhooks/stellar",
+      expect.objectContaining({
+        method: "POST",
+        body: payload,
+        headers: expect.objectContaining({
+          "Content-Type": "application/json",
+          "x-orbital-attempt": "1",
+          "x-orbital-timestamp": timestamp,
+          "x-orbital-signature": expectedSignature,
+        }),
+      }),
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      "https://staging.example.com/webhooks/stellar",
+      expect.objectContaining({
+        method: "POST",
+        body: payload,
+      }),
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      3,
+      "https://audit.example.com/webhooks/stellar",
+      expect.objectContaining({
+        method: "POST",
+        body: payload,
+      }),
+    );
+  });
+
+  it("keeps delivering to other URLs when one URL fails", async () => {
+    const failedUrl = "https://prod.example.com/webhooks/stellar";
+    const successfulUrl = "https://audit.example.com/webhooks/stellar";
+    const fetchMock = vi.fn((url: string) => {
+      if (url === failedUrl) {
+        return Promise.resolve({ ok: false, status: 500 });
+      }
+
+      return Promise.resolve({ ok: true, status: 200 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const watcher = new Watcher("GABC");
+    const failedHandler = vi.fn();
+    watcher.on("webhook.failed", failedHandler);
+
+    new WebhookDelivery(watcher, {
+      url: [failedUrl, successfulUrl],
+      secret: "top-secret",
+      retries: 1,
     });
 
-    it("delivers each event to every configured URL", () => {
-        vi.setSystemTime(new Date("2026-04-27T00:00:00.000Z"));
-        const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200 });
-        vi.stubGlobal("fetch", fetchMock);
+    watcher.emit("*", deliveryEvent);
+    await flushAsyncWork();
 
-        const secret = "top-secret";
-        const payload = JSON.stringify(deliveryEvent);
-        const timestamp = Date.now().toString();
-        const expectedSignature = signWebhookPayload(secret, payload, timestamp);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock).toHaveBeenCalledWith(
+      failedUrl,
+      expect.objectContaining({ method: "POST" }),
+    );
+    expect(fetchMock).toHaveBeenCalledWith(
+      successfulUrl,
+      expect.objectContaining({ method: "POST" }),
+    );
+    expect(failedHandler).toHaveBeenCalledTimes(1);
+    expect(failedHandler).toHaveBeenCalledWith(
+      expect.objectContaining({
+        raw: expect.objectContaining({
+          url: failedUrl,
+          attempts: 1,
+          originalEvent: deliveryEvent,
+        }),
+      }),
+    );
+  });
 
-        const watcher = new Watcher("GABC");
-        new WebhookDelivery(watcher, {
-            url: [
-                "https://prod.example.com/webhooks/stellar",
-                "https://staging.example.com/webhooks/stellar",
-                "https://audit.example.com/webhooks/stellar",
-            ],
-            secret,
-        });
+  it("cancels pending retries for all URLs when the watcher stops", async () => {
+    const fetchMock = vi.fn().mockRejectedValue(new Error("network down"));
+    vi.stubGlobal("fetch", fetchMock);
 
-        watcher.emit("*", deliveryEvent);
-
-        expect(fetchMock).toHaveBeenCalledTimes(3);
-        expect(fetchMock).toHaveBeenNthCalledWith(
-            1,
-            "https://prod.example.com/webhooks/stellar",
-            expect.objectContaining({
-                method: "POST",
-                body: payload,
-                headers: expect.objectContaining({
-                    "Content-Type": "application/json",
-                    "x-orbital-attempt": "1",
-                    "x-orbital-timestamp": timestamp,
-                    "x-orbital-signature": expectedSignature,
-                }),
-            })
-        );
-        expect(fetchMock).toHaveBeenNthCalledWith(
-            2,
-            "https://staging.example.com/webhooks/stellar",
-            expect.objectContaining({
-                method: "POST",
-                body: payload,
-            })
-        );
-        expect(fetchMock).toHaveBeenNthCalledWith(
-            3,
-            "https://audit.example.com/webhooks/stellar",
-            expect.objectContaining({
-                method: "POST",
-                body: payload,
-            })
-        );
+    const watcher = new Watcher("GABC");
+    new WebhookDelivery(watcher, {
+      url: [
+        "https://prod.example.com/webhooks/stellar",
+        "https://staging.example.com/webhooks/stellar",
+      ],
+      secret: "top-secret",
+      retries: 3,
     });
 
-    it("keeps delivering to other URLs when one URL fails", async () => {
-        const failedUrl = "https://prod.example.com/webhooks/stellar";
-        const successfulUrl = "https://audit.example.com/webhooks/stellar";
-        const fetchMock = vi.fn((url: string) => {
-            if (url === failedUrl) {
-                return Promise.resolve({ ok: false, status: 500 });
-            }
+    watcher.emit("*", deliveryEvent);
+    await flushAsyncWork();
 
-            return Promise.resolve({ ok: true, status: 200 });
-        });
-        vi.stubGlobal("fetch", fetchMock);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
 
-        const watcher = new Watcher("GABC");
-        const failedHandler = vi.fn();
-        watcher.on("webhook.failed", failedHandler);
+    watcher.stop();
+    vi.advanceTimersByTime(10_000);
+    await flushAsyncWork();
 
-        new WebhookDelivery(watcher, {
-            url: [failedUrl, successfulUrl],
-            secret: "top-secret",
-            retries: 1,
-        });
-
-        watcher.emit("*", deliveryEvent);
-        await flushAsyncWork();
-
-        expect(fetchMock).toHaveBeenCalledTimes(2);
-        expect(fetchMock).toHaveBeenCalledWith(
-            failedUrl,
-            expect.objectContaining({ method: "POST" })
-        );
-        expect(fetchMock).toHaveBeenCalledWith(
-            successfulUrl,
-            expect.objectContaining({ method: "POST" })
-        );
-        expect(failedHandler).toHaveBeenCalledTimes(1);
-        expect(failedHandler).toHaveBeenCalledWith(
-            expect.objectContaining({
-                raw: expect.objectContaining({
-                    url: failedUrl,
-                    attempts: 1,
-                    originalEvent: deliveryEvent,
-                }),
-            })
-        );
-    });
-
-    it("cancels pending retries for all URLs when the watcher stops", async () => {
-        const fetchMock = vi.fn().mockRejectedValue(new Error("network down"));
-        vi.stubGlobal("fetch", fetchMock);
-
-        const watcher = new Watcher("GABC");
-        new WebhookDelivery(watcher, {
-            url: [
-                "https://prod.example.com/webhooks/stellar",
-                "https://staging.example.com/webhooks/stellar",
-            ],
-            secret: "top-secret",
-            retries: 3,
-        });
-
-        watcher.emit("*", deliveryEvent);
-        await flushAsyncWork();
-
-        expect(fetchMock).toHaveBeenCalledTimes(2);
-
-        watcher.stop();
-        vi.advanceTimersByTime(10_000);
-        await flushAsyncWork();
-
-        expect(fetchMock).toHaveBeenCalledTimes(2);
-    });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
 });
 
 describe("pulse-webhooks verifyWebhook", () => {
-    it("returns parsed event when signature matches timestamped payload", () => {
-        const payload = JSON.stringify(deliveryEvent);
-        const timestamp = "1714176000000";
-        const signature = signWebhookPayload("top-secret", payload, timestamp);
+  it("returns parsed event when signature matches timestamped payload", () => {
+    const payload = JSON.stringify(deliveryEvent);
+    const timestamp = "1714176000000";
+    const signature = signWebhookPayload("top-secret", payload, timestamp);
 
-        const event = verifyWebhook(payload, signature, "top-secret", timestamp);
+    const event = verifyWebhook(payload, signature, "top-secret", timestamp);
 
-        expect(event).toEqual(deliveryEvent);
-    });
+    expect(event).toEqual(deliveryEvent);
+  });
 
-    it("returns null when timestamp is missing or invalid", () => {
-        const payload = JSON.stringify(deliveryEvent);
-        const signature = signWebhookPayload("top-secret", payload, "1714176000000");
+  it("returns null when timestamp is missing or invalid", () => {
+    const payload = JSON.stringify(deliveryEvent);
+    const signature = signWebhookPayload(
+      "top-secret",
+      payload,
+      "1714176000000",
+    );
 
-        expect(verifyWebhook(payload, signature, "top-secret", "")).toBeNull();
-        expect(verifyWebhook(payload, signature, "top-secret", "not-a-number")).toBeNull();
-    });
+    expect(verifyWebhook(payload, signature, "top-secret", "")).toBeNull();
+    expect(
+      verifyWebhook(payload, signature, "top-secret", "not-a-number"),
+    ).toBeNull();
+  });
 
-    it("returns null when signature does not match timestamped payload", () => {
-        const payload = JSON.stringify(deliveryEvent);
-        const timestamp = "1714176000000";
-        const signature = signWebhookPayload("top-secret", payload, timestamp);
+  it("returns null when signature does not match timestamped payload", () => {
+    const payload = JSON.stringify(deliveryEvent);
+    const timestamp = "1714176000000";
+    const signature = signWebhookPayload("top-secret", payload, timestamp);
 
-        expect(verifyWebhook(payload, signature, "wrong-secret", timestamp)).toBeNull();
-        expect(verifyWebhook(`${payload}x`, signature, "top-secret", timestamp)).toBeNull();
-        expect(verifyWebhook(payload, signature, "top-secret", "1714176000001")).toBeNull();
-    });
+    expect(
+      verifyWebhook(payload, signature, "wrong-secret", timestamp),
+    ).toBeNull();
+    expect(
+      verifyWebhook(`${payload}x`, signature, "top-secret", timestamp),
+    ).toBeNull();
+    expect(
+      verifyWebhook(payload, signature, "top-secret", "1714176000001"),
+    ).toBeNull();
+  });
+});
+
+describe("pulse-webhooks verifyWebhookEdge", () => {
+  it("returns parsed event when signature matches timestamped payload", async () => {
+    const payload = JSON.stringify(deliveryEvent);
+    const timestamp = "1714176000000";
+    const signature = signWebhookPayload("top-secret", payload, timestamp);
+
+    const event = await verifyWebhookEdge(
+      payload,
+      signature,
+      "top-secret",
+      timestamp,
+    );
+
+    expect(event).toEqual(deliveryEvent);
+  });
+
+  it("returns null when timestamp is missing or invalid", async () => {
+    const payload = JSON.stringify(deliveryEvent);
+    const signature = signWebhookPayload(
+      "top-secret",
+      payload,
+      "1714176000000",
+    );
+
+    expect(
+      await verifyWebhookEdge(payload, signature, "top-secret", ""),
+    ).toBeNull();
+    expect(
+      await verifyWebhookEdge(payload, signature, "top-secret", "not-a-number"),
+    ).toBeNull();
+  });
+
+  it("returns null when signature does not match timestamped payload", async () => {
+    const payload = JSON.stringify(deliveryEvent);
+    const timestamp = "1714176000000";
+    const signature = signWebhookPayload("top-secret", payload, timestamp);
+
+    expect(
+      await verifyWebhookEdge(payload, signature, "wrong-secret", timestamp),
+    ).toBeNull();
+    expect(
+      await verifyWebhookEdge(
+        `${payload}x`,
+        signature,
+        "top-secret",
+        timestamp,
+      ),
+    ).toBeNull();
+    expect(
+      await verifyWebhookEdge(
+        payload,
+        signature,
+        "top-secret",
+        "1714176000001",
+      ),
+    ).toBeNull();
+  });
+
+  it("returns null for malformed JSON payload", async () => {
+    const payload = "{ invalid json }";
+    const timestamp = "1714176000000";
+    const signature = signWebhookPayload("top-secret", payload, timestamp);
+
+    expect(
+      await verifyWebhookEdge(payload, signature, "top-secret", timestamp),
+    ).toBeNull();
+  });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,12 @@ importers:
       express:
         specifier: ^4.18.2
         version: 4.22.1
+      pino:
+        specifier: ^9.0.0
+        version: 9.14.0
+      pino-http:
+        specifier: ^10.0.0
+        version: 10.5.0
     devDependencies:
       '@types/express':
         specifier: ^4.17.21
@@ -30,6 +36,9 @@ importers:
       '@types/node':
         specifier: ^25.6.0
         version: 25.6.0
+      '@types/pino-http':
+        specifier: ^5.8.4
+        version: 5.8.4
       tsx:
         specifier: ^4.0.0
         version: 4.21.0
@@ -678,6 +687,9 @@ packages:
     resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
     engines: {node: ^14.21.3 || >=16}
 
+  '@pinojs/redact@0.4.0':
+    resolution: {integrity: sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==}
+
   '@rollup/rollup-android-arm-eabi@4.60.2':
     resolution: {integrity: sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==}
     cpu: [arm]
@@ -852,6 +864,20 @@ packages:
   '@types/node@25.6.0':
     resolution: {integrity: sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==}
 
+  '@types/pino-http@5.8.4':
+    resolution: {integrity: sha512-UTYBQ2acmJ2eK0w58vVtgZ9RAicFFndfrnWC1w5cBTf8zwn/HEy8O+H7psc03UZgTzHmlcuX8VkPRnRDEj+FUQ==}
+
+  '@types/pino-pretty@5.0.0':
+    resolution: {integrity: sha512-N1uzqSzioqz8R3AkDbSJwcfDWeI3YMPNapSQQhnB2ISU4NYgUIcAh+hYT5ygqBM+klX4htpEhXMmoJv3J7GrdA==}
+    deprecated: This is a stub types definition. pino-pretty provides its own type definitions, so you do not need this installed.
+
+  '@types/pino-std-serializers@4.0.0':
+    resolution: {integrity: sha512-gXfUZx2xIBbFYozGms53fT0nvkacx/+62c8iTxrEqH5PkIGAQvDbXg2774VWOycMPbqn5YJBQ3BMsg4Li3dWbg==}
+    deprecated: This is a stub types definition. pino-std-serializers provides its own type definitions, so you do not need this installed.
+
+  '@types/pino@6.3.12':
+    resolution: {integrity: sha512-dsLRTq8/4UtVSpJgl9aeqHvbh6pzdmjYD3C092SYgLD2TyoCqHpTJk6vp8DvCTGGc7iowZ2MoiYiVUUCcu7muw==}
+
   '@types/qs@6.15.0':
     resolution: {integrity: sha512-JawvT8iBVWpzTrz3EGw9BTQFg3BQNmwERdKE22vlTxawwtbyUSlMppvZYKLZzB5zgACXdXxbD3m1bXaMqP/9ow==}
 
@@ -933,6 +959,10 @@ packages:
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
+  atomic-sleep@1.0.0:
+    resolution: {integrity: sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==}
+    engines: {node: '>=8.0.0'}
+
   autoprefixer@10.5.0:
     resolution: {integrity: sha512-FMhOoZV4+qR6aTUALKX2rEqGG+oyATvwBt9IIzVR5rMa2HRWPkxf+P+PAJLD1I/H5/II+HuZcBJYEFBpq39ong==}
     engines: {node: ^10 || ^12 || >=14}
@@ -1000,6 +1030,9 @@ packages:
   client-only@0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
 
+  colorette@2.0.20:
+    resolution: {integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==}
+
   combined-stream@1.0.8:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
     engines: {node: '>= 0.8'}
@@ -1028,6 +1061,9 @@ packages:
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  dateformat@4.6.3:
+    resolution: {integrity: sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==}
 
   debug@2.6.9:
     resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
@@ -1070,6 +1106,9 @@ packages:
   encodeurl@2.0.0:
     resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
     engines: {node: '>= 0.8'}
+
+  end-of-stream@1.4.5:
+    resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
 
   es-define-property@1.0.1:
     resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
@@ -1134,6 +1173,12 @@ packages:
   extend-shallow@2.0.1:
     resolution: {integrity: sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==}
     engines: {node: '>=0.10.0'}
+
+  fast-copy@4.0.3:
+    resolution: {integrity: sha512-58apWr0GUiDFM8+3afrO6eYwJBn9ZAhDOzG3L+/9llab/haCARS2UIfffmOurYLwbgDRs8n0rfr6qAAPEAuAQw==}
+
+  fast-safe-stringify@2.1.1:
+    resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -1206,6 +1251,10 @@ packages:
     peerDependencies:
       next: '>=13.2.0'
 
+  get-caller-file@2.0.5:
+    resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
+    engines: {node: 6.* || 8.* || >= 10.*}
+
   get-intrinsic@1.3.0:
     resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
     engines: {node: '>= 0.4'}
@@ -1243,6 +1292,9 @@ packages:
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
+
+  help-me@5.0.0:
+    resolution: {integrity: sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==}
 
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
@@ -1299,6 +1351,10 @@ packages:
   jiti@1.21.7:
     resolution: {integrity: sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==}
     hasBin: true
+
+  joycon@3.1.1:
+    resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
+    engines: {node: '>=10'}
 
   js-tokens@10.0.0:
     resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
@@ -1361,6 +1417,9 @@ packages:
     engines: {node: '>=4'}
     hasBin: true
 
+  minimist@1.2.8:
+    resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+
   motion-dom@12.36.0:
     resolution: {integrity: sha512-Ep1pq8P88rGJ75om8lTCA13zqd7ywPGwCqwuWwin6BKc0hMLkVfcS6qKlRqEo2+t0DwoUcgGJfXwaiFn4AOcQA==}
 
@@ -1413,9 +1472,16 @@ packages:
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
 
+  on-exit-leak-free@2.1.2:
+    resolution: {integrity: sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==}
+    engines: {node: '>=14.0.0'}
+
   on-finished@2.4.1:
     resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
     engines: {node: '>= 0.8'}
+
+  once@1.4.0:
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
   parseurl@1.3.3:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
@@ -1434,6 +1500,26 @@ packages:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
 
+  pino-abstract-transport@2.0.0:
+    resolution: {integrity: sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==}
+
+  pino-abstract-transport@3.0.0:
+    resolution: {integrity: sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg==}
+
+  pino-http@10.5.0:
+    resolution: {integrity: sha512-hD91XjgaKkSsdn8P7LaebrNzhGTdB086W3pyPihX0EzGPjq5uBJBXo4N5guqNaK6mUjg9aubMF7wDViYek9dRA==}
+
+  pino-pretty@13.1.3:
+    resolution: {integrity: sha512-ttXRkkOz6WWC95KeY9+xxWL6AtImwbyMHrL1mSwqwW9u+vLp/WIElvHvCSDg0xO/Dzrggz1zv3rN5ovTRVowKg==}
+    hasBin: true
+
+  pino-std-serializers@7.1.0:
+    resolution: {integrity: sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==}
+
+  pino@9.14.0:
+    resolution: {integrity: sha512-8OEwKp5juEvb/MjpIc4hjqfgCNysrS94RIOMXYvpYCdm/jglrKEiAYmiumbmGhCvs+IcInsphYDFwqrjr7398w==}
+    hasBin: true
+
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
@@ -1449,6 +1535,9 @@ packages:
     resolution: {integrity: sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==}
     engines: {node: ^10 || ^12 || >=14}
 
+  process-warning@5.0.0:
+    resolution: {integrity: sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==}
+
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
@@ -1457,9 +1546,15 @@ packages:
     resolution: {integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==}
     engines: {node: '>=10'}
 
+  pump@3.0.4:
+    resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
+
   qs@6.14.2:
     resolution: {integrity: sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==}
     engines: {node: '>=0.6'}
+
+  quick-format-unescaped@4.0.4:
+    resolution: {integrity: sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==}
 
   randombytes@2.1.0:
     resolution: {integrity: sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==}
@@ -1485,6 +1580,10 @@ packages:
     resolution: {integrity: sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==}
     engines: {node: '>=0.10.0'}
 
+  real-require@0.2.0:
+    resolution: {integrity: sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==}
+    engines: {node: '>= 12.13.0'}
+
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
 
@@ -1496,6 +1595,10 @@ packages:
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
 
+  safe-stable-stringify@2.5.0:
+    resolution: {integrity: sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==}
+    engines: {node: '>=10'}
+
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
@@ -1505,6 +1608,9 @@ packages:
   section-matter@1.0.0:
     resolution: {integrity: sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==}
     engines: {node: '>=4'}
+
+  secure-json-parse@4.1.0:
+    resolution: {integrity: sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA==}
 
   semver@7.7.4:
     resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
@@ -1554,9 +1660,19 @@ packages:
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
 
+  sonic-boom@2.8.0:
+    resolution: {integrity: sha512-kuonw1YOYYNOve5iHdSahXPOK49GqwA+LZhI6Wz/l0rP57iKyXXIHaRagOBHAPmGwJC6od2Z9zgvZ5loSgMlVg==}
+
+  sonic-boom@4.2.1:
+    resolution: {integrity: sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==}
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
+
+  split2@4.2.0:
+    resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
+    engines: {node: '>= 10.x'}
 
   sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
@@ -1574,6 +1690,10 @@ packages:
   strip-bom-string@1.0.0:
     resolution: {integrity: sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==}
     engines: {node: '>=0.10.0'}
+
+  strip-json-comments@5.0.3:
+    resolution: {integrity: sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw==}
+    engines: {node: '>=14.16'}
 
   styled-jsx@5.1.6:
     resolution: {integrity: sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==}
@@ -1594,6 +1714,9 @@ packages:
 
   tailwindcss@4.2.4:
     resolution: {integrity: sha512-HhKppgO81FQof5m6TEnuBWCZGgfRAWbaeOaGT00KOy/Pf/j6oUihdvBpA7ltCeAvZpFhW3j0PTclkxsd4IXYDA==}
+
+  thread-stream@3.1.0:
+    resolution: {integrity: sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -1755,6 +1878,9 @@ packages:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
     engines: {node: '>=8'}
     hasBin: true
+
+  wrappy@1.0.2:
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
 snapshots:
 
@@ -2072,6 +2198,8 @@ snapshots:
 
   '@noble/hashes@1.8.0': {}
 
+  '@pinojs/redact@0.4.0': {}
+
   '@rollup/rollup-android-arm-eabi@4.60.2':
     optional: true
 
@@ -2218,6 +2346,25 @@ snapshots:
     dependencies:
       undici-types: 7.19.2
 
+  '@types/pino-http@5.8.4':
+    dependencies:
+      '@types/pino': 6.3.12
+
+  '@types/pino-pretty@5.0.0':
+    dependencies:
+      pino-pretty: 13.1.3
+
+  '@types/pino-std-serializers@4.0.0':
+    dependencies:
+      pino-std-serializers: 7.1.0
+
+  '@types/pino@6.3.12':
+    dependencies:
+      '@types/node': 25.6.0
+      '@types/pino-pretty': 5.0.0
+      '@types/pino-std-serializers': 4.0.0
+      sonic-boom: 2.8.0
+
   '@types/qs@6.15.0': {}
 
   '@types/range-parser@1.2.7': {}
@@ -2321,6 +2468,8 @@ snapshots:
 
   asynckit@0.4.0: {}
 
+  atomic-sleep@1.0.0: {}
+
   autoprefixer@10.5.0(postcss@8.5.12):
     dependencies:
       browserslist: 4.28.2
@@ -2405,6 +2554,8 @@ snapshots:
 
   client-only@0.0.1: {}
 
+  colorette@2.0.20: {}
+
   combined-stream@1.0.8:
     dependencies:
       delayed-stream: 1.0.0
@@ -2424,6 +2575,8 @@ snapshots:
   cookie@0.7.2: {}
 
   csstype@3.2.3: {}
+
+  dateformat@4.6.3: {}
 
   debug@2.6.9:
     dependencies:
@@ -2455,6 +2608,10 @@ snapshots:
   electron-to-chromium@1.5.344: {}
 
   encodeurl@2.0.0: {}
+
+  end-of-stream@1.4.5:
+    dependencies:
+      once: 1.4.0
 
   es-define-property@1.0.1: {}
 
@@ -2587,6 +2744,10 @@ snapshots:
     dependencies:
       is-extendable: 0.1.1
 
+  fast-copy@4.0.3: {}
+
+  fast-safe-stringify@2.1.1: {}
+
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
@@ -2645,6 +2806,8 @@ snapshots:
     dependencies:
       next: 16.2.4(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
 
+  get-caller-file@2.0.5: {}
+
   get-intrinsic@1.3.0:
     dependencies:
       call-bind-apply-helpers: 1.0.2
@@ -2691,6 +2854,8 @@ snapshots:
   hasown@2.0.2:
     dependencies:
       function-bind: 1.1.2
+
+  help-me@5.0.0: {}
 
   html-escaper@2.0.2: {}
 
@@ -2740,6 +2905,8 @@ snapshots:
   jiti@1.21.7:
     optional: true
 
+  joycon@3.1.1: {}
+
   js-tokens@10.0.0: {}
 
   js-tokens@4.0.0: {}
@@ -2787,6 +2954,8 @@ snapshots:
 
   mime@1.6.0: {}
 
+  minimist@1.2.8: {}
+
   motion-dom@12.36.0:
     dependencies:
       motion-utils: 12.36.0
@@ -2831,9 +3000,15 @@ snapshots:
 
   obug@2.1.1: {}
 
+  on-exit-leak-free@2.1.2: {}
+
   on-finished@2.4.1:
     dependencies:
       ee-first: 1.1.1
+
+  once@1.4.0:
+    dependencies:
+      wrappy: 1.0.2
 
   parseurl@1.3.3: {}
 
@@ -2844,6 +3019,53 @@ snapshots:
   picocolors@1.1.1: {}
 
   picomatch@4.0.4: {}
+
+  pino-abstract-transport@2.0.0:
+    dependencies:
+      split2: 4.2.0
+
+  pino-abstract-transport@3.0.0:
+    dependencies:
+      split2: 4.2.0
+
+  pino-http@10.5.0:
+    dependencies:
+      get-caller-file: 2.0.5
+      pino: 9.14.0
+      pino-std-serializers: 7.1.0
+      process-warning: 5.0.0
+
+  pino-pretty@13.1.3:
+    dependencies:
+      colorette: 2.0.20
+      dateformat: 4.6.3
+      fast-copy: 4.0.3
+      fast-safe-stringify: 2.1.1
+      help-me: 5.0.0
+      joycon: 3.1.1
+      minimist: 1.2.8
+      on-exit-leak-free: 2.1.2
+      pino-abstract-transport: 3.0.0
+      pump: 3.0.4
+      secure-json-parse: 4.1.0
+      sonic-boom: 4.2.1
+      strip-json-comments: 5.0.3
+
+  pino-std-serializers@7.1.0: {}
+
+  pino@9.14.0:
+    dependencies:
+      '@pinojs/redact': 0.4.0
+      atomic-sleep: 1.0.0
+      on-exit-leak-free: 2.1.2
+      pino-abstract-transport: 2.0.0
+      pino-std-serializers: 7.1.0
+      process-warning: 5.0.0
+      quick-format-unescaped: 4.0.4
+      real-require: 0.2.0
+      safe-stable-stringify: 2.5.0
+      sonic-boom: 4.2.1
+      thread-stream: 3.1.0
 
   possible-typed-array-names@1.1.0: {}
 
@@ -2861,6 +3083,8 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  process-warning@5.0.0: {}
+
   proxy-addr@2.0.7:
     dependencies:
       forwarded: 0.2.0
@@ -2868,9 +3092,16 @@ snapshots:
 
   proxy-from-env@2.1.0: {}
 
+  pump@3.0.4:
+    dependencies:
+      end-of-stream: 1.4.5
+      once: 1.4.0
+
   qs@6.14.2:
     dependencies:
       side-channel: 1.1.0
+
+  quick-format-unescaped@4.0.4: {}
 
   randombytes@2.1.0:
     dependencies:
@@ -2895,6 +3126,8 @@ snapshots:
       loose-envify: 1.4.0
 
   react@19.2.5: {}
+
+  real-require@0.2.0: {}
 
   resolve-pkg-maps@1.0.0: {}
 
@@ -2931,6 +3164,8 @@ snapshots:
 
   safe-buffer@5.2.1: {}
 
+  safe-stable-stringify@2.5.0: {}
+
   safer-buffer@2.1.2: {}
 
   scheduler@0.27.0: {}
@@ -2939,6 +3174,8 @@ snapshots:
     dependencies:
       extend-shallow: 2.0.1
       kind-of: 6.0.3
+
+  secure-json-parse@4.1.0: {}
 
   semver@7.7.4: {}
 
@@ -3048,7 +3285,17 @@ snapshots:
 
   siginfo@2.0.0: {}
 
+  sonic-boom@2.8.0:
+    dependencies:
+      atomic-sleep: 1.0.0
+
+  sonic-boom@4.2.1:
+    dependencies:
+      atomic-sleep: 1.0.0
+
   source-map-js@1.2.1: {}
+
+  split2@4.2.0: {}
 
   sprintf-js@1.0.3: {}
 
@@ -3060,6 +3307,8 @@ snapshots:
 
   strip-bom-string@1.0.0: {}
 
+  strip-json-comments@5.0.3: {}
+
   styled-jsx@5.1.6(react@19.2.5):
     dependencies:
       client-only: 0.0.1
@@ -3070,6 +3319,10 @@ snapshots:
       has-flag: 4.0.0
 
   tailwindcss@4.2.4: {}
+
+  thread-stream@3.1.0:
+    dependencies:
+      real-require: 0.2.0
 
   tinybench@2.9.0: {}
 
@@ -3186,3 +3439,5 @@ snapshots:
     dependencies:
       siginfo: 2.0.0
       stackback: 0.0.2
+
+  wrappy@1.0.2: {}


### PR DESCRIPTION
- Add verifyWebhookEdge function using Web Crypto API for edge runtime compatibility
- Create edge.ts with Web Crypto implementation of HMAC-SHA256 verification
- Update README with Cloudflare Workers section and copy-pastable example
- Add comprehensive tests for verifyWebhookEdge function
- Export verifyWebhookEdge from main index.ts

Fixes #129

