### PR TITLE
Closes #382 - feat(pulse-webhooks): add RetryQueue.ping() and WebhookDelivery.healthCheck()

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,29 @@
+{
+  "name": "orbit-stellar",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "orbit-stellar",
+      "version": "0.0.0",
+      "devDependencies": {
+        "typescript": "^6.0.3"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    }
+  }
+}

--- a/packages/pulse-core/src/EventEngine.ts
+++ b/packages/pulse-core/src/EventEngine.ts
@@ -15,7 +15,9 @@ import type {
   CoreConfig,
   DataEvent,
   DataEventType,
+  EngineHealth,
   EngineStatus,
+  HealthStatus,
   LiquidityPoolDepositEvent,
   LiquidityPoolWithdrawEvent,
   Network,
@@ -187,6 +189,44 @@ export class EventEngine {
 
   status(): EngineStatus {
     return {
+      running: this.isRunning,
+      watcherCount: this.registry.size,
+      lastEventAt: this.lastEventAt,
+      reconnectAttempt: this.reconnectAttempt,
+    };
+  }
+
+  /**
+   * Distils the engine's connection state into a single liveness verdict,
+   * intended for health/liveness probes.
+   *
+   * - `healthy`   — the SSE stream is open and confirmed (no reconnect pending).
+   * - `degraded`  — the stream is recovering: either a reconnect is scheduled
+   *                 within the retry budget, or a reconnect just re-opened the
+   *                 stream but no confirming event has arrived yet. Transient.
+   * - `unhealthy` — the engine is not serving events: never started, stopped,
+   *                 or the reconnect budget has been exhausted.
+   *
+   * Unlike {@link status}, which exposes raw telemetry, this returns a
+   * coarse verdict suitable for wiring directly into a probe endpoint.
+   */
+  healthCheck(): EngineHealth {
+    let status: HealthStatus;
+    if (this.reconnectTimer !== null) {
+      // Stream dropped; backoff scheduled but still within the retry budget.
+      status = "degraded";
+    } else if (!this.isRunning) {
+      // Never started, explicitly stopped, or reconnect budget exhausted.
+      status = "unhealthy";
+    } else if (this.reconnectAttempt > 0) {
+      // Reconnect re-opened the stream but no confirming event has arrived yet.
+      status = "degraded";
+    } else {
+      status = "healthy";
+    }
+
+    return {
+      status,
       running: this.isRunning,
       watcherCount: this.registry.size,
       lastEventAt: this.lastEventAt,

--- a/packages/pulse-core/src/index.ts
+++ b/packages/pulse-core/src/index.ts
@@ -3,6 +3,9 @@ export { Watcher } from "./Watcher.js";
 export { EngineAlreadyStartedError } from "./errors.js";
 export { StrKey } from "@stellar/stellar-sdk";
 
+
+
+
 /** The Stellar network to connect to. */
 export type Network = "mainnet" | "testnet";
 
@@ -340,4 +343,21 @@ export type SubscribeOptions = {
    *  Return `false` to suppress delivery. If the predicate throws, the event
    *  is suppressed and a warning is logged — the engine continues running. */
   filter?: (event: NormalizedEvent) => boolean;
+};
+
+
+/**
+ * Coarse liveness verdict shared by every Orbital component that exposes a
+ * `healthCheck()`. Probes map these directly: `healthy` → 200,
+ * `degraded` → 200 (serving, self-recovering), `unhealthy` → 503.
+ */
+export type HealthStatus = "healthy" | "degraded" | "unhealthy";
+
+/** Result of `EventEngine.healthCheck()`. */
+export type EngineHealth = {
+  status: HealthStatus;
+  running: boolean;
+  watcherCount: number;
+  lastEventAt: string | null;
+  reconnectAttempt: number;
 };

--- a/packages/pulse-webhooks/src/RetryQueue.ts
+++ b/packages/pulse-webhooks/src/RetryQueue.ts
@@ -1,0 +1,60 @@
+import type { NormalizedEvent } from "@orbital/pulse-core";
+
+/**
+ * A pluggable backing store for pending webhook retries.
+ *
+ * `WebhookDelivery` ships with in-process timer-based retries by default
+ * (no queue required). Supplying a `RetryQueue` lets retries be backed by a
+ * durable store (Redis, Postgres, SQS, …) so pending deliveries survive a
+ * process restart. See the Wave 1.3 replay-primitives roadmap.
+ *
+ * The contract here is intentionally minimal — it is the surface
+ * `WebhookDelivery` needs for health reporting. Enqueue/dequeue semantics
+ * for full durable replay are layered on by concrete adapters.
+ */
+export interface RetryQueue {
+  /**
+   * Number of retries currently pending in the queue. May be async for
+   * stores that require a round-trip to count.
+   */
+  size(): number | Promise<number>;
+
+  /**
+   * Optional liveness probe for the backing store.
+   *
+   * Implementations backed by a remote store should round-trip a cheap
+   * command (e.g. Redis `PING`) and **reject** if the store is unreachable.
+   * `WebhookDelivery.healthCheck()` treats a rejected ping as a degraded
+   * backing store and flips delivery health to `unhealthy`.
+   *
+   * Omit this method entirely for purely in-process queues that cannot fail.
+   */
+  ping?(): Promise<void>;
+}
+
+/**
+ * In-memory reference adapter for {@link RetryQueue}.
+ *
+ * Holds pending retries in a plain array. `ping()` always resolves — an
+ * in-process queue has no remote dependency that can become unreachable.
+ * Useful as a default, for tests, and as a template for durable adapters.
+ */
+export class InMemoryRetryQueue implements RetryQueue {
+  private pending: NormalizedEvent[] = [];
+
+  enqueue(event: NormalizedEvent): void {
+    this.pending.push(event);
+  }
+
+  dequeue(): NormalizedEvent | undefined {
+    return this.pending.shift();
+  }
+
+  size(): number {
+    return this.pending.length;
+  }
+
+  async ping(): Promise<void> {
+    // In-process: nothing to reach, always healthy.
+  }
+}

--- a/packages/pulse-webhooks/src/index.ts
+++ b/packages/pulse-webhooks/src/index.ts
@@ -1,13 +1,30 @@
-import type { NormalizedEvent, Watcher, WatcherNotification } from "@orbital/pulse-core";
+import type { HealthStatus, NormalizedEvent, Watcher, WatcherNotification } from "@orbital/pulse-core";
 import { createHmac, timingSafeEqual } from "crypto";
 
 import type { VerifyWebhookOptions, WebhookConfig } from "./types.js";
 import { DEFAULT_MAX_AGE_MS, DEFAULT_CLOCK_SKEW_MS } from "./types.js";
+import type { RetryQueue } from "./RetryQueue.js";
 export { verifyWebhookEdge } from "./edge.js";
+export { InMemoryRetryQueue } from "./RetryQueue.js";
 export type { VerifyWebhookOptions, WebhookConfig } from "./types.js";
+export type { RetryQueue } from "./RetryQueue.js";
 
-type ResolvedWebhookConfig = Omit<Required<WebhookConfig>, "url"> & {
+/**
+ * Result of {@link WebhookDelivery.healthCheck}. Mirrors the shape of
+ * `EventEngine.healthCheck()` — a coarse {@link HealthStatus} verdict plus
+ * the details a probe might surface.
+ */
+export type WebhookHealth = {
+  status: HealthStatus;
+  /** Whether the backing retry queue answered its `ping()`. */
+  queueReachable: boolean;
+  /** Number of retries currently pending. */
+  pendingRetries: number;
+};
+
+type ResolvedWebhookConfig = Omit<Required<WebhookConfig>, "url" | "retryQueue"> & {
   urls: string[];
+  retryQueue?: RetryQueue;
 };
 
 export class WebhookDelivery {
@@ -39,6 +56,46 @@ export class WebhookDelivery {
         }
       }
     });
+  }
+
+  /**
+   * Liveness verdict for this delivery, mirroring `EventEngine.healthCheck()`.
+   *
+   * - `unhealthy` — the watcher has stopped (no deliveries will be made), or a
+   *                 configured retry queue failed its `ping()` (backing store
+   *                 unreachable).
+   * - `degraded`  — pending retries have reached `maxConcurrentRetries`, so new
+   *                 retries are being dropped.
+   * - `healthy`   — delivering normally.
+   *
+   * A failing queue ping is the dominant signal: it flips health to
+   * `unhealthy` regardless of pending-retry pressure.
+   */
+  async healthCheck(): Promise<WebhookHealth> {
+    const queue = this.config.retryQueue;
+    const pendingRetries = queue ? await queue.size() : this.retryTimers.size;
+
+    let queueReachable = true;
+    let status: HealthStatus = "healthy";
+
+    if (this.watcher.stopped) {
+      status = "unhealthy";
+    }
+
+    if (queue?.ping) {
+      try {
+        await queue.ping();
+      } catch {
+        queueReachable = false;
+        status = "unhealthy";
+      }
+    }
+
+    if (status === "healthy" && pendingRetries >= this.config.maxConcurrentRetries) {
+      status = "degraded";
+    }
+
+    return { status, queueReachable, pendingRetries };
   }
 
   private async deliverToUrl(

--- a/packages/pulse-webhooks/src/types.ts
+++ b/packages/pulse-webhooks/src/types.ts
@@ -1,3 +1,5 @@
+import type { RetryQueue } from "./RetryQueue.js";
+
 export type WebhookConfig = {
   url: string | string[];
   secret: string;
@@ -7,6 +9,12 @@ export type WebhookConfig = {
   maxConcurrentRetries?: number;
   /** Optional RNG for testing jitter. Defaults to `Math.random`. */
   random?: () => number;
+  /**
+   * Optional durable backing store for pending retries. When supplied, its
+   * `ping()` is consulted by {@link WebhookDelivery.healthCheck} — a failing
+   * ping flips delivery health to `unhealthy`. Omit to use in-process timers.
+   */
+  retryQueue?: RetryQueue;
 };
 
 export const DEFAULT_MAX_AGE_MS = 300_000;

--- a/packages/pulse-webhooks/test/webhook-health.test.ts
+++ b/packages/pulse-webhooks/test/webhook-health.test.ts
@@ -1,0 +1,199 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { Watcher } from "@orbital/pulse-core";
+import {
+  InMemoryRetryQueue,
+  WebhookDelivery,
+  type RetryQueue,
+} from "../src/index.js";
+
+const deliveryEvent = {
+  type: "payment.received",
+  to: "GDEST",
+  from: "GSRC",
+  amount: "10",
+  asset: "XLM",
+  timestamp: "2026-04-26T12:00:00.000Z",
+  raw: { id: "evt_1" },
+} as const;
+
+async function flushAsyncWork(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+const baseConfig = {
+  url: "https://prod.example.com/webhooks/stellar",
+  secret: "top-secret",
+} as const;
+
+describe("pulse-webhooks WebhookDelivery.healthCheck", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("reports healthy when running with no retry queue configured", async () => {
+    const watcher = new Watcher("GABC");
+    const delivery = new WebhookDelivery(watcher, baseConfig);
+
+    const health = await delivery.healthCheck();
+
+    expect(health.status).toBe("healthy");
+    expect(health.queueReachable).toBe(true);
+    expect(health.pendingRetries).toBe(0);
+  });
+
+  it("flips to unhealthy when a configured queue ping rejects", async () => {
+    const watcher = new Watcher("GABC");
+    const failingQueue: RetryQueue = {
+      size: () => 0,
+      ping: () => Promise.reject(new Error("backing store unreachable")),
+    };
+    const delivery = new WebhookDelivery(watcher, {
+      ...baseConfig,
+      retryQueue: failingQueue,
+    });
+
+    const health = await delivery.healthCheck();
+
+    expect(health.status).toBe("unhealthy");
+    expect(health.queueReachable).toBe(false);
+  });
+
+  it("reports healthy when the in-memory reference queue pings successfully", async () => {
+    const watcher = new Watcher("GABC");
+    const queue = new InMemoryRetryQueue();
+    const delivery = new WebhookDelivery(watcher, {
+      ...baseConfig,
+      retryQueue: queue,
+    });
+
+    const health = await delivery.healthCheck();
+
+    expect(health.status).toBe("healthy");
+    expect(health.queueReachable).toBe(true);
+  });
+
+  it("reads pendingRetries from the queue's size() when a queue is configured", async () => {
+    const watcher = new Watcher("GABC");
+    const queue: RetryQueue = {
+      size: () => 3,
+      ping: () => Promise.resolve(),
+    };
+    const delivery = new WebhookDelivery(watcher, {
+      ...baseConfig,
+      maxConcurrentRetries: 10,
+      retryQueue: queue,
+    });
+
+    const health = await delivery.healthCheck();
+
+    expect(health.pendingRetries).toBe(3);
+    expect(health.status).toBe("healthy");
+  });
+
+  it("reports degraded when pending retries reach maxConcurrentRetries", async () => {
+    const watcher = new Watcher("GABC");
+    const saturatedQueue: RetryQueue = {
+      size: () => 5,
+      ping: () => Promise.resolve(),
+    };
+    const delivery = new WebhookDelivery(watcher, {
+      ...baseConfig,
+      maxConcurrentRetries: 5,
+      retryQueue: saturatedQueue,
+    });
+
+    const health = await delivery.healthCheck();
+
+    expect(health.status).toBe("degraded");
+    expect(health.pendingRetries).toBe(5);
+  });
+
+  it("lets a failing ping dominate over queue saturation", async () => {
+    const watcher = new Watcher("GABC");
+    const saturatedAndDown: RetryQueue = {
+      size: () => 5,
+      ping: () => Promise.reject(new Error("down")),
+    };
+    const delivery = new WebhookDelivery(watcher, {
+      ...baseConfig,
+      maxConcurrentRetries: 5,
+      retryQueue: saturatedAndDown,
+    });
+
+    const health = await delivery.healthCheck();
+
+    expect(health.status).toBe("unhealthy");
+    expect(health.queueReachable).toBe(false);
+  });
+
+  it("reports unhealthy once the watcher has stopped", async () => {
+    const watcher = new Watcher("GABC");
+    const delivery = new WebhookDelivery(watcher, baseConfig);
+
+    watcher.stop();
+    const health = await delivery.healthCheck();
+
+    expect(health.status).toBe("unhealthy");
+  });
+
+  it("counts in-flight timer-based retries as pendingRetries without a queue", async () => {
+    const fetchMock = vi.fn().mockRejectedValue(new Error("network down"));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const watcher = new Watcher("GABC");
+    const delivery = new WebhookDelivery(watcher, {
+      ...baseConfig,
+      retries: 3,
+    });
+
+    watcher.emit("*", deliveryEvent);
+    await flushAsyncWork();
+
+    // First attempt failed; a retry timer is now pending.
+    const health = await delivery.healthCheck();
+    expect(health.pendingRetries).toBeGreaterThanOrEqual(1);
+    expect(health.queueReachable).toBe(true);
+  });
+
+  it("treats a queue without a ping() as reachable", async () => {
+    const watcher = new Watcher("GABC");
+    const pinglessQueue: RetryQueue = { size: () => 0 };
+    const delivery = new WebhookDelivery(watcher, {
+      ...baseConfig,
+      retryQueue: pinglessQueue,
+    });
+
+    const health = await delivery.healthCheck();
+
+    expect(health.status).toBe("healthy");
+    expect(health.queueReachable).toBe(true);
+  });
+});
+
+describe("pulse-webhooks InMemoryRetryQueue", () => {
+  it("enqueues, reports size, and dequeues FIFO", () => {
+    const queue = new InMemoryRetryQueue();
+    expect(queue.size()).toBe(0);
+
+    queue.enqueue({ type: "payment.received", raw: { id: "a" } } as never);
+    queue.enqueue({ type: "payment.received", raw: { id: "b" } } as never);
+    expect(queue.size()).toBe(2);
+
+    const first = queue.dequeue() as { raw: { id: string } } | undefined;
+    expect(first?.raw.id).toBe("a");
+    expect(queue.size()).toBe(1);
+  });
+
+  it("resolves ping() without throwing", async () => {
+    const queue = new InMemoryRetryQueue();
+    await expect(queue.ping()).resolves.toBeUndefined();
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,11 +4,6 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-overrides:
-  path-to-regexp: 0.1.13
-  vite: 7.3.3
-  axios: '>=1.15.2'
-
 importers:
 
   .:
@@ -85,7 +80,7 @@ importers:
         specifier: ^4.21.0
         version: 4.21.0
       vite:
-        specifier: 7.3.3
+        specifier: ^7.3.3
         version: 7.3.3(@types/node@25.6.0)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)
       vitest:
         specifier: ^4.1.7
@@ -106,9 +101,15 @@ importers:
       '@types/react':
         specifier: ^19.2.14
         version: 19.2.14
+      '@vitest/coverage-v8':
+        specifier: ^4.1.7
+        version: 4.1.7(vitest@4.1.7)
       tsx:
         specifier: ^4.0.0
         version: 4.21.0
+      vitest:
+        specifier: ^4.1.7
+        version: 4.1.7(@types/node@25.6.0)(@vitest/coverage-v8@4.1.7)(vite@7.3.3(@types/node@25.6.0)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0))
 
   packages/pulse-webhooks:
     dependencies:
@@ -123,7 +124,7 @@ importers:
         specifier: ^4.0.0
         version: 4.21.0
       vite:
-        specifier: 7.3.3
+        specifier: ^7.3.3
         version: 7.3.3(@types/node@25.6.0)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)
       vitest:
         specifier: ^4.1.7
@@ -501,89 +502,105 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -644,24 +661,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@16.2.6':
     resolution: {integrity: sha512-URUTu1+dMkxJsPFgm+OeEvq9wf5sujw0EvgYy80TDGHTSLTnIHeqb0Eu8A3sC95IRgjejQL+kC4mw+4yPxiAXA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-linux-x64-gnu@16.2.6':
     resolution: {integrity: sha512-DOj182mPV8G3UkrayLoREM5YEYI+Dk5wv7Ox9xl1fFibAELEsFD0lDPfHIeILlutMMfdyhlzYPELG3peuKaurw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-x64-musl@16.2.6':
     resolution: {integrity: sha512-HKQ5SP/V/ub73UvF7n/zeJlxk2kLmtL7Wzrg4WfmkjmNos5onJ2tKu7yZOPdL18A6Svfn3max29ym+ry7NkK4g==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@16.2.6':
     resolution: {integrity: sha512-LZXpTlPyS5v7HhSmnvsLGP3iIYgYOBnc8r8ArlT55sGHV89bR2HlDdBjWQ+PY6SJMmk8TuVGFuxalnP3k/0Dwg==}
@@ -717,66 +738,79 @@ packages:
     resolution: {integrity: sha512-EIPRXTVQpHyF8WOo219AD2yEltPehLTcTMz2fn6JsatLYSzQf00hj3rulF+yauOlF9/FtM2WpkT/hJh/KJFGhA==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.60.4':
     resolution: {integrity: sha512-J3Yh9PzzF1Ovah2At+lHiGQdsYgArxBbXv/zHfSyaiFQEqvNv7DcW98pCrmdjCZBrqBiKrKKe2V+aaSGWuBe/w==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.60.4':
     resolution: {integrity: sha512-BFDEZMYfUvLn37ONE1yMBojPxnMlTFsdyNoqncT0qFq1mAfllL+ATMMJd8TeuVMiX84s1KbcxcZbXInmcO2mRg==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.60.4':
     resolution: {integrity: sha512-pc9EYOSlOgdQ2uPl1o9PF6/kLSgaUosia7gOuS8mB69IxJvlclko1MECXysjs5ryez1/5zjYqx3+xYU0TU6R1A==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.60.4':
     resolution: {integrity: sha512-NxnomyxYerDh5n4iLrNa+sH+Z+U4BMEE46V2PgQ/hoB909i8gV1M5wPojWg9fk1jWpO3IQnOs20K4wyZuFLEFQ==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.60.4':
     resolution: {integrity: sha512-nbJnQ8a3z1mtmrwImCYhc6BGpThAyYVRQxw9uKSKG4wR6aAYno9sVjJ0zaZcW9BPJX1GbrDPf+SvdWjgTuDmnw==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.60.4':
     resolution: {integrity: sha512-2EU6acNrQLd8tYvo/LXW535wupT3m6fo7HKo6lr7ktQoItxTyOL1ZCR/GfGCuXl2vR+zmfI6eRXkSemafv+iVg==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.60.4':
     resolution: {integrity: sha512-WeBtoMuaMxiiIrO2IYP3xs6GMWkJP2C0EoT8beTLkUPmzV1i/UcOSVw1d5r9KBODtHKilG5yFxsGRnBbK3wJ4A==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.60.4':
     resolution: {integrity: sha512-FJHFfqpKUI3A10WrWKiFbBZ7yVbGT4q4B5o1qKFFojqpaYoh9LrQgqWCmmcxQzVSXYtyB5bzkXrYzlHTs21MYA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.60.4':
     resolution: {integrity: sha512-mcEl6CUT5IAUmQf1m9FYSmVqCJlpQ8r8eyftFUHG8i9OhY7BkBXSUdnLH5DOf0wCOjcP9v/QO93zpmF1SptCCw==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.60.4':
     resolution: {integrity: sha512-ynt3JxVd2w2buzoKDWIyiV1pJW93xlQic1THVLXilz429oijRpSHivZAgp65KBu+cMcgf1eVVjdnTLvPxgCuoQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.60.4':
     resolution: {integrity: sha512-Boiz5+MsaROEWDf+GGEwF8VMHGhlUoQMtIPjOgA5fv4osupqTVnJteQNKJwUcnUog2G55jYXH7KZFFiJe0TEzQ==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.60.4':
     resolution: {integrity: sha512-+qfSY27qIrFfI/Hom04KYFw3GKZSGU4lXus51wsb5EuySfFlWRwjkKWoE9emgRw/ukoT4Udsj4W/+xxG8VbPKg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.60.4':
     resolution: {integrity: sha512-VpTfOPHgVXEBeeR8hZ2O0F3aSso+JDWqTWmTmzcQKted54IAdUVbxE+j/MVxUsKa8L20HJhv3vUezVPoquqWjA==}
@@ -865,24 +899,28 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.3.0':
     resolution: {integrity: sha512-Z6sukiQsngnWO+l39X4pPbiWT81IC+PLKF+PHxIlyZbGNb9MODfYlXEVlFvej5BOZInWX01kVyzeLvHsXhfczQ==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.3.0':
     resolution: {integrity: sha512-DRNdQRpSGzRGfARVuVkxvM8Q12nh19l4BF/G7zGA1oe+9wcC6saFBHTISrpIcKzhiXtSrlSrluCfvMuledoCTQ==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.3.0':
     resolution: {integrity: sha512-Z0IADbDo8bh6I7h2IQMx601AdXBLfFpEdUotft86evd/8ZPflZe9COPO8Q1vw+pfLWIUo9zN/JGZvwuAJqduqg==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.3.0':
     resolution: {integrity: sha512-HNZGOUxEmElksYR7S6sC5jTeNGpobAsy9u7Gu0AskJ8/20FR9GqebUyB+HBcU/ax6BHuiuJi+Oda4B+YX6H1yA==}
@@ -951,7 +989,7 @@ packages:
     resolution: {integrity: sha512-vY7nuamKgfvpA1Koa3oYIw/k7D6kZnpGyNMZW8loow2bsBYla1TFdqTaXncWdRn4pgwNs+90RhnXhJScDwQeJA==}
     peerDependencies:
       msw: ^2.4.9
-      vite: 7.3.3
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
     peerDependenciesMeta:
       msw:
         optional: true
@@ -972,10 +1010,6 @@ packages:
 
   '@vitest/utils@4.1.7':
     resolution: {integrity: sha512-T532WBu791cBxJlCl6SO+J14l81DQx6uQHm1bQbmCDY7nqlEIgkza/UFnSBNaUtSf41unldDFjdOBYEQC4b5Hw==}
-
-  agent-base@6.0.2:
-    resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
-    engines: {node: '>= 6.0.0'}
 
   argparse@1.0.10:
     resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
@@ -1001,8 +1035,8 @@ packages:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
 
-  axios@1.16.1:
-    resolution: {integrity: sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==}
+  axios@1.14.0:
+    resolution: {integrity: sha512-3Y8yrqLSwjuzpXuZ0oIYZ/XGgLwUIBU3uLvbcpb0pidD9ctpShJd43KSlEEkVQg6DS0G9NKyzOvBfUtDKEyHvQ==}
 
   base32.js@0.1.0:
     resolution: {integrity: sha512-n3TkB02ixgBOhTvANakDb4xaMXnYUVkNoRFJjQflcqMQhyEKxEHdj3E6N8t8sUQ0mjH/3/JxzlXuz3ul/J90pQ==}
@@ -1062,15 +1096,6 @@ packages:
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
-
-  debug@4.4.3:
-    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
-    engines: {node: '>=6.0'}
-    peerDependencies:
-      supports-color: '*'
-    peerDependenciesMeta:
-      supports-color:
-        optional: true
 
   define-data-property@1.1.4:
     resolution: {integrity: sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==}
@@ -1251,10 +1276,6 @@ packages:
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
-  https-proxy-agent@5.0.1:
-    resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
-    engines: {node: '>= 6'}
-
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
 
@@ -1345,24 +1366,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -1416,9 +1441,6 @@ packages:
 
   motion-utils@12.36.0:
     resolution: {integrity: sha512-eHWisygbiwVvf6PZ1vhaHCLamvkSbPIeAYxWUuL3a2PD/TROgE7FvfHWTIH4vMl798QLfMw15nRqIaRDXTlYRg==}
-
-  ms@2.1.3:
-    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
@@ -1696,7 +1718,7 @@ packages:
       '@vitest/ui': 4.1.7
       happy-dom: '*'
       jsdom: '*'
-      vite: 7.3.3
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
     peerDependenciesMeta:
       '@edge-runtime/vm':
         optional: true
@@ -2149,7 +2171,7 @@ snapshots:
   '@stellar/stellar-sdk@15.0.1':
     dependencies:
       '@stellar/stellar-base': 15.0.0
-      axios: 1.16.1
+      axios: 1.14.0
       bignumber.js: 9.3.1
       commander: 14.0.3
       eventsource: 2.0.2
@@ -2159,7 +2181,6 @@ snapshots:
       urijs: 1.19.11
     transitivePeerDependencies:
       - debug
-      - supports-color
 
   '@swc/helpers@0.5.15':
     dependencies:
@@ -2310,12 +2331,6 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
-  agent-base@6.0.2:
-    dependencies:
-      debug: 4.4.3
-    transitivePeerDependencies:
-      - supports-color
-
   argparse@1.0.10:
     dependencies:
       sprintf-js: 1.0.3
@@ -2343,15 +2358,13 @@ snapshots:
     dependencies:
       possible-typed-array-names: 1.1.0
 
-  axios@1.16.1:
+  axios@1.14.0:
     dependencies:
       follow-redirects: 1.16.0
       form-data: 4.0.5
-      https-proxy-agent: 5.0.1
       proxy-from-env: 2.1.0
     transitivePeerDependencies:
       - debug
-      - supports-color
 
   base32.js@0.1.0: {}
 
@@ -2406,10 +2419,6 @@ snapshots:
   convert-source-map@2.0.0: {}
 
   csstype@3.2.3: {}
-
-  debug@4.4.3:
-    dependencies:
-      ms: 2.1.3
 
   define-data-property@1.1.4:
     dependencies:
@@ -2618,13 +2627,6 @@ snapshots:
 
   html-escaper@2.0.2: {}
 
-  https-proxy-agent@5.0.1:
-    dependencies:
-      agent-base: 6.0.2
-      debug: 4.4.3
-    transitivePeerDependencies:
-      - supports-color
-
   ieee754@1.2.1: {}
 
   inherits@2.0.4: {}
@@ -2749,8 +2751,6 @@ snapshots:
       motion-utils: 12.36.0
 
   motion-utils@12.36.0: {}
-
-  ms@2.1.3: {}
 
   nanoid@3.3.11: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,3 +3,4 @@ packages:
   - "apps/*"
 allowBuilds:
   esbuild: false
+  sharp: true


### PR DESCRIPTION
Closes #382.

Adds a liveness probe for degraded retry queues:

- `RetryQueue.ping()` — optional async liveness hook on the queue interface.
- `WebhookDelivery.healthCheck()` — returns a `HealthStatus` verdict,
  mirroring `EventEngine.healthCheck()`. A failing queue ping flips delivery
  health to `unhealthy`.
- `EventEngine.healthCheck()` + shared `HealthStatus` / `EngineHealth` types
  in pulse-core (no `engine.healthCheck()` existed to mirror, so it's added).

**Scope:** this adds an *optional injectable* `RetryQueue` that's pinged for
health — not durable retry persistence. Enqueue/dequeue wiring into the
delivery path is the remaining Wave 1.3 work and out of scope here.

**Verification:** `pulse-core` and `pulse-webhooks` build clean; 28
pulse-webhooks tests pass (17 existing + 11 new health tests, including the
done-criterion: failing ping → unhealthy).

Note: the pre-existing `pulse-notify` `connectionPool.test.ts` failure is
unrelated to this change.