### PR TITLE
docs: expose Stellar network passphrases

### DIFF
--- a/packages/pulse-core/README.md
+++ b/packages/pulse-core/README.md
@@ -62,6 +62,24 @@ Once a watcher has been stopped, it will not accept new listeners. Calling `watc
 
 Stops and removes the watcher for the given address.
 
+### Network passphrases and asset format
+
+`pulse-core` exports `NETWORK_PASSPHRASES` as the source of truth for the supported Stellar network passphrases:
+
+```ts
+import { NETWORK_PASSPHRASES } from "@orbital/pulse-core";
+
+NETWORK_PASSPHRASES.mainnet; // "Public Global Stellar Network ; September 2015"
+NETWORK_PASSPHRASES.testnet; // "Test SDF Network ; September 2015"
+```
+
+Use these constants in tests, signing helpers, or Stellar RPC calls that need the exact network passphrase for the same `network` value passed to `EventEngine`.
+
+Normalized asset strings follow one rule across every event payload:
+
+- Native XLM is emitted as `XLM`.
+- Issued assets are emitted as `CODE:ISSUER`, for example `USDC:G...`.
+
 ### `Watcher` events
 
 | Event | Payload | Fired when |

--- a/packages/pulse-core/src/index.ts
+++ b/packages/pulse-core/src/index.ts
@@ -6,6 +6,12 @@ export { StrKey } from "@stellar/stellar-sdk";
 /** The Stellar network to connect to. */
 export type Network = "mainnet" | "testnet";
 
+/** Passphrase strings for each supported Stellar network. */
+export const NETWORK_PASSPHRASES = {
+  mainnet: "Public Global Stellar Network ; September 2015",
+  testnet: "Test SDF Network ; September 2015",
+} as const satisfies Record<Network, string>;
+
 /** Event types for payment-related events (received, sent, or self-payment). */
 export type PaymentEventType =
   | "payment.received"


### PR DESCRIPTION
## Summary
- export `NETWORK_PASSPHRASES` from `@orbital/pulse-core`
- document the exact mainnet/testnet passphrase strings in the pulse-core README
- document the normalized asset format rule: native `XLM`, issued assets as `CODE:ISSUER`

Fixes #318

## Validation
- `pnpm install --frozen-lockfile` was attempted first, but the existing lockfile is stale against `packages/pulse-notify/package.json`
- `pnpm install --no-frozen-lockfile --lockfile=false`
- `pnpm --filter @orbital/pulse-core typecheck`
- `pnpm --filter @orbital/pulse-core build`
- `pnpm --filter @orbital/pulse-core test`
- `git diff --check`