### PR TITLE
Closes #399 - feat(pulse-webhooks): add OtelWebhookMetrics adapter (#399)

### DIFF
--- a/apps/web/content/api/metrics.md
+++ b/apps/web/content/api/metrics.md
@@ -1,0 +1,80 @@
+# Webhook delivery metrics
+
+`@orbital/pulse-webhooks` can emit delivery metrics through a pluggable
+[`WebhookMetrics`](../packages/pulse-webhooks/src/metrics.ts) sink. The package
+ships one reference adapter — `OtelWebhookMetrics`, backed by OpenTelemetry —
+and a `NoopWebhookMetrics` default so delivery works unchanged when no sink is
+configured.
+
+```ts
+import { metrics } from "@opentelemetry/api";
+import { WebhookDelivery, OtelWebhookMetrics } from "@orbital/pulse-webhooks";
+
+const meter = metrics.getMeter("orbital-pulse-webhooks");
+
+const delivery = new WebhookDelivery(watcher, {
+  url: "https://hooks.example.com/stellar",
+  secret: process.env.WEBHOOK_SECRET!,
+  metrics: new OtelWebhookMetrics(meter),
+});
+```
+
+Wiring the meter up to an OTLP exporter (so the metrics reach a collector) is
+the operator's responsibility and is standard OpenTelemetry setup — see the
+`@opentelemetry/sdk-metrics` docs. The adapter only needs a `Meter`.
+
+## Instruments
+
+| Instrument                  | Kind      | Unit | Description                                            |
+|-----------------------------|-----------|------|--------------------------------------------------------|
+| `webhook.deliveries`        | Counter   | `1`  | Terminal delivery outcomes, split by the `outcome` attribute. |
+| `webhook.delivery.duration` | Histogram | `s`  | Latency of successful deliveries, in **seconds**.      |
+| `webhook.retries`           | Counter   | `1`  | Retries scheduled after a transient failure.           |
+
+A single `webhook.deliveries` counter covers every terminal state via the
+`outcome` attribute (`delivered` / `failed` / `dropped`) rather than three
+separate counters. Sum it for total terminal deliveries, or split by `outcome`
+for a success-rate panel.
+
+## Attribute conventions
+
+All instruments carry these attributes. They are deliberately **low
+cardinality** — every value is bounded by the event-type union or a hostname,
+never by an unbounded identifier.
+
+| Attribute    | On                                | Values                                  |
+|--------------|-----------------------------------|-----------------------------------------|
+| `outcome`    | `webhook.deliveries`              | `delivered`, `failed`, `dropped`        |
+| `host`       | all                               | Host of the target URL (e.g. `hooks.example.com`) |
+| `event.type` | all                               | Normalized event type (e.g. `payment.received`) |
+| `attempt`    | `webhook.retries`                 | 1-based attempt number                  |
+
+### What is deliberately excluded, and why
+
+- **The full target URL.** Only the `host` is recorded. URLs can embed
+  credentials or signed tokens in the path/query; emitting them as a metric
+  label would leak secrets into your metrics backend. The host is enough to
+  attribute traffic to a destination.
+- **The event payload and account addresses.** These are unbounded and would
+  explode time-series cardinality, degrading the metrics backend. Per-event
+  detail belongs in logs/traces, not metric labels.
+- **`attempt` on the success and failure counters.** Attempt number is only
+  attached to `webhook.retries`, where it is meaningful and stays small
+  (bounded by `config.retries`). Putting it on every counter would multiply
+  the series count for little value.
+
+### Unit note: seconds vs milliseconds
+
+The `WebhookMetrics` interface reports durations in **milliseconds** (matching
+the rest of the codebase — `deliveryTimeoutMs`, `maxAgeMs`). The OTel adapter
+converts to **seconds** when recording the histogram, because OpenTelemetry's
+duration convention is seconds, and dashboards that overlay these metrics with
+other OTel-instrumented services expect seconds. If you implement your own
+`WebhookMetrics` adapter and prefer milliseconds, record `durationMs` directly.
+
+## Writing your own adapter
+
+`WebhookMetrics` is backend-agnostic. A Prometheus adapter, for instance, would
+implement the same four methods against `prom-client` counters and a histogram,
+following the same attribute conventions above so dashboards stay portable
+across backends.

