### PR TITLE
Add pulse-notify connection status indicator

### DIFF
--- a/apps/web/content/api/pulse-notify.md
+++ b/apps/web/content/api/pulse-notify.md
@@ -104,6 +104,27 @@ import { useStellarActivity } from "@orbital/pulse-notify";
 const { event, connected } = useStellarActivity(serverUrl, address);
 ```
 
+## StellarConnectionStatus
+
+Small status indicator that opens its own `EventSource` and renders connection health without requiring consumers to wire `connected` and `error` state.
+
+```tsx
+"use client";
+import { StellarConnectionStatus } from "@orbital/pulse-notify";
+
+<StellarConnectionStatus serverUrl={serverUrl} address={address} />;
+```
+
+The component sets `data-status` to `connecting`, `connected`, or `error`, and applies classes such as `stellar-connection-status--connected`. Built-in inline styles read CSS custom properties, so apps can theme it without importing a CSS file:
+
+```css
+.stellar-connection-status {
+  --stellar-connection-status-connected-color: #16a34a;
+  --stellar-connection-status-error-color: #dc2626;
+  --stellar-connection-status-padding: 0.35rem 0.65rem;
+}
+```
+
 ## Type narrowing
 
 Pass a narrower union as `T` to get full IDE support and avoid manual casts:

--- a/packages/pulse-notify/README.md
+++ b/packages/pulse-notify/README.md
@@ -77,6 +77,38 @@ Shorthand for payments received. Equivalent to `useStellarEvent(serverUrl, addre
 
 Shorthand for all events on an address. Equivalent to `useStellarEvent(serverUrl, address, { event: "*" })`.
 
+### `<StellarConnectionStatus serverUrl address />`
+
+Small client-side status indicator for places that need connection health but do not need to wire `connected` and `error` state by hand.
+
+```tsx
+"use client";
+import { StellarConnectionStatus } from "@orbital/pulse-notify";
+
+export function HeaderConnection({ address }: { address: string }) {
+  return (
+    <StellarConnectionStatus
+      serverUrl={process.env.NEXT_PUBLIC_ORBITAL_URL!}
+      address={address}
+    />
+  );
+}
+```
+
+The indicator owns its `EventSource` lifecycle and sets `data-status` to `connecting`, `connected`, or `error`. It also adds state classes such as `stellar-connection-status--connected`.
+
+Customize the built-in styles with CSS custom properties:
+
+```css
+.stellar-connection-status {
+  --stellar-connection-status-background: color-mix(in srgb, currentColor 10%, transparent);
+  --stellar-connection-status-padding: 0.35rem 0.65rem;
+  --stellar-connection-status-connected-color: #16a34a;
+  --stellar-connection-status-error-color: #dc2626;
+  --stellar-connection-status-dot-size: 0.55rem;
+}
+```
+
 ## Return shape
 
 ```ts

--- a/packages/pulse-notify/src/StellarConnectionStatus.tsx
+++ b/packages/pulse-notify/src/StellarConnectionStatus.tsx
@@ -1,0 +1,140 @@
+import { createElement, useEffect, useMemo, useState } from "react";
+import type {
+  ComponentPropsWithoutRef,
+  CSSProperties,
+  ReactElement,
+} from "react";
+
+export type StellarConnectionStatusState =
+  | "connecting"
+  | "connected"
+  | "error";
+
+export type StellarConnectionStatusLabels = Partial<
+  Record<StellarConnectionStatusState, string>
+>;
+
+export type StellarConnectionStatusProps = Omit<
+  ComponentPropsWithoutRef<"span">,
+  "children"
+> & {
+  serverUrl: string;
+  address: string;
+  token?: string;
+  labels?: StellarConnectionStatusLabels;
+};
+
+const DEFAULT_LABELS: Record<StellarConnectionStatusState, string> = {
+  connecting: "Connecting",
+  connected: "Connected",
+  error: "Retrying",
+};
+
+const STATUS_COLORS: Record<StellarConnectionStatusState, string> = {
+  connecting: "#b45309",
+  connected: "#047857",
+  error: "#b91c1c",
+};
+
+function eventSourceUrl(serverUrl: string, address: string, token?: string) {
+  const base = `${serverUrl}/events/${address}`;
+  return token ? `${base}?token=${encodeURIComponent(token)}` : base;
+}
+
+export function StellarConnectionStatus({
+  serverUrl,
+  address,
+  token,
+  labels,
+  className,
+  style,
+  "aria-label": ariaLabel,
+  ...spanProps
+}: StellarConnectionStatusProps): ReactElement {
+  const [status, setStatus] =
+    useState<StellarConnectionStatusState>("connecting");
+
+  useEffect(() => {
+    if (!serverUrl || !address) {
+      setStatus("error");
+      return;
+    }
+
+    setStatus("connecting");
+
+    const source = new EventSource(eventSourceUrl(serverUrl, address, token));
+
+    source.onopen = () => {
+      setStatus("connected");
+    };
+
+    source.onerror = () => {
+      setStatus("error");
+    };
+
+    return () => {
+      source.close();
+    };
+  }, [serverUrl, address, token]);
+
+  const label = labels?.[status] ?? DEFAULT_LABELS[status];
+  const statusClassName = [
+    "stellar-connection-status",
+    `stellar-connection-status--${status}`,
+    className,
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  const rootStyle = useMemo<CSSProperties>(
+    () => ({
+      alignItems: "center",
+      background: `var(--stellar-connection-status-${status}-background, var(--stellar-connection-status-background, transparent))`,
+      border: `var(--stellar-connection-status-${status}-border, var(--stellar-connection-status-border, 1px solid currentColor))`,
+      borderRadius: "var(--stellar-connection-status-radius, 999px)",
+      color: `var(--stellar-connection-status-${status}-color, var(--stellar-connection-status-color, ${STATUS_COLORS[status]}))`,
+      display: "inline-flex",
+      fontSize: "var(--stellar-connection-status-font-size, 0.875rem)",
+      fontWeight: "var(--stellar-connection-status-font-weight, 500)",
+      gap: "var(--stellar-connection-status-gap, 0.375rem)",
+      lineHeight: "var(--stellar-connection-status-line-height, 1)",
+      padding: "var(--stellar-connection-status-padding, 0.25rem 0.5rem)",
+      ...style,
+    }),
+    [status, style]
+  );
+
+  const dotStyle = useMemo<CSSProperties>(
+    () => ({
+      background: `var(--stellar-connection-status-${status}-dot-color, var(--stellar-connection-status-dot-color, currentColor))`,
+      borderRadius: "999px",
+      display: "inline-block",
+      height: "var(--stellar-connection-status-dot-size, 0.5rem)",
+      width: "var(--stellar-connection-status-dot-size, 0.5rem)",
+    }),
+    [status]
+  );
+
+  return createElement(
+    "span",
+    {
+      ...spanProps,
+      "aria-label": ariaLabel ?? `Stellar connection ${label}`,
+      "aria-live": spanProps["aria-live"] ?? "polite",
+      className: statusClassName,
+      "data-status": status,
+      role: spanProps.role ?? "status",
+      style: rootStyle,
+    },
+    createElement("span", {
+      "aria-hidden": true,
+      className: "stellar-connection-status__dot",
+      style: dotStyle,
+    }),
+    createElement(
+      "span",
+      { className: "stellar-connection-status__label" },
+      label
+    )
+  );
+}

--- a/packages/pulse-notify/src/index.ts
+++ b/packages/pulse-notify/src/index.ts
@@ -114,3 +114,10 @@ export function useStellarPayment(serverUrl: string, address: string) {
 export function useStellarActivity(serverUrl: string, address: string) {
   return useStellarEvent(serverUrl, address, { event: "*" });
 }
+
+export {
+  StellarConnectionStatus,
+  type StellarConnectionStatusLabels,
+  type StellarConnectionStatusProps,
+  type StellarConnectionStatusState,
+} from "./StellarConnectionStatus.js";

--- a/packages/pulse-notify/tsconfig.json
+++ b/packages/pulse-notify/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
+    "jsx": "react-jsx",
     "outDir": "./dist",
     "rootDir": "./src"
   },


### PR DESCRIPTION
## Summary
- add `StellarConnectionStatus` for connection health without consumer wiring
- expose state classes, `data-status`, accessible status text, and CSS variable styling hooks
- document usage in the package README and API docs

Closes #416

## Verification
- `pnpm --filter @orbital/pulse-core run build`
- `pnpm --filter @orbital/pulse-notify run build`
- `pnpm build`
- `pnpm test`
- `git diff --check`
- `git diff --cached --check`