### PR TITLE
fix(pulse-webhooks): support replay clock skew

### DIFF
--- a/packages/pulse-webhooks/src/edge.ts
+++ b/packages/pulse-webhooks/src/edge.ts
@@ -1,5 +1,10 @@
 import type { NormalizedEvent } from "@orbital/pulse-core";
 
+import type { VerifyWebhookOptions } from "./types.js";
+
+const DEFAULT_MAX_AGE_MS = 300_000;
+const DEFAULT_CLOCK_SKEW_MS = 30_000;
+
 /**
  * Verifies webhook signatures using Web Crypto API (compatible with Cloudflare Workers, Deno, and browsers)
  *
@@ -7,6 +12,7 @@ import type { NormalizedEvent } from "@orbital/pulse-core";
  * @param signature - The x-orbital-signature header value
  * @param secret - Your webhook secret
  * @param timestamp - The x-orbital-timestamp header value
+ * @param options - Optional replay-window options (`maxAgeMs`, `clockSkewMs`, `nowMs`)
  * @returns Parsed NormalizedEvent if verification succeeds, null otherwise
  */
 export async function verifyWebhookEdge(
@@ -14,9 +20,20 @@ export async function verifyWebhookEdge(
   signature: string,
   secret: string,
   timestamp: string,
+  options: VerifyWebhookOptions = {},
 ): Promise<NormalizedEvent | null> {
   // Validate timestamp format
   if (!/^\d+$/.test(timestamp)) return null;
+
+  const timestampMs = Number(timestamp);
+  if (!Number.isFinite(timestampMs)) return null;
+
+  const maxAgeMs = options.maxAgeMs ?? DEFAULT_MAX_AGE_MS;
+  const clockSkewMs = options.clockSkewMs ?? DEFAULT_CLOCK_SKEW_MS;
+  const nowMs = options.nowMs ?? Date.now();
+
+  if (timestampMs > nowMs + clockSkewMs) return null;
+  if (timestampMs < nowMs - maxAgeMs - clockSkewMs) return null;
 
   try {
     // Import the secret key

--- a/packages/pulse-webhooks/src/index.ts
+++ b/packages/pulse-webhooks/src/index.ts
@@ -1,9 +1,12 @@
 import type { NormalizedEvent, Watcher, WatcherNotification } from "@orbital/pulse-core";
 import { createHmac, timingSafeEqual } from "crypto";
 
-import type { WebhookConfig } from "./types.js";
+import type { VerifyWebhookOptions, WebhookConfig } from "./types.js";
 export { verifyWebhookEdge } from "./edge.js";
-export type { WebhookConfig } from "./types.js";
+export type { VerifyWebhookOptions, WebhookConfig } from "./types.js";
+
+const DEFAULT_MAX_AGE_MS = 300_000;
+const DEFAULT_CLOCK_SKEW_MS = 30_000;
 
 type ResolvedWebhookConfig = Omit<Required<WebhookConfig>, "url"> & {
   urls: string[];
@@ -144,8 +147,19 @@ export function verifyWebhook(
   signature: string,
   secret: string,
   timestamp: string,
+  options: VerifyWebhookOptions = {},
 ): NormalizedEvent | null {
   if (!/^\d+$/.test(timestamp)) return null;
+
+  const timestampMs = Number(timestamp);
+  if (!Number.isFinite(timestampMs)) return null;
+
+  const maxAgeMs = options.maxAgeMs ?? DEFAULT_MAX_AGE_MS;
+  const clockSkewMs = options.clockSkewMs ?? DEFAULT_CLOCK_SKEW_MS;
+  const nowMs = options.nowMs ?? Date.now();
+
+  if (timestampMs > nowMs + clockSkewMs) return null;
+  if (timestampMs < nowMs - maxAgeMs - clockSkewMs) return null;
 
   const expected = createHmac("sha256", secret)
     .update(`${timestamp}.${payload}`)

--- a/packages/pulse-webhooks/src/types.ts
+++ b/packages/pulse-webhooks/src/types.ts
@@ -8,3 +8,12 @@ export type WebhookConfig = {
   /** Optional RNG for testing jitter. Defaults to `Math.random`. */
   random?: () => number;
 };
+
+export type VerifyWebhookOptions = {
+  /** Reject signatures older than this age in milliseconds. Defaults to 300_000 (5 minutes). */
+  maxAgeMs?: number;
+  /** Clock skew allowance in milliseconds for sender/receiver clock differences. Defaults to 30_000. */
+  clockSkewMs?: number;
+  /** Override current time for testing. Defaults to Date.now(). */
+  nowMs?: number;
+};

--- a/packages/pulse-webhooks/test/pulse-webhooks.test.ts
+++ b/packages/pulse-webhooks/test/pulse-webhooks.test.ts
@@ -281,7 +281,9 @@ describe("pulse-webhooks verifyWebhook", () => {
     const timestamp = "1714176000000";
     const signature = signWebhookPayload("top-secret", payload, timestamp);
 
-    const event = verifyWebhook(payload, signature, "top-secret", timestamp);
+    const event = verifyWebhook(payload, signature, "top-secret", timestamp, {
+      nowMs: Number(timestamp),
+    });
 
     expect(event).toEqual(deliveryEvent);
   });
@@ -315,6 +317,46 @@ describe("pulse-webhooks verifyWebhook", () => {
       verifyWebhook(payload, signature, "top-secret", "1714176000001"),
     ).toBeNull();
   });
+
+  it("accepts timestamp within configured clock skew window", () => {
+    const payload = JSON.stringify(deliveryEvent);
+    const nowMs = 1_714_176_000_000;
+    const timestamp = String(nowMs + 20_000);
+    const signature = signWebhookPayload("top-secret", payload, timestamp);
+
+    const event = verifyWebhook(payload, signature, "top-secret", timestamp, {
+      nowMs,
+      maxAgeMs: 60_000,
+      clockSkewMs: 30_000,
+    });
+
+    expect(event).toEqual(deliveryEvent);
+  });
+
+  it("rejects timestamp outside configured skew and maxAge window", () => {
+    const payload = JSON.stringify(deliveryEvent);
+    const nowMs = 1_714_176_000_000;
+    const tooFarFutureTs = String(nowMs + 30_001);
+    const tooOldTs = String(nowMs - 60_000 - 30_001);
+
+    const futureSig = signWebhookPayload("top-secret", payload, tooFarFutureTs);
+    const oldSig = signWebhookPayload("top-secret", payload, tooOldTs);
+
+    expect(
+      verifyWebhook(payload, futureSig, "top-secret", tooFarFutureTs, {
+        nowMs,
+        maxAgeMs: 60_000,
+        clockSkewMs: 30_000,
+      }),
+    ).toBeNull();
+    expect(
+      verifyWebhook(payload, oldSig, "top-secret", tooOldTs, {
+        nowMs,
+        maxAgeMs: 60_000,
+        clockSkewMs: 30_000,
+      }),
+    ).toBeNull();
+  });
 });
 
 describe("pulse-webhooks verifyWebhookEdge", () => {
@@ -328,6 +370,7 @@ describe("pulse-webhooks verifyWebhookEdge", () => {
       signature,
       "top-secret",
       timestamp,
+      { nowMs: Number(timestamp) },
     );
 
     expect(event).toEqual(deliveryEvent);
@@ -372,6 +415,46 @@ describe("pulse-webhooks verifyWebhookEdge", () => {
         "top-secret",
         "1714176000001",
       ),
+    ).toBeNull();
+  });
+
+  it("accepts timestamp within configured clock skew window", async () => {
+    const payload = JSON.stringify(deliveryEvent);
+    const nowMs = 1_714_176_000_000;
+    const timestamp = String(nowMs + 20_000);
+    const signature = signWebhookPayload("top-secret", payload, timestamp);
+
+    const event = await verifyWebhookEdge(payload, signature, "top-secret", timestamp, {
+      nowMs,
+      maxAgeMs: 60_000,
+      clockSkewMs: 30_000,
+    });
+
+    expect(event).toEqual(deliveryEvent);
+  });
+
+  it("rejects timestamp outside configured skew and maxAge window", async () => {
+    const payload = JSON.stringify(deliveryEvent);
+    const nowMs = 1_714_176_000_000;
+    const tooFarFutureTs = String(nowMs + 30_001);
+    const tooOldTs = String(nowMs - 60_000 - 30_001);
+
+    const futureSig = signWebhookPayload("top-secret", payload, tooFarFutureTs);
+    const oldSig = signWebhookPayload("top-secret", payload, tooOldTs);
+
+    expect(
+      await verifyWebhookEdge(payload, futureSig, "top-secret", tooFarFutureTs, {
+        nowMs,
+        maxAgeMs: 60_000,
+        clockSkewMs: 30_000,
+      }),
+    ).toBeNull();
+    expect(
+      await verifyWebhookEdge(payload, oldSig, "top-secret", tooOldTs, {
+        nowMs,
+        maxAgeMs: 60_000,
+        clockSkewMs: 30_000,
+      }),
     ).toBeNull();
   });
 


### PR DESCRIPTION
Closes #404.

## What changed
- added `VerifyWebhookOptions` with `maxAgeMs`, `clockSkewMs`, and `nowMs`
- updated `verifyWebhook` to allow bounded future skew and bounded stale skew
- updated `verifyWebhookEdge` with the same replay-window behavior
- documented the replay-window options inline where they are used

## Rationale
Receivers can have slightly skewed clocks. This keeps replay protection strict while allowing a small default tolerance (`clockSkewMs = 30_000`) so valid signatures are not rejected just because the receiver clock is ahead or behind.

## Verification
- `npx vitest run` in `packages/pulse-webhooks` passed
- `npx tsc -p tsconfig.json` in `packages/pulse-webhooks` fails due to pre-existing workspace/type-resolution issues (`@orbital/pulse-core`, Node globals like `Buffer`/`crypto`) not introduced by this change