--- a/packages/pulse-webhooks/package.json
+++ b/packages/pulse-webhooks/package.json
@@ -10,9 +10,11 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "@opentelemetry/api": "^1.9.1",
     "@orbital/pulse-core": "workspace:*"
   },
   "devDependencies": {
+    "@opentelemetry/sdk-metrics": "^1.30.1",
     "@types/node": "^25.6.0",
     "tsx": "^4.0.0",
     "vite": "^7.3.3",

--- a/packages/pulse-webhooks/src/OtelWebhookMetrics.ts
+++ b/packages/pulse-webhooks/src/OtelWebhookMetrics.ts
@@ -1,0 +1,89 @@
+import type { Counter, Histogram, Meter, Attributes } from "@opentelemetry/api";
+
+import type { DeliveryAttributes, WebhookMetrics } from "./metrics.js";
+
+/**
+ * OpenTelemetry reference adapter for {@link WebhookMetrics}.
+ *
+ * Construct it with a `Meter` (from `@opentelemetry/api`) and pass it to
+ * `WebhookDelivery` via `config.metrics`. The adapter creates its instruments
+ * once in the constructor and reuses them, as recommended by the OTel spec.
+ *
+ * ```ts
+ * import { metrics } from "@opentelemetry/api";
+ * const meter = metrics.getMeter("orbital-pulse-webhooks");
+ * const delivery = new WebhookDelivery(watcher, {
+ *   url, secret,
+ *   metrics: new OtelWebhookMetrics(meter),
+ * });
+ * ```
+ *
+ * ## Instruments
+ *
+ * | Instrument                  | Kind      | Unit | Attributes                       |
+ * |-----------------------------|-----------|------|----------------------------------|
+ * | `webhook.deliveries`        | Counter   | `1`  | `outcome`, `host`, `event.type`  |
+ * | `webhook.delivery.duration` | Histogram | `s`  | `host`, `event.type`             |
+ * | `webhook.retries`           | Counter   | `1`  | `host`, `event.type`, `attempt`  |
+ *
+ * The `outcome` attribute on `webhook.deliveries` is one of `delivered`,
+ * `failed`, or `dropped`, so a single counter covers every terminal state and
+ * can be summed or split by outcome at query time.
+ *
+ * Durations are recorded in **seconds** to match OpenTelemetry's duration
+ * convention, even though the interface hands them over in milliseconds.
+ *
+ * See `docs/metrics.md` for the full attribute conventions and the rationale
+ * for excluding the full URL and payload.
+ */
+export class OtelWebhookMetrics implements WebhookMetrics {
+  private readonly deliveries: Counter;
+  private readonly duration: Histogram;
+  private readonly retries: Counter;
+
+  constructor(meter: Meter) {
+    this.deliveries = meter.createCounter("webhook.deliveries", {
+      description:
+        "Count of terminal webhook delivery outcomes, split by `outcome`.",
+      unit: "1",
+    });
+    this.duration = meter.createHistogram("webhook.delivery.duration", {
+      description: "Latency of successful webhook deliveries.",
+      unit: "s",
+    });
+    this.retries = meter.createCounter("webhook.retries", {
+      description: "Count of scheduled webhook delivery retries.",
+      unit: "1",
+    });
+  }
+
+  onDelivered(durationMs: number, attrs: DeliveryAttributes): void {
+    const a = base(attrs);
+    this.deliveries.add(1, { ...a, outcome: "delivered" });
+    // Interface reports ms; OTel duration convention is seconds.
+    this.duration.record(durationMs / 1000, a);
+  }
+
+  onFailed(attrs: DeliveryAttributes): void {
+    this.deliveries.add(1, { ...base(attrs), outcome: "failed" });
+  }
+
+  onDropped(attrs: DeliveryAttributes): void {
+    this.deliveries.add(1, { ...base(attrs), outcome: "dropped" });
+  }
+
+  onRetry(attrs: DeliveryAttributes): void {
+    this.retries.add(1, { ...base(attrs), attempt: attrs.attempt });
+  }
+}
+
+/**
+ * Map the provider-agnostic attribute names to OTel attribute keys. Keeping
+ * this mapping in one place is what makes the conventions doc enforceable.
+ */
+function base(attrs: DeliveryAttributes): Attributes {
+  return {
+    host: attrs.host,
+    "event.type": attrs.eventType,
+  };
+}

--- a/packages/pulse-webhooks/src/index.ts
+++ b/packages/pulse-webhooks/src/index.ts
@@ -3,7 +3,12 @@ import { createHmac, timingSafeEqual } from "crypto";
 
 import type { VerifyWebhookOptions, WebhookConfig } from "./types.js";
 import { DEFAULT_MAX_AGE_MS, DEFAULT_CLOCK_SKEW_MS } from "./types.js";
+import type { WebhookMetrics, DeliveryAttributes } from "./metrics.js";
+import { NoopWebhookMetrics, hostOf } from "./metrics.js";
 export { verifyWebhookEdge } from "./edge.js";
+export { OtelWebhookMetrics } from "./OtelWebhookMetrics.js";
+export { NoopWebhookMetrics } from "./metrics.js";
+export type { WebhookMetrics, DeliveryAttributes } from "./metrics.js";
 export type { VerifyWebhookOptions, WebhookConfig } from "./types.js";
 
 type ResolvedWebhookConfig = Omit<Required<WebhookConfig>, "url"> & {
@@ -23,6 +28,7 @@ export class WebhookDelivery {
       deliveryTimeoutMs: 10000,
       maxConcurrentRetries: 100,
       random: Math.random,
+      metrics: NoopWebhookMetrics,
       ...config,
       urls: Array.isArray(config.url) ? [...config.url] : [config.url],
     };
@@ -48,6 +54,13 @@ export class WebhookDelivery {
   ): Promise<void> {
     if (this.watcher.stopped) return;
 
+    const startedAt = Date.now();
+    const attrs: DeliveryAttributes = {
+      host: hostOf(url),
+      eventType: event.type,
+      attempt,
+    };
+
     const payload = JSON.stringify(event);
     const timestamp = Date.now().toString();
     const signature = this.sign(payload, timestamp);
@@ -69,6 +82,8 @@ export class WebhookDelivery {
       });
 
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
+
+      this.config.metrics.onDelivered(Date.now() - startedAt, attrs);
     } catch (err) {
       if (this.watcher.stopped) return;
 
@@ -91,6 +106,11 @@ export class WebhookDelivery {
               originalEvent: newest.event,
             },
           } as unknown as NormalizedEvent);
