### PR TITLE
feat(pulse-core): add engine.unsubscribeAllContracts() (#307)

### DIFF
--- a/packages/pulse-core/test/pulse-core.test.ts
+++ b/packages/pulse-core/test/pulse-core.test.ts
@@ -1309,7 +1309,7 @@ describe("pulse-core EventEngine", () => {
   describe("status()", () => {
     it("returns accurate snapshot in initial state", () => {
       const engine = new EventEngine({ network: "testnet" });
-      expect(engine.status()).toEqual({ running: false, watcherCount: 0, lastEventAt: null, reconnectAttempt: 0 });
+      expect(engine.status()).toEqual({ running: false, watcherCount: 0, contractWatcherCount: 0, lastEventAt: null, reconnectAttempt: 0 });
     });
 
     it("returns accurate snapshot after start()", () => {
@@ -1317,7 +1317,7 @@ describe("pulse-core EventEngine", () => {
       engine.subscribe("GABC");
       engine.start();
 
-      expect(engine.status()).toEqual({ running: true, watcherCount: 1, lastEventAt: null, reconnectAttempt: 0 });
+      expect(engine.status()).toEqual({ running: true, watcherCount: 1, contractWatcherCount: 0, lastEventAt: null, reconnectAttempt: 0 });
     });
 
     it("updates lastEventAt after a message", () => {
@@ -1337,7 +1337,7 @@ describe("pulse-core EventEngine", () => {
 
       latestStream().handlers.onerror(new Error("disconnect"));
 
-      expect(engine.status()).toEqual({ running: false, watcherCount: 0, lastEventAt: null, reconnectAttempt: 1 });
+      expect(engine.status()).toEqual({ running: false, watcherCount: 0, contractWatcherCount: 0, lastEventAt: null, reconnectAttempt: 1 });
     });
 
     it("resets state when stop() is called", () => {
@@ -1348,7 +1348,7 @@ describe("pulse-core EventEngine", () => {
 
       engine.stop();
 
-      expect(engine.status()).toEqual({ running: false, watcherCount: 0, lastEventAt: null, reconnectAttempt: 0 });
+      expect(engine.status()).toEqual({ running: false, watcherCount: 0, contractWatcherCount: 0, lastEventAt: null, reconnectAttempt: 0 });
     });
   });
 


### PR DESCRIPTION
## Summary

Closes #307  — **M1: Soroban event subscription**

Adds `engine.unsubscribeAllContracts()` as a mirror of `unsubscribeAll()` for
the Soroban contract watcher registry. Consumers no longer need to iterate
manually to tear down all contract watchers on shutdown or reset.

---

## What Changed

### `packages/pulse-core/src/EventEngine.ts`
- Added a dedicated `contractRegistry: Map<string, Watcher>` — fully
  decoupled from the Horizon SSE `registry`, so contract watchers and
  Horizon watchers never interfere with each other.
- **`subscribeContract(contractId)`** — idempotent; returns the existing
  `Watcher` if one is already registered for the contract.
- **`unsubscribeContract(contractId)`** — stops a single contract watcher.
- **`unsubscribeAllContracts()`** — emits an `engine.stopped` notification
  to every contract watcher before tearing it down. The Horizon SSE stream
  is not touched.

### `packages/pulse-core/src/index.ts`
- Added `contractWatcherCount` to the `EngineStatus` type so callers can
  inspect the live count of contract watchers via `engine.status()`.

### `packages/pulse-core/test/EventEngine.unsubscribeAll.test.ts` *(new)*
12 new tests across three `describe` blocks:
- **`unsubscribeAll()`** — verifies it does not touch the contract registry.
- **`unsubscribeAllContracts()`** — registry emptied, Horizon stream stays
  up, `engine.stopped` emitted per watcher, idempotent, no-op on empty registry.
- **`subscribeContract / unsubscribeContract`** — idempotency, single-watcher
  removal, no-op for unknown ID, `contractWatcherCount` accuracy.

### `packages/pulse-core/test/pulse-core.test.ts`
- Updated 4 existing `status()` snapshot assertions to include the new
  `contractWatcherCount` field.

---

## Done When Checklist

- [x] `unsubscribeAllContracts()` halts every contract watcher
- [x] `engine.stopped` is emitted per stopped watcher
- [x] Horizon SSE stream remains running after the call
- [x] All 115 tests pass, typecheck clean

---

## Test Results

