### PR TITLE
feat(pulse-core): add contract event routing for Soroban events

### DIFF
--- a/packages/pulse-core/src/EventEngine.ts
+++ b/packages/pulse-core/src/EventEngine.ts
@@ -12,6 +12,10 @@ import type {
   ClaimableBalanceClaimant,
   ClaimableClaimedEvent,
   ClaimableCreatedEvent,
+  ContractEmittedEvent,
+  ContractInvokedEvent,
+  ContractSubscribeOptions,
+  ContractSubscriptionFilter,
   CoreConfig,
   DataEvent,
   DataEventType,
@@ -49,7 +53,9 @@ type NormalizedEventOrPending =
   | ClaimableClaimedEvent
   | LiquidityPoolDepositEvent
   | LiquidityPoolWithdrawEvent
-  | TrustAuthEvent;
+  | TrustAuthEvent
+  | ContractInvokedEvent
+  | ContractEmittedEvent;
 
 type StreamCallbacks = {
   onmessage: (record: unknown) => void;
@@ -78,6 +84,7 @@ const noop = { info: () => {}, warn: () => {}, error: () => {} };
 export class EventEngine {
   private server: Horizon.Server;
   private registry: Map<string, Watcher> = new Map();
+  private contractRegistry: Map<string, { watcher: Watcher; filters: ContractSubscriptionFilter[] }> = new Map();
   private stopStream: HorizonStreamStopper | null = null;
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
   private reconnectAttempt = 0;
@@ -165,6 +172,35 @@ export class EventEngine {
     for (const watcher of this.registry.values()) {
       watcher.stop();
     }
+  }
+
+  /**
+   * Subscribes to Soroban contract events matching the given filters.
+   * Returns a Watcher that emits "contract.invoked", "contract.emitted", and "*".
+   * Multiple calls with different filters create independent subscriptions.
+   * @param id - A caller-chosen identifier for this subscription (used to unsubscribe).
+   * @param options - Optional filters; omitting filters matches all contract events.
+   */
+  subscribeContract(id: string, options?: ContractSubscribeOptions): Watcher {
+    const existing = this.contractRegistry.get(id);
+    if (existing) {
+      return existing.watcher;
+    }
+
+    const watcher = new Watcher(id);
+    const filters = options?.filters ?? [];
+    watcher.addStopHandler(() => {
+      this.contractRegistry.delete(id);
+    });
+    this.contractRegistry.set(id, { watcher, filters });
+    return watcher;
+  }
+
+  /**
+   * Removes a contract subscription by its id.
+   */
+  unsubscribeContract(id: string): void {
+    this.contractRegistry.get(id)?.watcher.stop();
   }
 
   /**
@@ -510,6 +546,14 @@ export class EventEngine {
 
     if (r.type === "set_trust_line_flags") {
       return this.normalizeSetTrustLineFlags(r, record);
+    }
+
+    if (r.type === "contract_invocation") {
+      return this.normalizeContractInvoked(r, record);
+    }
+
+    if (r.type === "contract_event") {
+      return this.normalizeContractEmitted(r, record);
     }
 
     return null;
@@ -950,6 +994,38 @@ export class EventEngine {
     };
   }
 
+  private normalizeContractInvoked(
+    r: Record<string, unknown>,
+    raw: unknown
+  ): ContractInvokedEvent | null {
+    if (typeof r.contract_id !== "string" || r.contract_id === "") return null;
+    if (typeof r.function !== "string") return null;
+    return {
+      type: "contract.invoked",
+      contractId: r.contract_id,
+      function: r.function,
+      topics: Array.isArray(r.topics) ? (r.topics as string[]) : [],
+      data: r.data ?? null,
+      timestamp: typeof r.created_at === "string" ? r.created_at : "",
+      raw,
+    };
+  }
+
+  private normalizeContractEmitted(
+    r: Record<string, unknown>,
+    raw: unknown
+  ): ContractEmittedEvent | null {
+    if (typeof r.contract_id !== "string" || r.contract_id === "") return null;
+    return {
+      type: "contract.emitted",
+      contractId: r.contract_id,
+      topics: Array.isArray(r.topics) ? (r.topics as string[]) : [],
+      data: r.data ?? null,
+      timestamp: typeof r.created_at === "string" ? r.created_at : "",
+      raw,
+    };
+  }
+
   private passesFilter(address: string, event: NormalizedEvent): boolean {
     const filter = this.filters.get(address);
     if (!filter) return true;
@@ -963,6 +1039,27 @@ export class EventEngine {
       );
       return false;
     }
+  }
+
+  private matchesContractFilters(
+    event: { type: string; contractId: string; topics: string[] },
+    filters: ContractSubscriptionFilter[]
+  ): boolean {
+    // No filters = match everything
+    if (filters.length === 0) return true;
+
+    // At least one filter must match (OR across filters)
+    return filters.some((f) => {
+      if (f.type !== undefined && f.type !== event.type) return false;
+      if (f.contractIds !== undefined && !f.contractIds.includes(event.contractId)) return false;
+      if (f.topicFilters !== undefined) {
+        for (let i = 0; i < f.topicFilters.length; i++) {
+          const pattern = f.topicFilters[i];
+          if (pattern !== null && pattern !== event.topics[i]) return false;
+        }
+      }
+      return true;
+    });
   }
 
   private route(event: NormalizedEventOrPending): void {
@@ -1100,6 +1197,16 @@ export class EventEngine {
       if (trustorWatcher && event.trustor !== event.issuer && this.passesFilter(event.trustor, event)) {
         trustorWatcher.emit(event.type, event);
         trustorWatcher.emit("*", event);
+      }
+      return;
+    }
+
+    if (event.type === "contract.invoked" || event.type === "contract.emitted") {
+      for (const { watcher, filters } of this.contractRegistry.values()) {
+        if (this.matchesContractFilters(event, filters)) {
+          watcher.emit(event.type, event);
+          watcher.emit("*", event);
+        }
       }
       return;
     }

--- a/packages/pulse-core/src/index.ts
+++ b/packages/pulse-core/src/index.ts
@@ -263,7 +263,9 @@ export type NormalizedEvent =
   | ClaimableClaimedEvent
   | LiquidityPoolDepositEvent
   | LiquidityPoolWithdrawEvent
-  | TrustAuthEvent;
+  | TrustAuthEvent
+  | ContractInvokedEvent
+  | ContractEmittedEvent;
 
 /**
  * A notification emitted by the EventEngine during reconnection attempts.
@@ -340,4 +342,71 @@ export type SubscribeOptions = {
    *  Return `false` to suppress delivery. If the predicate throws, the event
    *  is suppressed and a warning is logged — the engine continues running. */
   filter?: (event: NormalizedEvent) => boolean;
+};
+
+// ---------------------------------------------------------------------------
+// Contract events (Phase 1 — Soroban)
+// ---------------------------------------------------------------------------
+
+export type ContractEventType = "contract.invoked" | "contract.emitted";
+
+/**
+ * A normalized Soroban contract invocation event.
+ * Emitted when a contract function is called.
+ */
+export type ContractInvokedEvent = {
+  type: "contract.invoked";
+  contractId: string;
+  /** The function name that was invoked. */
+  function: string;
+  /** Ordered list of topic strings (XDR-encoded or decoded). */
+  topics: string[];
+  /** Arbitrary event data payload. */
+  data: unknown;
+  timestamp: string;
+  raw: unknown;
+};
+
+/**
+ * A normalized Soroban contract-emitted event (contract_events in the ledger).
+ */
+export type ContractEmittedEvent = {
+  type: "contract.emitted";
+  contractId: string;
+  /** Ordered list of topic strings (XDR-encoded or decoded). */
+  topics: string[];
+  /** Arbitrary event data payload. */
+  data: unknown;
+  timestamp: string;
+  raw: unknown;
+};
+
+export type ContractEvent = ContractInvokedEvent | ContractEmittedEvent;
+
+/**
+ * Filter criteria for a contract subscription.
+ * All specified fields must match (AND semantics).
+ * Omitting a field means "match any".
+ */
+export type ContractSubscriptionFilter = {
+  /** Match only events of this type. Omit to match both. */
+  type?: ContractEventType;
+  /**
+   * Match only events from one of these contract IDs.
+   * Omit to match any contract.
+   */
+  contractIds?: string[];
+  /**
+   * Topic-pattern match: each entry is matched positionally against the event's
+   * topics array. Use `null` as a wildcard for a position.
+   * Omit to match any topics.
+   *
+   * @example ["transfer", null] — matches events whose first topic is "transfer"
+   */
+  topicFilters?: (string | null)[];
+};
+
+/** Options for subscribeContract(). */
+export type ContractSubscribeOptions = {
+  filters?: ContractSubscriptionFilter[];
 };

--- a/packages/pulse-core/test/EventEngine.routeContract.test.ts
+++ b/packages/pulse-core/test/EventEngine.routeContract.test.ts
@@ -1,0 +1,235 @@
+import { describe, it, expect, vi } from "vitest";
+import { EventEngine } from "../src/EventEngine.js";
+import type { ContractEmittedEvent, ContractInvokedEvent } from "../src/index.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function buildEngine(): {
+  engine: EventEngine;
+  simulateRecord: (record: unknown) => void;
+} {
+  const engine = new EventEngine({ network: "testnet" });
+
+  let capturedOnMessage: ((record: unknown) => void) | null = null;
+
+  vi.spyOn((engine as any).server, "operations").mockImplementation(() => ({
+    cursor: () => ({
+      stream: (callbacks: { onmessage: (r: unknown) => void }) => {
+        capturedOnMessage = callbacks.onmessage;
+        return () => {};
+      },
+    }),
+  }));
+
+  engine.start();
+
+  return {
+    engine,
+    simulateRecord: (record) => {
+      if (!capturedOnMessage) throw new Error("Stream not opened");
+      capturedOnMessage(record);
+    },
+  };
+}
+
+function makeEmittedRecord(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    type: "contract_event",
+    contract_id: "CABC1234",
+    topics: ["transfer", "GABC"],
+    data: { amount: "100" },
+    created_at: "2024-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function makeInvokedRecord(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    type: "contract_invocation",
+    contract_id: "CABC1234",
+    function: "transfer",
+    topics: ["transfer"],
+    data: null,
+    created_at: "2024-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("EventEngine — contract event routing", () => {
+  it("drops a contract.emitted event when no contract subscriptions exist", () => {
+    const { engine, simulateRecord } = buildEngine();
+    // Classic address watcher — should not receive contract events
+    const watcher = engine.subscribe("GABC1234");
+    const received: unknown[] = [];
+    watcher.on("*", (e) => received.push(e));
+
+    simulateRecord(makeEmittedRecord());
+
+    expect(received).toHaveLength(0);
+  });
+
+  it("drops a contract.emitted event when no filter matches", () => {
+    const { engine, simulateRecord } = buildEngine();
+    const watcher = engine.subscribeContract("sub1", {
+      filters: [{ contractIds: ["COTHER999"] }],
+    });
+    const received: unknown[] = [];
+    watcher.on("*", (e) => received.push(e));
+
+    simulateRecord(makeEmittedRecord({ contract_id: "CABC1234" }));
+
+    expect(received).toHaveLength(0);
+  });
+
+  it("delivers contract.emitted to a subscription with matching contractId", () => {
+    const { engine, simulateRecord } = buildEngine();
+    const watcher = engine.subscribeContract("sub1", {
+      filters: [{ contractIds: ["CABC1234"] }],
+    });
+    const received: ContractEmittedEvent[] = [];
+    watcher.on("contract.emitted", (e) => received.push(e as ContractEmittedEvent));
+
+    simulateRecord(makeEmittedRecord());
+
+    expect(received).toHaveLength(1);
+    expect(received[0]).toMatchObject({
+      type: "contract.emitted",
+      contractId: "CABC1234",
+      topics: ["transfer", "GABC"],
+      data: { amount: "100" },
+      timestamp: "2024-01-01T00:00:00Z",
+    });
+  });
+
+  it("delivers contract.emitted on the '*' wildcard", () => {
+    const { engine, simulateRecord } = buildEngine();
+    const watcher = engine.subscribeContract("sub1", {
+      filters: [{ contractIds: ["CABC1234"] }],
+    });
+    const wildcard: unknown[] = [];
+    watcher.on("*", (e) => wildcard.push(e));
+
+    simulateRecord(makeEmittedRecord());
+
+    expect(wildcard).toHaveLength(1);
+  });
+
+  it("delivers contract.invoked to a matching subscription", () => {
+    const { engine, simulateRecord } = buildEngine();
+    const watcher = engine.subscribeContract("sub1", {
+      filters: [{ type: "contract.invoked", contractIds: ["CABC1234"] }],
+    });
+    const received: ContractInvokedEvent[] = [];
+    watcher.on("contract.invoked", (e) => received.push(e as ContractInvokedEvent));
+
+    simulateRecord(makeInvokedRecord());
+
+    expect(received).toHaveLength(1);
+    expect(received[0]).toMatchObject({
+      type: "contract.invoked",
+      contractId: "CABC1234",
+      function: "transfer",
+    });
+  });
+
+  it("does not deliver contract.invoked to a subscription filtered to contract.emitted", () => {
+    const { engine, simulateRecord } = buildEngine();
+    const watcher = engine.subscribeContract("sub1", {
+      filters: [{ type: "contract.emitted" }],
+    });
+    const received: unknown[] = [];
+    watcher.on("*", (e) => received.push(e));
+
+    simulateRecord(makeInvokedRecord());
+
+    expect(received).toHaveLength(0);
+  });
+
+  it("matches a topic-pattern filter positionally (null = wildcard)", () => {
+    const { engine, simulateRecord } = buildEngine();
+    const watcher = engine.subscribeContract("sub1", {
+      filters: [{ topicFilters: ["transfer", null] }],
+    });
+    const received: unknown[] = [];
+    watcher.on("contract.emitted", (e) => received.push(e));
+
+    simulateRecord(makeEmittedRecord({ topics: ["transfer", "GABC"] }));
+
+    expect(received).toHaveLength(1);
+  });
+
+  it("rejects an event whose first topic does not match the pattern", () => {
+    const { engine, simulateRecord } = buildEngine();
+    const watcher = engine.subscribeContract("sub1", {
+      filters: [{ topicFilters: ["mint"] }],
+    });
+    const received: unknown[] = [];
+    watcher.on("*", (e) => received.push(e));
+
+    simulateRecord(makeEmittedRecord({ topics: ["transfer", "GABC"] }));
+
+    expect(received).toHaveLength(0);
+  });
+
+  it("delivers to two overlapping subscriptions independently (no dedup)", () => {
+    const { engine, simulateRecord } = buildEngine();
+
+    const w1 = engine.subscribeContract("sub1", {
+      filters: [{ contractIds: ["CABC1234"] }],
+    });
+    const w2 = engine.subscribeContract("sub2", {
+      filters: [{ topicFilters: ["transfer", null] }],
+    });
+
+    const r1: unknown[] = [];
+    const r2: unknown[] = [];
+    w1.on("contract.emitted", (e) => r1.push(e));
+    w2.on("contract.emitted", (e) => r2.push(e));
+
+    simulateRecord(makeEmittedRecord());
+
+    expect(r1).toHaveLength(1);
+    expect(r2).toHaveLength(1);
+  });
+
+  it("a subscription with no filters matches all contract events", () => {
+    const { engine, simulateRecord } = buildEngine();
+    const watcher = engine.subscribeContract("sub1");
+    const received: unknown[] = [];
+    watcher.on("*", (e) => received.push(e));
+
+    simulateRecord(makeEmittedRecord({ contract_id: "CANY" }));
+    simulateRecord(makeInvokedRecord({ contract_id: "COTHER" }));
+
+    expect(received).toHaveLength(2);
+  });
+
+  it("drops a contract_event record with missing contract_id", () => {
+    const { engine, simulateRecord } = buildEngine();
+    const watcher = engine.subscribeContract("sub1");
+    const received: unknown[] = [];
+    watcher.on("*", (e) => received.push(e));
+
+    simulateRecord(makeEmittedRecord({ contract_id: "" }));
+
+    expect(received).toHaveLength(0);
+  });
+
+  it("unsubscribeContract stops delivery", () => {
+    const { engine, simulateRecord } = buildEngine();
+    const watcher = engine.subscribeContract("sub1");
+    const received: unknown[] = [];
+    watcher.on("*", (e) => received.push(e));
+
+    engine.unsubscribeContract("sub1");
+    simulateRecord(makeEmittedRecord());
+
+    expect(received).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
[- Add ContractInvokedEvent, ContractEmittedEvent types and ContractSubscriptionFilter to index.ts
- Add subscribeContract() / unsubscribeContract() to EventEngine
- Normalize contract_invocation and contract_event Horizon records
- Route contract.* events against contract subscriptions using OR-across-filters, AND-within-filter matching (type, contractIds, topicFilters with null wildcard support)
- Multiple overlapping subscriptions each receive the event independently
- Add EventEngine.routeContract.test.ts (12 tests)

## Linked issue

Closes #

## What changed and why

## Summary

Extends `EventEngine` to route `contract.invoked` and `contract.emitted` events to contract subscriptions — the missing delivery layer for Phase 1 Soroban support.

Classic events continue to route by Stellar address. Contract events route by `(contractId, topic-pattern)` via a separate `contractRegistry`, so the two subscription models are fully independent.

---

## Changes

### `packages/pulse-core/src/index.ts`

- `ContractInvokedEvent` — normalized Soroban invocation event (`contractId`, `function`, `topics`, `data`, `timestamp`, `raw`)
- `ContractEmittedEvent` — normalized contract-emitted event (`contractId`, `topics`, `data`, `timestamp`, `raw`)
- `ContractEvent` — union of the two above
- `ContractSubscriptionFilter` — AND-semantics within a filter, OR across filters:
  - `type?` — restrict to `"contract.invoked"` or `"contract.emitted"`
  - `contractIds?` — membership check
  - `topicFilters?` — positional match; `null` is a wildcard
- `ContractSubscribeOptions` — wraps `filters[]`
- `NormalizedEvent` union extended with both contract event types

### `packages/pulse-core/src/EventEngine.ts`

- `contractRegistry: Map<string, { watcher, filters[] }>` — separate from the address registry
- `subscribeContract(id, options?)` — creates an independent subscription; returns existing watcher if `id` already registered
- `unsubscribeContract(id)` — stops the watcher and removes it from the registry
- `normalizeContractInvoked()` — normalizes `contract_invocation` Horizon records
- `normalizeContractEmitted()` — normalizes `contract_event` Horizon records
- `matchesContractFilters()` — OR across filters, AND within each filter
- `route()` extended — `contract.*` events fan out to every subscription whose filters match, independently (no dedup across subscriptions)

### `packages/pulse-core/test/EventEngine.routeContract.test.ts` _(new)_

12 tests:

| Test | What it verifies |
|---|---|
| drops event when no contract subscriptions exist | unmatched events are silently dropped |
| drops event when no filter matches | contractId mismatch → no delivery |
| delivers `contract.emitted` to matching contractId | basic delivery path |
| delivers on the `*` wildcard | wildcard listener receives the event |
| delivers `contract.invoked` to matching subscription | invoked event type works |
| does not deliver `contract.invoked` to `contract.emitted`-only filter | type filter is enforced |
| matches topic-pattern positionally (`null` = wildcard) | positional topic matching |
| rejects event whose first topic does not match | topic mismatch → no delivery |
| two overlapping subscriptions each receive the event exactly once | independent fan-out, no dedup |
| no-filter subscription matches all contract events | empty filters = catch-all |
| drops record with missing `contract_id` | normalization guard |
| `unsubscribeContract` stops delivery | cleanup works |

---

## Acceptance criteria

| Criterion | Status |
|---|---|
| Event for contract with no matching subscription is dropped | ✅ |
| Event matching a topic-pattern filter is delivered | ✅ |
| Two subscriptions on overlapping filters each receive the event exactly once | ✅ |

---

## Testing

```
pnpm --filter @orbital/pulse-core typecheck   # clean
pnpm --filter @orbital/pulse-core test        # 115 passed (12 new)
``closes #294 