+          this.config.metrics.onDropped({
+            host: hostOf(newest.url),
+            eventType: newest.event.type,
+            attempt,
+          });
         }
 
         const exponentialDelay = Math.pow(2, attempt - 1) * 1000;
@@ -100,6 +120,7 @@ export class WebhookDelivery {
           void this.deliverToUrl(event, url, attempt + 1);
         }, delay);
         this.retryTimers.set(retryTimer, { event, url });
+        this.config.metrics.onRetry(attrs);
       } else {
         this.watcher.emit("webhook.failed", {
           ...event,
@@ -110,6 +131,7 @@ export class WebhookDelivery {
             originalEvent: event,
           },
         } as unknown as NormalizedEvent);
+        this.config.metrics.onFailed(attrs);
       }
     } finally {
       clearTimeout(abortTimer);

--- a/packages/pulse-webhooks/src/metrics.ts
+++ b/packages/pulse-webhooks/src/metrics.ts
@@ -1,0 +1,85 @@
+/**
+ * Provider-agnostic metrics surface for {@link WebhookDelivery}.
+ *
+ * `WebhookDelivery` calls into this interface at each terminal outcome of a
+ * delivery attempt. The interface deliberately knows nothing about any metrics
+ * backend — concrete adapters (OpenTelemetry, Prometheus, StatsD, …) translate
+ * these calls into their own counters and histograms.
+ *
+ * All methods MUST be cheap and non-throwing: they run inline on the delivery
+ * path. Adapters that talk to a remote collector should buffer/aggregate
+ * locally (the OTel SDK already does this) rather than doing I/O per call.
+ *
+ * ## Attribute conventions
+ *
+ * Attributes are intentionally low-cardinality. The full target URL and the
+ * event payload are **never** passed through, because (a) URLs can embed
+ * secrets/tokens and (b) unbounded label values blow up a metrics backend's
+ * cardinality. `host` carries only the URL host, not the path or query.
+ *
+ * See `docs/metrics.md` for the documented conventions.
+ */
+export interface WebhookMetrics {
+  /**
+   * A delivery attempt succeeded (HTTP 2xx).
+   * @param durationMs Wall-clock time from attempt start to the successful
+   *   response, in **milliseconds**. Adapters convert to their own unit.
+   */
+  onDelivered(durationMs: number, attrs: DeliveryAttributes): void;
+
+  /**
+   * A delivery permanently failed — all `retries` attempts for this URL were
+   * exhausted. Mirrors the existing `webhook.failed` watcher event.
+   */
+  onFailed(attrs: DeliveryAttributes): void;
+
+  /**
+   * A pending retry was evicted because the concurrent-retry cap was hit.
+   * Mirrors the existing `webhook.dropped` watcher event.
+   */
+  onDropped(attrs: DeliveryAttributes): void;
+
+  /**
+   * A retry was scheduled after a transient failure (i.e. an attempt failed
+   * but more attempts remain).
+   */
+  onRetry(attrs: DeliveryAttributes): void;
+}
+
+/**
+ * Low-cardinality attributes attached to every metric data point.
+ *
+ * Keep every field bounded. Do not add the full URL, the payload, account
+ * addresses, or anything else unbounded — see the cardinality note above.
+ */
+export interface DeliveryAttributes {
+  /** Host of the target URL only (never the full URL). E.g. `hooks.example.com`. */
+  host: string;
+  /** Normalized event type, e.g. `payment.received`. Bounded by the event union. */
+  eventType: string;
+  /** 1-based attempt number for this data point. */
+  attempt: number;
+}
+
+/**
+ * A `WebhookMetrics` that does nothing. Used as the default when no metrics
+ * adapter is configured, so the delivery path never has to null-check.
+ */
+export const NoopWebhookMetrics: WebhookMetrics = {
+  onDelivered() {},
+  onFailed() {},
+  onDropped() {},
+  onRetry() {},
+};
+
+/**
+ * Extract the bounded `host` attribute from a target URL. Falls back to
+ * `"unknown"` for unparseable URLs so a metric is still recorded.
+ */
+export function hostOf(url: string): string {
+  try {
+    return new URL(url).host;
+  } catch {
+    return "unknown";
+  }
+}

--- a/packages/pulse-webhooks/src/types.ts
+++ b/packages/pulse-webhooks/src/types.ts
@@ -1,3 +1,5 @@
+import type { WebhookMetrics } from "./metrics.js";
+
 export type WebhookConfig = {
   url: string | string[];
   secret: string;
@@ -7,6 +9,11 @@ export type WebhookConfig = {
   maxConcurrentRetries?: number;
   /** Optional RNG for testing jitter. Defaults to `Math.random`. */
   random?: () => number;
+  /**
+   * Optional metrics sink. Defaults to a no-op. Pass an adapter such as
+   * `OtelWebhookMetrics` to export delivery counters and latency histograms.
+   */
+  metrics?: WebhookMetrics;
 };
 
 export const DEFAULT_MAX_AGE_MS = 300_000;

--- a/packages/pulse-webhooks/test/OtelWebhookMetrics.integration.test.ts
+++ b/packages/pulse-webhooks/test/OtelWebhookMetrics.integration.test.ts
@@ -1,0 +1,142 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  MeterProvider,
+  PeriodicExportingMetricReader,
+  AggregationTemporality,
+} from "@opentelemetry/sdk-metrics";
+import type {
+  PushMetricExporter,
+  ResourceMetrics,
+} from "@opentelemetry/sdk-metrics";
+import type { ExportResult } from "@opentelemetry/core";
+
+import { OtelWebhookMetrics } from "../src/OtelWebhookMetrics.js";
+import type { DeliveryAttributes } from "../src/metrics.js";
+
+/**
+ * In-memory stand-in for an OTLP collector. The reader pushes the same
+ * `ResourceMetrics` batch here that it would serialize and ship over the wire,
+ * so asserting on what lands here is equivalent to asserting on what a real
+ * collector would receive.
+ */
+class CollectingExporter implements PushMetricExporter {
+  readonly batches: ResourceMetrics[] = [];
+  export(
+    metrics: ResourceMetrics,
+    resultCallback: (result: ExportResult) => void,
+  ): void {
+    this.batches.push(metrics);
+    resultCallback({ code: 0 });
+  }
+  async forceFlush(): Promise<void> {}
+  async shutdown(): Promise<void> {}
+  selectAggregationTemporality(): AggregationTemporality {
+    return AggregationTemporality.CUMULATIVE;
+  }
+}
+
+const attrs: DeliveryAttributes = {
+  host: "hooks.example.com",
+  eventType: "payment.received",
+  attempt: 1,
+};
+
+function collectMetricNames(batch: ResourceMetrics): Map<string, unknown> {
+  const out = new Map<string, unknown>();
+  for (const scope of batch.scopeMetrics) {
+    for (const m of scope.metrics) {
+      out.set(m.descriptor.name, m);
+    }
+  }
+  return out;
+}
+
+describe("OtelWebhookMetrics integration (exports to a collector)", () => {
+  let provider: MeterProvider;
+  let exporter: CollectingExporter;
+
+  beforeEach(() => {
+    exporter = new CollectingExporter();
+    const reader = new PeriodicExportingMetricReader({
+      exporter,
+      exportIntervalMillis: 60_000, // never auto-fires; we force-collect
+    });
+    provider = new MeterProvider({ readers: [reader] });
+  });
+
+  afterEach(async () => {
+    await provider.shutdown();
+  });
+
+  it("exports a delivery counter and a duration histogram to the collector", async () => {
+    const meter = provider.getMeter("orbital-pulse-webhooks");
+    const metrics = new OtelWebhookMetrics(meter);
+
+    metrics.onDelivered(250, attrs);
+
+    await provider.forceFlush();
+    expect(exporter.batches.length).toBeGreaterThan(0);
+
+    const byName = collectMetricNames(
+      exporter.batches[exporter.batches.length - 1],
+    );
+    expect([...byName.keys()]).toEqual(
+      expect.arrayContaining([
+        "webhook.deliveries",
+        "webhook.delivery.duration",
+      ]),
+    );
+
+    // Histogram value should be in SECONDS (250ms -> 0.25s).
+    const hist = byName.get("webhook.delivery.duration") as {
+      dataPoints: { value: { sum: number; count: number } }[];
+    };
+    expect(hist.dataPoints[0].value.count).toBe(1);
+    expect(hist.dataPoints[0].value.sum).toBeCloseTo(0.25, 5);
+  });
+
+  it("tags the deliveries counter with the outcome attribute", async () => {
+    const meter = provider.getMeter("orbital-pulse-webhooks");
+    const metrics = new OtelWebhookMetrics(meter);
+
+    metrics.onDelivered(100, attrs);
+    metrics.onFailed(attrs);
+    metrics.onDropped(attrs);
+
+    await provider.forceFlush();
+    const byName = collectMetricNames(
+      exporter.batches[exporter.batches.length - 1],
+    );
+    const counter = byName.get("webhook.deliveries") as {
+      dataPoints: { attributes: Record<string, unknown>; value: number }[];
+    };
+    const outcomes = counter.dataPoints
+      .map((d) => d.attributes.outcome)
+      .sort();
+    expect(outcomes).toEqual(["delivered", "dropped", "failed"]);
+    // Each outcome recorded exactly once.
+    for (const d of counter.dataPoints) {
+      expect(d.value).toBe(1);
+      expect(d.attributes.host).toBe("hooks.example.com");
+      expect(d.attributes["event.type"]).toBe("payment.received");
+    }
+  });
+
+  it("records retries on its own counter", async () => {
+    const meter = provider.getMeter("orbital-pulse-webhooks");
+    const metrics = new OtelWebhookMetrics(meter);
+
+    metrics.onRetry(attrs);
+    metrics.onRetry({ ...attrs, attempt: 2 });
+
+    await provider.forceFlush();
+    const byName = collectMetricNames(
+      exporter.batches[exporter.batches.length - 1],
+    );
+    const retries = byName.get("webhook.retries") as {
+      dataPoints: { value: number }[];
+    };
+    const total = retries.dataPoints.reduce((s, d) => s + d.value, 0);
+    expect(total).toBe(2);
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,11 +4,6 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-overrides:
-  path-to-regexp: 0.1.13
-  vite: 7.3.3
-  axios: '>=1.15.2'
-
 importers:
 
   .:
@@ -27,7 +22,7 @@ importers:
         version: 12.36.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       geist:
         specifier: ^1.7.0
-        version: 1.7.0(next@16.2.6(react-dom@19.2.5(react@19.2.5))(react@19.2.5))
+        version: 1.7.0(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))
       gray-matter:
         specifier: ^4.0.3
         version: 4.0.3
@@ -36,7 +31,7 @@ importers:
         version: 18.0.2
       next:
         specifier: ^16.2.6
-        version: 16.2.6(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+        version: 16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       react:
         specifier: ^19.2.5
         version: 19.2.5
@@ -85,11 +80,11 @@ importers:
         specifier: ^4.21.0
         version: 4.21.0
       vite:
-        specifier: 7.3.3
+        specifier: ^7.3.3
         version: 7.3.3(@types/node@25.6.0)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)
       vitest:
         specifier: ^4.1.7
-        version: 4.1.7(@types/node@25.6.0)(@vitest/coverage-v8@4.1.7)(vite@7.3.3(@types/node@25.6.0)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0))
+        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.7)(vite@7.3.3(@types/node@25.6.0)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0))
 
   packages/pulse-notify:
     dependencies:
@@ -106,16 +101,28 @@ importers:
       '@types/react':
         specifier: ^19.2.14
         version: 19.2.14
+      '@vitest/coverage-v8':
+        specifier: ^4.1.7
+        version: 4.1.7(vitest@4.1.7)
       tsx:
         specifier: ^4.0.0
         version: 4.21.0
+      vitest:
+        specifier: ^4.1.7
+        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.7)(vite@7.3.3(@types/node@25.6.0)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0))
 
   packages/pulse-webhooks:
     dependencies:
