### PR TITLE
dx(pulse-notify): expose amountStroop bigint on useStellarPayment

### DIFF
--- a/packages/pulse-notify/src/index.ts
+++ b/packages/pulse-notify/src/index.ts
@@ -100,15 +100,21 @@ export function useStellarEvent<T extends NormalizedEvent = NormalizedEvent>(
     // an array literal, which would otherwise be a new reference every render.
   }, [serverUrl, addr, eventKey, token]);
 
+
   return state;
 }
 
+type PaymentEvent = Extract<NormalizedEvent, { type: "payment.received" }>;
+
 export function useStellarPayment(serverUrl: string, address: string) {
-  return useStellarEvent<Extract<NormalizedEvent, { type: "payment.received" }>>(
-    serverUrl,
-    address,
-    { event: "payment.received" }
-  );
+  const base = useStellarEvent<PaymentEvent>(serverUrl, address, {
+    event: "payment.received",
+  });
+  const amountStroop: bigint | null =
+    base.event?.amount != null
+      ? BigInt(Math.round(parseFloat(base.event.amount) * 10_000_000))
+      : null;
+  return { ...base, amountStroop };
 }
 
 export function useStellarActivity(serverUrl: string, address: string) {


### PR DESCRIPTION
## Summary

- Adds `amountStroop: bigint | null` to the return value of `useStellarPayment`
- Computed as `BigInt(Math.round(parseFloat(event.amount) * 10_000_000))` (7-decimal Stellar stroops)
- Returns `null` when no payment event has been received yet
- Eliminates the repetitive manual conversion every consumer had to write

Closes #425

## Test plan

- [ ] `useStellarPayment(url, addr).amountStroop` is `null` before first event
- [ ] After a `payment.received` event with `amount: "10.5000000"`, `amountStroop === 105_000_000n`

🤖 Generated with [Claude Code](https://claude.com/claude-code)