### PR TITLE
feat(pulse-webhooks): add custom url validator

### DIFF
--- a/packages/pulse-webhooks/src/index.ts
+++ b/packages/pulse-webhooks/src/index.ts
@@ -5,8 +5,9 @@ import type { WebhookConfig } from "./types.js";
 export { verifyWebhookEdge } from "./edge.js";
 export type { WebhookConfig } from "./types.js";
 
-type ResolvedWebhookConfig = Omit<Required<WebhookConfig>, "url"> & {
+type ResolvedWebhookConfig = Omit<Required<WebhookConfig>, "url" | "urlValidator"> & {
   urls: string[];
+  urlValidator?: WebhookConfig["urlValidator"];
 };
 
 export class WebhookDelivery {
@@ -55,6 +56,14 @@ export class WebhookDelivery {
     const abortTimer = setTimeout(() => controller.abort(), timeoutMs);
 
     try {
+      const customValidationError = this.config.urlValidator
+        ? await this.config.urlValidator(url)
+        : null;
+
+      if (customValidationError) {
+        throw new Error(customValidationError);
+      }
+
       const res = await fetch(url, {
         method: "POST",
         headers: {

--- a/packages/pulse-webhooks/src/index.ts
+++ b/packages/pulse-webhooks/src/index.ts
@@ -48,6 +48,25 @@ export class WebhookDelivery {
   ): Promise<void> {
     if (this.watcher.stopped) return;
 
+    let customValidationError: string | null = null;
+    try {
+      customValidationError = this.config.urlValidator
+        ? await this.config.urlValidator(url)
+        : null;
+    } catch (err) {
+      if (this.watcher.stopped) return;
+
+      this.emitFailure(event, url, this.getErrorMessage(err), attempt);
+      return;
+    }
+
+    if (this.watcher.stopped) return;
+
+    if (customValidationError) {
+      this.emitFailure(event, url, customValidationError, attempt);
+      return;
+    }
+
     const payload = JSON.stringify(event);
     const timestamp = Date.now().toString();
     const signature = this.sign(payload, timestamp);
@@ -56,14 +75,6 @@ export class WebhookDelivery {
     const abortTimer = setTimeout(() => controller.abort(), timeoutMs);
 
     try {
-      const customValidationError = this.config.urlValidator
-        ? await this.config.urlValidator(url)
-        : null;
-
-      if (customValidationError) {
-        throw new Error(customValidationError);
-      }
-
       const res = await fetch(url, {
         method: "POST",
         headers: {
@@ -109,19 +120,28 @@ export class WebhookDelivery {
         }, delay);
         this.retryTimers.set(retryTimer, { event, url });
       } else {
-        this.watcher.emit("webhook.failed", {
-          ...event,
-          raw: {
-            error: errorMessage,
-            url,
-            attempts: attempt,
-            originalEvent: event,
-          },
-        } as unknown as NormalizedEvent);
+        this.emitFailure(event, url, errorMessage, attempt);
       }
     } finally {
       clearTimeout(abortTimer);
     }
+  }
+
+  private emitFailure(
+    event: NormalizedEvent,
+    url: string,
+    errorMessage: string,
+    attempt: number,
+  ): void {
+    this.watcher.emit("webhook.failed", {
+      ...event,
+      raw: {
+        error: errorMessage,
+        url,
+        attempts: attempt,
+        originalEvent: event,
+      },
+    } as unknown as NormalizedEvent);
   }
 
   private clearRetryTimers(): void {

--- a/packages/pulse-webhooks/src/types.ts
+++ b/packages/pulse-webhooks/src/types.ts
@@ -7,4 +7,6 @@ export type WebhookConfig = {
   maxConcurrentRetries?: number;
   /** Optional RNG for testing jitter. Defaults to `Math.random`. */
   random?: () => number;
+  /** Optional custom URL validator for additional block-lists. Return an error message to reject, or null to allow. */
+  urlValidator?: (url: string) => Promise<string | null>;
 };

--- a/packages/pulse-webhooks/test/pulse-webhooks.test.ts
+++ b/packages/pulse-webhooks/test/pulse-webhooks.test.ts
@@ -99,6 +99,39 @@ describe("pulse-webhooks WebhookDelivery", () => {
     );
   });
 
+  it("rejects URL when custom urlValidator blocks an otherwise allowed URL", async () => {
+    const allowedUrl = "https://prod.example.com/webhooks/stellar";
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200 });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const watcher = new Watcher("GABC");
+    const failedHandler = vi.fn();
+    watcher.on("webhook.failed", failedHandler);
+
+    new WebhookDelivery(watcher, {
+      url: allowedUrl,
+      secret: "top-secret",
+      retries: 1,
+      urlValidator: async (url) =>
+        url === allowedUrl ? "blocked by custom validator" : null,
+    });
+
+    watcher.emit("*", deliveryEvent);
+    await flushAsyncWork();
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(failedHandler).toHaveBeenCalledTimes(1);
+    expect(failedHandler).toHaveBeenCalledWith(
+      expect.objectContaining({
+        raw: expect.objectContaining({
+          url: allowedUrl,
+          error: "blocked by custom validator",
+          attempts: 1,
+        }),
+      }),
+    );
+  });
+
   it("keeps delivering to other URLs when one URL fails", async () => {
     const failedUrl = "https://prod.example.com/webhooks/stellar";
     const successfulUrl = "https://audit.example.com/webhooks/stellar";

--- a/packages/pulse-webhooks/test/pulse-webhooks.test.ts
+++ b/packages/pulse-webhooks/test/pulse-webhooks.test.ts
@@ -99,7 +99,7 @@ describe("pulse-webhooks WebhookDelivery", () => {
     );
   });
 
-  it("rejects URL when custom urlValidator blocks an otherwise allowed URL", async () => {
+  it("rejects URL when custom urlValidator blocks an otherwise allowed URL without retrying", async () => {
     const allowedUrl = "https://prod.example.com/webhooks/stellar";
     const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200 });
     vi.stubGlobal("fetch", fetchMock);
@@ -111,7 +111,6 @@ describe("pulse-webhooks WebhookDelivery", () => {
     new WebhookDelivery(watcher, {
       url: allowedUrl,
       secret: "top-secret",
-      retries: 1,
       urlValidator: async (url) =>
         url === allowedUrl ? "blocked by custom validator" : null,
     });
@@ -130,6 +129,12 @@ describe("pulse-webhooks WebhookDelivery", () => {
         }),
       }),
     );
+
+    vi.advanceTimersByTime(10_000);
+    await flushAsyncWork();
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(failedHandler).toHaveBeenCalledTimes(1);
   });
 
   it("keeps delivering to other URLs when one URL fails", async () => {


### PR DESCRIPTION
Closes #401.

## What changed
- added `WebhookConfig.urlValidator?: (url) => Promise<string | null>`
- run the custom validator during delivery before fetch
- reject delivery when the custom validator returns an error message
- added a test covering a custom validator rejecting a URL the built-in flow otherwise allows

## Scope note
This PR is intentionally minimal and only adds the pluggable validator extension point requested in the issue.

## Verification
- `npx vitest run` in `packages/pulse-webhooks` passed
- `npx tsc -p tsconfig.json` in `packages/pulse-webhooks` fails due to pre-existing workspace/type-resolution issues (`@orbital/pulse-core`, Node globals like `Buffer`/`crypto`) not introduced by this change