+      '@opentelemetry/api':
+        specifier: ^1.9.1
+        version: 1.9.1
       '@orbital/pulse-core':
         specifier: workspace:*
         version: link:../pulse-core
     devDependencies:
+      '@opentelemetry/sdk-metrics':
+        specifier: ^1.30.1
+        version: 1.30.1(@opentelemetry/api@1.9.1)
       '@types/node':
         specifier: ^25.6.0
         version: 25.6.0
@@ -123,11 +130,11 @@ importers:
         specifier: ^4.0.0
         version: 4.21.0
       vite:
-        specifier: 7.3.3
+        specifier: ^7.3.3
         version: 7.3.3(@types/node@25.6.0)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)
       vitest:
         specifier: ^4.1.7
-        version: 4.1.7(@types/node@25.6.0)(@vitest/coverage-v8@4.1.7)(vite@7.3.3(@types/node@25.6.0)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0))
+        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.7)(vite@7.3.3(@types/node@25.6.0)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0))
 
 packages:
 
@@ -501,89 +508,105 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -644,24 +667,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@16.2.6':
     resolution: {integrity: sha512-URUTu1+dMkxJsPFgm+OeEvq9wf5sujw0EvgYy80TDGHTSLTnIHeqb0Eu8A3sC95IRgjejQL+kC4mw+4yPxiAXA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-linux-x64-gnu@16.2.6':
     resolution: {integrity: sha512-DOj182mPV8G3UkrayLoREM5YEYI+Dk5wv7Ox9xl1fFibAELEsFD0lDPfHIeILlutMMfdyhlzYPELG3peuKaurw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-x64-musl@16.2.6':
     resolution: {integrity: sha512-HKQ5SP/V/ub73UvF7n/zeJlxk2kLmtL7Wzrg4WfmkjmNos5onJ2tKu7yZOPdL18A6Svfn3max29ym+ry7NkK4g==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@16.2.6':
     resolution: {integrity: sha512-LZXpTlPyS5v7HhSmnvsLGP3iIYgYOBnc8r8ArlT55sGHV89bR2HlDdBjWQ+PY6SJMmk8TuVGFuxalnP3k/0Dwg==}
@@ -682,6 +709,32 @@ packages:
   '@noble/hashes@1.8.0':
     resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
     engines: {node: ^14.21.3 || >=16}
+
+  '@opentelemetry/api@1.9.1':
+    resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
+    engines: {node: '>=8.0.0'}
+
+  '@opentelemetry/core@1.30.1':
+    resolution: {integrity: sha512-OOCM2C/QIURhJMuKaekP3TRBxBKxG/TWWA0TL2J6nXUtDnuCtccy49LUJF8xPFXMX+0LMcxFpCo8M9cGY1W6rQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/resources@1.30.1':
+    resolution: {integrity: sha512-5UxZqiAgLYGFjS4s9qm5mBVo433u+dSPUFWVWXmLAD4wB65oMCoXaJP1KJa9DIYYMeHu3z4BZcStG3LC593cWA==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/sdk-metrics@1.30.1':
+    resolution: {integrity: sha512-q9zcZ0Okl8jRgmy7eNW3Ku1XSgg3sDLa5evHZpCwjspw7E8Is4K/haRPDJrBcX3YSn/Y7gUvFnByNYEKQNbNog==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/semantic-conventions@1.28.0':
+    resolution: {integrity: sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==}
+    engines: {node: '>=14'}
 
   '@rollup/rollup-android-arm-eabi@4.60.4':
     resolution: {integrity: sha512-F5QXMSiFebS9hKZj02XhWLLnRpJ3B3AROP0tWbFBSj+6kCbg5m9j5JoHKd4mmSVy5mS/IMQloYgYxCuJC0fxEQ==}
@@ -717,66 +770,79 @@ packages:
     resolution: {integrity: sha512-EIPRXTVQpHyF8WOo219AD2yEltPehLTcTMz2fn6JsatLYSzQf00hj3rulF+yauOlF9/FtM2WpkT/hJh/KJFGhA==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.60.4':
     resolution: {integrity: sha512-J3Yh9PzzF1Ovah2At+lHiGQdsYgArxBbXv/zHfSyaiFQEqvNv7DcW98pCrmdjCZBrqBiKrKKe2V+aaSGWuBe/w==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.60.4':
     resolution: {integrity: sha512-BFDEZMYfUvLn37ONE1yMBojPxnMlTFsdyNoqncT0qFq1mAfllL+ATMMJd8TeuVMiX84s1KbcxcZbXInmcO2mRg==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.60.4':
     resolution: {integrity: sha512-pc9EYOSlOgdQ2uPl1o9PF6/kLSgaUosia7gOuS8mB69IxJvlclko1MECXysjs5ryez1/5zjYqx3+xYU0TU6R1A==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.60.4':
     resolution: {integrity: sha512-NxnomyxYerDh5n4iLrNa+sH+Z+U4BMEE46V2PgQ/hoB909i8gV1M5wPojWg9fk1jWpO3IQnOs20K4wyZuFLEFQ==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.60.4':
     resolution: {integrity: sha512-nbJnQ8a3z1mtmrwImCYhc6BGpThAyYVRQxw9uKSKG4wR6aAYno9sVjJ0zaZcW9BPJX1GbrDPf+SvdWjgTuDmnw==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.60.4':
     resolution: {integrity: sha512-2EU6acNrQLd8tYvo/LXW535wupT3m6fo7HKo6lr7ktQoItxTyOL1ZCR/GfGCuXl2vR+zmfI6eRXkSemafv+iVg==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.60.4':
     resolution: {integrity: sha512-WeBtoMuaMxiiIrO2IYP3xs6GMWkJP2C0EoT8beTLkUPmzV1i/UcOSVw1d5r9KBODtHKilG5yFxsGRnBbK3wJ4A==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.60.4':
     resolution: {integrity: sha512-FJHFfqpKUI3A10WrWKiFbBZ7yVbGT4q4B5o1qKFFojqpaYoh9LrQgqWCmmcxQzVSXYtyB5bzkXrYzlHTs21MYA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.60.4':
     resolution: {integrity: sha512-mcEl6CUT5IAUmQf1m9FYSmVqCJlpQ8r8eyftFUHG8i9OhY7BkBXSUdnLH5DOf0wCOjcP9v/QO93zpmF1SptCCw==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.60.4':
     resolution: {integrity: sha512-ynt3JxVd2w2buzoKDWIyiV1pJW93xlQic1THVLXilz429oijRpSHivZAgp65KBu+cMcgf1eVVjdnTLvPxgCuoQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.60.4':
     resolution: {integrity: sha512-Boiz5+MsaROEWDf+GGEwF8VMHGhlUoQMtIPjOgA5fv4osupqTVnJteQNKJwUcnUog2G55jYXH7KZFFiJe0TEzQ==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.60.4':
     resolution: {integrity: sha512-+qfSY27qIrFfI/Hom04KYFw3GKZSGU4lXus51wsb5EuySfFlWRwjkKWoE9emgRw/ukoT4Udsj4W/+xxG8VbPKg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.60.4':
     resolution: {integrity: sha512-VpTfOPHgVXEBeeR8hZ2O0F3aSso+JDWqTWmTmzcQKted54IAdUVbxE+j/MVxUsKa8L20HJhv3vUezVPoquqWjA==}
@@ -865,24 +931,28 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.3.0':
     resolution: {integrity: sha512-Z6sukiQsngnWO+l39X4pPbiWT81IC+PLKF+PHxIlyZbGNb9MODfYlXEVlFvej5BOZInWX01kVyzeLvHsXhfczQ==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.3.0':
     resolution: {integrity: sha512-DRNdQRpSGzRGfARVuVkxvM8Q12nh19l4BF/G7zGA1oe+9wcC6saFBHTISrpIcKzhiXtSrlSrluCfvMuledoCTQ==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.3.0':
     resolution: {integrity: sha512-Z0IADbDo8bh6I7h2IQMx601AdXBLfFpEdUotft86evd/8ZPflZe9COPO8Q1vw+pfLWIUo9zN/JGZvwuAJqduqg==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.3.0':
     resolution: {integrity: sha512-HNZGOUxEmElksYR7S6sC5jTeNGpobAsy9u7Gu0AskJ8/20FR9GqebUyB+HBcU/ax6BHuiuJi+Oda4B+YX6H1yA==}
@@ -951,7 +1021,7 @@ packages:
     resolution: {integrity: sha512-vY7nuamKgfvpA1Koa3oYIw/k7D6kZnpGyNMZW8loow2bsBYla1TFdqTaXncWdRn4pgwNs+90RhnXhJScDwQeJA==}
     peerDependencies:
       msw: ^2.4.9
-      vite: 7.3.3
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
     peerDependenciesMeta:
       msw:
         optional: true
@@ -972,10 +1042,6 @@ packages:
 
   '@vitest/utils@4.1.7':
     resolution: {integrity: sha512-T532WBu791cBxJlCl6SO+J14l81DQx6uQHm1bQbmCDY7nqlEIgkza/UFnSBNaUtSf41unldDFjdOBYEQC4b5Hw==}
-
-  agent-base@6.0.2:
-    resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
-    engines: {node: '>= 6.0.0'}
 
   argparse@1.0.10:
     resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
@@ -1001,8 +1067,8 @@ packages:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
 
-  axios@1.16.1:
-    resolution: {integrity: sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==}
+  axios@1.14.0:
+    resolution: {integrity: sha512-3Y8yrqLSwjuzpXuZ0oIYZ/XGgLwUIBU3uLvbcpb0pidD9ctpShJd43KSlEEkVQg6DS0G9NKyzOvBfUtDKEyHvQ==}
 
   base32.js@0.1.0:
     resolution: {integrity: sha512-n3TkB02ixgBOhTvANakDb4xaMXnYUVkNoRFJjQflcqMQhyEKxEHdj3E6N8t8sUQ0mjH/3/JxzlXuz3ul/J90pQ==}
@@ -1062,15 +1128,6 @@ packages:
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
-
-  debug@4.4.3:
-    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
-    engines: {node: '>=6.0'}
-    peerDependencies:
-      supports-color: '*'
-    peerDependenciesMeta:
-      supports-color:
-        optional: true
 
   define-data-property@1.1.4:
     resolution: {integrity: sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==}
@@ -1251,10 +1308,6 @@ packages:
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
-  https-proxy-agent@5.0.1:
-    resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
-    engines: {node: '>= 6'}
-
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
 
@@ -1345,24 +1398,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -1416,9 +1473,6 @@ packages:
 
   motion-utils@12.36.0:
     resolution: {integrity: sha512-eHWisygbiwVvf6PZ1vhaHCLamvkSbPIeAYxWUuL3a2PD/TROgE7FvfHWTIH4vMl798QLfMw15nRqIaRDXTlYRg==}
-
-  ms@2.1.3:
-    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
@@ -1696,7 +1750,7 @@ packages:
       '@vitest/ui': 4.1.7
       happy-dom: '*'
       jsdom: '*'
-      vite: 7.3.3
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
     peerDependenciesMeta:
       '@edge-runtime/vm':
         optional: true
@@ -2058,6 +2112,27 @@ snapshots:
 
   '@noble/hashes@1.8.0': {}
 
+  '@opentelemetry/api@1.9.1': {}
+
+  '@opentelemetry/core@1.30.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/semantic-conventions': 1.28.0
+
+  '@opentelemetry/resources@1.30.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.28.0
+
+  '@opentelemetry/sdk-metrics@1.30.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/semantic-conventions@1.28.0': {}
+
   '@rollup/rollup-android-arm-eabi@4.60.4':
     optional: true
 
@@ -2149,7 +2224,7 @@ snapshots:
   '@stellar/stellar-sdk@15.0.1':
     dependencies:
       '@stellar/stellar-base': 15.0.0
-      axios: 1.16.1
+      axios: 1.14.0
       bignumber.js: 9.3.1
       commander: 14.0.3
       eventsource: 2.0.2
@@ -2159,7 +2234,6 @@ snapshots:
       urijs: 1.19.11
     transitivePeerDependencies:
       - debug
-      - supports-color
 
   '@swc/helpers@0.5.15':
     dependencies:
@@ -2267,7 +2341,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.7(@types/node@25.6.0)(@vitest/coverage-v8@4.1.7)(vite@7.3.3(@types/node@25.6.0)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0))
+      vitest: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.7)(vite@7.3.3(@types/node@25.6.0)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0))
 
   '@vitest/expect@4.1.7':
     dependencies:
@@ -2310,12 +2384,6 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
-  agent-base@6.0.2:
-    dependencies:
-      debug: 4.4.3
-    transitivePeerDependencies:
-      - supports-color
-
   argparse@1.0.10:
     dependencies:
       sprintf-js: 1.0.3
@@ -2343,15 +2411,13 @@ snapshots:
     dependencies:
       possible-typed-array-names: 1.1.0
 
-  axios@1.16.1:
+  axios@1.14.0:
     dependencies:
       follow-redirects: 1.16.0
       form-data: 4.0.5
-      https-proxy-agent: 5.0.1
       proxy-from-env: 2.1.0
     transitivePeerDependencies:
       - debug
-      - supports-color
 
   base32.js@0.1.0: {}
 
@@ -2406,10 +2472,6 @@ snapshots:
   convert-source-map@2.0.0: {}
 
   csstype@3.2.3: {}
-
-  debug@4.4.3:
-    dependencies:
-      ms: 2.1.3
 
   define-data-property@1.1.4:
     dependencies:
@@ -2563,9 +2625,9 @@ snapshots:
 
   function-bind@1.1.2: {}
 
-  geist@1.7.0(next@16.2.6(react-dom@19.2.5(react@19.2.5))(react@19.2.5)):
+  geist@1.7.0(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)):
     dependencies:
-      next: 16.2.6(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      next: 16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
 
   get-intrinsic@1.3.0:
     dependencies:
@@ -2617,13 +2679,6 @@ snapshots:
       function-bind: 1.1.2
 
   html-escaper@2.0.2: {}
-
-  https-proxy-agent@5.0.1:
-    dependencies:
-      agent-base: 6.0.2
-      debug: 4.4.3
-    transitivePeerDependencies:
-      - supports-color
 
   ieee754@1.2.1: {}
 
@@ -2750,13 +2805,11 @@ snapshots:
 
   motion-utils@12.36.0: {}
 
-  ms@2.1.3: {}
-
   nanoid@3.3.11: {}
 
   nanoid@3.3.12: {}
 
-  next@16.2.6(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
+  next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
     dependencies:
       '@next/env': 16.2.6
       '@swc/helpers': 0.5.15
@@ -2775,6 +2828,7 @@ snapshots:
       '@next/swc-linux-x64-musl': 16.2.6
       '@next/swc-win32-arm64-msvc': 16.2.6
       '@next/swc-win32-x64-msvc': 16.2.6
+      '@opentelemetry/api': 1.9.1
       sharp: 0.34.5
     transitivePeerDependencies:
       - '@babel/core'
@@ -3008,7 +3062,7 @@ snapshots:
       lightningcss: 1.32.0
       tsx: 4.21.0
 
-  vitest@4.1.7(@types/node@25.6.0)(@vitest/coverage-v8@4.1.7)(vite@7.3.3(@types/node@25.6.0)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)):
+  vitest@4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.7)(vite@7.3.3(@types/node@25.6.0)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)):
     dependencies:
       '@vitest/expect': 4.1.7
       '@vitest/mocker': 4.1.7(vite@7.3.3(@types/node@25.6.0)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0))
@@ -3031,6 +3085,7 @@ snapshots:
       vite: 7.3.3(@types/node@25.6.0)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
+      '@opentelemetry/api': 1.9.1
       '@types/node': 25.6.0
       '@vitest/coverage-v8': 4.1.7(vitest@4.1.7)
     transitivePeerDependencies:


### PR DESCRIPTION


## Summary

Adds a reference OpenTelemetry metrics adapter for webhook delivery. Closes #399.

The ticket assumed a metrics interface already existed to be "equivalent" to — it didn't. So this PR establishes the foundation (a provider-agnostic `WebhookMetrics` interface + delivery instrumentation) and the OTel adapter on top of it.

## Changes

- **`metrics.ts`** (new) — `WebhookMetrics` interface (`onDelivered` / `onFailed` / `onDropped` / `onRetry`), the `DeliveryAttributes` shape, a `NoopWebhookMetrics` default, and a `hostOf()` URL→host helper.
- **`OtelWebhookMetrics.ts`** (new) — takes a `Meter`, exposes `webhook.deliveries` (counter, `outcome`-tagged), `webhook.delivery.duration` (histogram), and `webhook.retries` (counter). Instruments created once and reused per OTel guidance.
- **`index.ts` / `types.ts`** — `WebhookDelivery` gains an optional `metrics` config (defaults to no-op), captures delivery latency, and calls the hooks at each existing terminal point. No new watcher events and no control-flow change, so existing consumers see identical behavior.
- **`OtelWebhookMetrics.integration.test.ts`** (new) — exercises the adapter through a real `MeterProvider` + `PeriodicExportingMetricReader` into an in-memory collector exporter.
- **`docs/metrics.md`** (new) — instrument table and attribute conventions.
- **`package.json`** — adds `@opentelemetry/api` (dependency) and `@opentelemetry/sdk-metrics` (dev).

## Attribute conventions

Low-cardinality only: `outcome` (`delivered`/`failed`/`dropped`), `host` (host only, never the full URL), `event.type`, and `attempt` (on retries). Full URLs are excluded to avoid leaking tokens into metric labels; payloads/addresses excluded for cardinality. Full rationale in `docs/metrics.md`.

## Decisions for review

- **Scope.** This grew the `WebhookMetrics` interface beyond the ticket's "add an adapter" framing. The interface is now the contract a future Prometheus adapter implements against.
- **Histogram unit.** Recorded in **seconds** (OTel convention) while the interface reports **milliseconds** (codebase convention). One-line flip if reviewers prefer ms.

