### PR TITLE
Pool pulse-notify EventSource connections

### DIFF
--- a/apps/web/content/api/pulse-notify.md
+++ b/apps/web/content/api/pulse-notify.md
@@ -147,7 +147,7 @@ The hooks are client-only — they rely on `EventSource`, which doesn't exist in
 
 ## Connection behavior
 
-- One `EventSource` connection per hook instance
+- Hook instances with the same `serverUrl`, `address`, and `token` share one `EventSource`
 - Browser handles reconnection automatically on transient network errors
 - Connections are cleaned up on unmount or when `address` / `serverUrl` change
 - Each render returns the *most recent* event — accumulate history yourself in component state if needed

--- a/apps/web/content/guides/real-time-events.md
+++ b/apps/web/content/guides/real-time-events.md
@@ -184,6 +184,6 @@ useStellarEvent(serverUrl, address, {
 ## Connection lifecycle
 
 - The browser's `EventSource` reconnects automatically on disconnect
-- Each hook instance opens one connection — share the address across components if possible to avoid duplicate connections
+- Hook instances with the same `serverUrl`, `address`, and `token` share one browser connection while keeping their own event filters
 - Clean shutdown: when your backend exits, send a custom `shutdown` event so clients can distinguish planned restarts from network failures
 - Heartbeats every ~30 seconds keep the connection alive through proxies and load balancers

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -284,8 +284,13 @@ verifier doesn't load there.
 
 ## 7. React hook internals
 
-`useStellarEvent<T>` is intentionally thin: ~70 lines of `useEffect` opening
-an `EventSource`, with two design choices worth noting.
+`useStellarEvent<T>` is intentionally thin: it acquires a pooled
+`EventSource` connection and applies a per-hook event filter, with three
+design choices worth noting.
+
+**Connection pooling.** Hook instances with the same `serverUrl`, `address`,
+and `token` share one browser `EventSource`; the pool closes that connection
+when the last hook using the key unmounts.
 
 **Stable dep-array.** An array literal passed as the `event` allowlist
 would otherwise be a new reference every render and re-run the effect

--- a/packages/pulse-notify/README.md
+++ b/packages/pulse-notify/README.md
@@ -10,7 +10,7 @@ Requires React 18 or 19. Designed for Next.js App Router, Vite, Remix, and plain
 
 ## What it does
 
-`pulse-notify` opens a browser-native `EventSource` connection to your Orbital server, subscribes to an address, and re-renders your component whenever a new event arrives. It is intentionally thin — no global store, no custom cache, no peer-dependency on a state manager.
+`pulse-notify` opens a browser-native `EventSource` connection to your Orbital server, subscribes to an address, and re-renders your component whenever a new event arrives. Hook instances watching the same `serverUrl`, `address`, and `token` share one connection internally while keeping their own event filters. It is intentionally thin — no global store, no custom cache, no peer-dependency on a state manager.
 
 You point the hook at your own Orbital server (self-hosted or managed) and pass the address you want to watch.
 
@@ -216,7 +216,7 @@ The hooks are client-only — they rely on `EventSource`, which does not exist i
 
 ## Current limitations
 
-- One connection per hook instance. Deduplication across components watching the same address is a planned enhancement.
+- Hook instances with the same `serverUrl`, `address`, and `token` share one browser `EventSource`; different keys open separate connections.
 - No offline queue. Events that arrive while the tab is backgrounded and the connection is closed are not replayed on reconnect.
 - `EventSource` reconnect is browser-controlled. Fine-grained retry policy belongs in a future WebSocket-based transport.
 

--- a/packages/pulse-notify/package.json
+++ b/packages/pulse-notify/package.json
@@ -6,7 +6,8 @@
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "scripts": {
-    "build": "tsc -p tsconfig.json"
+    "build": "tsc -p tsconfig.json",
+    "test": "tsx test/connectionPool.test.ts"
   },
   "dependencies": {
     "@orbital/pulse-core": "workspace:*"

--- a/packages/pulse-notify/src/connectionPool.ts
+++ b/packages/pulse-notify/src/connectionPool.ts
@@ -1,0 +1,103 @@
+import type { NormalizedEvent } from "@orbital/pulse-core";
+
+type ConnectionKey = {
+  serverUrl: string;
+  address: string;
+  token?: string;
+};
+
+type ConnectionSubscriber = {
+  onOpen: () => void;
+  onEvent: (event: NormalizedEvent) => void;
+  onParseError: () => void;
+  onError: () => void;
+};
+
+type ConnectionEntry = {
+  source: EventSource;
+  subscribers: Set<ConnectionSubscriber>;
+  connected: boolean;
+};
+
+const pool = new Map<string, ConnectionEntry>();
+
+function getConnectionKey({ serverUrl, address, token }: ConnectionKey): string {
+  return JSON.stringify([serverUrl, address, token ?? ""]);
+}
+
+function getEventSourceUrl({ serverUrl, address, token }: ConnectionKey): string {
+  const base = `${serverUrl}/events/${address}`;
+  return token ? `${base}?token=${encodeURIComponent(token)}` : base;
+}
+
+function notifySubscribers(
+  entry: ConnectionEntry,
+  notify: (subscriber: ConnectionSubscriber) => void
+) {
+  for (const subscriber of [...entry.subscribers]) {
+    notify(subscriber);
+  }
+}
+
+export function acquireEventConnection(
+  key: ConnectionKey,
+  subscriber: ConnectionSubscriber
+) {
+  const poolKey = getConnectionKey(key);
+  let entry = pool.get(poolKey);
+
+  if (!entry) {
+    const newEntry: ConnectionEntry = {
+      source: new EventSource(getEventSourceUrl(key)),
+      subscribers: new Set(),
+      connected: false,
+    };
+
+    newEntry.source.onopen = () => {
+      newEntry.connected = true;
+      notifySubscribers(newEntry, (current) => current.onOpen());
+    };
+
+    newEntry.source.onmessage = (message) => {
+      try {
+        const event = JSON.parse(message.data) as NormalizedEvent;
+        notifySubscribers(newEntry, (current) => current.onEvent(event));
+      } catch {
+        notifySubscribers(newEntry, (current) => current.onParseError());
+      }
+    };
+
+    newEntry.source.onerror = () => {
+      newEntry.connected = false;
+      notifySubscribers(newEntry, (current) => current.onError());
+    };
+
+    pool.set(poolKey, newEntry);
+    entry = newEntry;
+  }
+
+  entry.subscribers.add(subscriber);
+
+  return {
+    connected: entry.connected,
+    unsubscribe: () => {
+      entry.subscribers.delete(subscriber);
+
+      if (entry.subscribers.size === 0) {
+        entry.source.close();
+        pool.delete(poolKey);
+      }
+    },
+  };
+}
+
+export function __getConnectionPoolSizeForTests() {
+  return pool.size;
+}
+
+export function __resetConnectionPoolForTests() {
+  for (const entry of pool.values()) {
+    entry.source.close();
+  }
+  pool.clear();
+}

--- a/packages/pulse-notify/src/index.ts
+++ b/packages/pulse-notify/src/index.ts
@@ -1,5 +1,6 @@
 import { useState, useEffect } from "react";
 import type { NormalizedEvent } from "@orbital/pulse-core";
+import { acquireEventConnection } from "./connectionPool.js";
 
 export type UseEventConfig = {
   serverUrl: string;
@@ -56,45 +57,44 @@ export function useStellarEvent<T extends NormalizedEvent = NormalizedEvent>(
   });
 
   useEffect(() => {
-    const base = `${serverUrl}/events/${addr}`;
-    const url = token ? `${base}?token=${encodeURIComponent(token)}` : base;
+    const connection = acquireEventConnection(
+      { serverUrl, address: addr, token },
+      {
+        onOpen: () => {
+          setState((prev) => ({ ...prev, connected: true, error: null }));
+        },
+        onEvent: (incoming) => {
+          // Filter by event type: pass if "*", if type matches the string,
+          // or if type is included in the allowlist array.
+          const allowed =
+            eventType === "*" ||
+            (Array.isArray(eventType)
+              ? eventType.includes(incoming.type)
+              : incoming.type === eventType);
 
-    const source = new EventSource(url);
+          if (!allowed) return;
 
-    source.onopen = () => {
-      setState((prev) => ({ ...prev, connected: true, error: null }));
-    };
-
-    source.onmessage = (e) => {
-      try {
-        const incoming: NormalizedEvent = JSON.parse(e.data);
-
-        // Filter by event type: pass if "*", if type matches the string,
-        // or if type is included in the allowlist array.
-        const allowed =
-          eventType === "*" ||
-          (Array.isArray(eventType)
-            ? eventType.includes(incoming.type)
-            : incoming.type === eventType);
-
-        if (!allowed) return;
-
-        setState((prev) => ({ ...prev, event: incoming as T }));
-      } catch {
-        setState((prev) => ({ ...prev, error: "Failed to parse event" }));
+          setState((prev) => ({ ...prev, event: incoming as T }));
+        },
+        onParseError: () => {
+          setState((prev) => ({ ...prev, error: "Failed to parse event" }));
+        },
+        onError: () => {
+          setState((prev) => ({
+            ...prev,
+            connected: false,
+            error: "Connection lost — retrying...",
+          }));
+        },
       }
-    };
+    );
 
-    source.onerror = () => {
-      setState((prev) => ({
-        ...prev,
-        connected: false,
-        error: "Connection lost — retrying...",
-      }));
-    };
+    if (connection.connected) {
+      setState((prev) => ({ ...prev, connected: true, error: null }));
+    }
 
     return () => {
-      source.close();
+      connection.unsubscribe();
     };
     // ✅ eventKey is a serialised string — stable even when the caller passes
     // an array literal, which would otherwise be a new reference every render.

--- a/packages/pulse-notify/test/connectionPool.test.ts
+++ b/packages/pulse-notify/test/connectionPool.test.ts
@@ -1,0 +1,101 @@
+import assert from "node:assert/strict";
+import {
+  __getConnectionPoolSizeForTests,
+  __resetConnectionPoolForTests,
+  acquireEventConnection,
+} from "../src/connectionPool.ts";
+
+type EventSourceMessageHandler = (message: { data: string }) => void;
+
+class MockEventSource {
+  static instances: MockEventSource[] = [];
+
+  onopen: (() => void) | null = null;
+  onmessage: EventSourceMessageHandler | null = null;
+  onerror: (() => void) | null = null;
+  closeCount = 0;
+
+  constructor(readonly url: string) {
+    MockEventSource.instances.push(this);
+  }
+
+  close() {
+    this.closeCount += 1;
+  }
+}
+
+globalThis.EventSource = MockEventSource as unknown as typeof EventSource;
+
+function reset() {
+  __resetConnectionPoolForTests();
+  MockEventSource.instances = [];
+}
+
+reset();
+
+const firstEvents: string[] = [];
+const secondEvents: string[] = [];
+
+const first = acquireEventConnection(
+  { serverUrl: "https://events.example.com", address: "GABC", token: "secret" },
+  {
+    onOpen: () => undefined,
+    onEvent: (event) => firstEvents.push(event.type),
+    onParseError: () => undefined,
+    onError: () => undefined,
+  }
+);
+
+const second = acquireEventConnection(
+  { serverUrl: "https://events.example.com", address: "GABC", token: "secret" },
+  {
+    onOpen: () => undefined,
+    onEvent: (event) => secondEvents.push(event.type),
+    onParseError: () => undefined,
+    onError: () => undefined,
+  }
+);
+
+assert.equal(MockEventSource.instances.length, 1);
+assert.equal(__getConnectionPoolSizeForTests(), 1);
+
+MockEventSource.instances[0]?.onmessage?.({
+  data: JSON.stringify({ type: "payment.received" }),
+});
+
+assert.deepEqual(firstEvents, ["payment.received"]);
+assert.deepEqual(secondEvents, ["payment.received"]);
+
+first.unsubscribe();
+assert.equal(MockEventSource.instances[0]?.closeCount, 0);
+assert.equal(__getConnectionPoolSizeForTests(), 1);
+
+second.unsubscribe();
+assert.equal(MockEventSource.instances[0]?.closeCount, 1);
+assert.equal(__getConnectionPoolSizeForTests(), 0);
+
+const withoutToken = acquireEventConnection(
+  { serverUrl: "https://events.example.com", address: "GABC" },
+  {
+    onOpen: () => undefined,
+    onEvent: () => undefined,
+    onParseError: () => undefined,
+    onError: () => undefined,
+  }
+);
+const withToken = acquireEventConnection(
+  { serverUrl: "https://events.example.com", address: "GABC", token: "secret" },
+  {
+    onOpen: () => undefined,
+    onEvent: () => undefined,
+    onParseError: () => undefined,
+    onError: () => undefined,
+  }
+);
+
+assert.equal(MockEventSource.instances.length, 3);
+assert.equal(__getConnectionPoolSizeForTests(), 2);
+
+withoutToken.unsubscribe();
+withToken.unsubscribe();
+reset();


### PR DESCRIPTION
## Summary
- add an internal pulse-notify connection pool keyed by serverUrl, address, and token so matching hook instances share one EventSource
- keep per-hook event filtering and state callbacks while closing the pooled connection when the last subscriber unmounts
- document the new connection behavior and add a focused pool regression test

Closes #432

## Verification
- pnpm build
- pnpm test