### PR TITLE
perf(pulse-notify): add 5 kB gzip bundle-size budget with CI gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,29 @@ jobs:
       - name: Test packages
         run: pnpm -r --if-present test
 
+  bundle-size:
+    needs: changes
+    if: ${{ needs.changes.outputs.packages == 'true' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v6
+        with:
+          version: 10
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - name: Build pulse-core
+        run: pnpm tsc -p packages/pulse-core/tsconfig.json
+      - name: Build pulse-notify
+        run: pnpm tsc -p packages/pulse-notify/tsconfig.json
+      - name: Check bundle size
+        run: pnpm --filter @orbital/pulse-notify size
+
   typecheck-web:
     needs: changes
     if: ${{ needs.changes.outputs.web == 'true' }}

--- a/packages/pulse-notify/.size-limit.json
+++ b/packages/pulse-notify/.size-limit.json
@@ -1,0 +1,7 @@
+[
+  {
+    "path": "dist/index.js",
+    "limit": "5 kB",
+    "gzip": true
+  }
+]

--- a/packages/pulse-notify/package.json
+++ b/packages/pulse-notify/package.json
@@ -7,14 +7,17 @@
   "types": "./dist/index.d.ts",
   "scripts": {
     "build": "tsc -p tsconfig.json",
-    "test": "tsx test/connectionPool.test.ts"
+    "test": "tsx test/connectionPool.test.ts",
+    "size": "size-limit"
   },
   "dependencies": {
     "@orbital/pulse-core": "workspace:*"
   },
   "devDependencies": {
+    "@size-limit/preset-small-lib": "^11.0.0",
     "@types/node": "^25.6.0",
     "@types/react": "^19.2.14",
+    "size-limit": "^11.0.0",
     "tsx": "^4.0.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
## Summary

- Adds `.size-limit.json` asserting `@orbital/pulse-notify` stays under **5 kB gzipped**
- Adds `size` script to `package.json` (`pnpm size`)
- Adds `bundle-size` CI job that builds the package and runs `size-limit`; fails if the budget is exceeded

Closes #428

## Test plan

- [ ] CI `bundle-size` job passes on this branch
- [ ] Artificially inflate `dist/index.js` to confirm the job fails correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)