### PR TITLE
feat(pulse-core): add PostgresCursorStore adapter

### DIFF
--- a/packages/pulse-core/migrations/001_cursor_store.sql
+++ b/packages/pulse-core/migrations/001_cursor_store.sql
@@ -1,0 +1,6 @@
+-- Migration: create cursor_store table for PostgresCursorStore
+CREATE TABLE IF NOT EXISTS cursor_store (
+    stream_key TEXT PRIMARY KEY,
+    cursor TEXT NOT NULL,
+    updated_at TIMESTAMP NOT NULL DEFAULT NOW()
+);

--- a/packages/pulse-core/package.json
+++ b/packages/pulse-core/package.json
@@ -18,7 +18,9 @@
   },
   "devDependencies": {
     "@types/node": "^25.6.0",
+    "@types/pg": "^8.11.11",
     "@vitest/coverage-v8": "^4.1.7",
+    "pg": "^8.11.5",
     "tsx": "^4.21.0",
     "vite": "^7.3.3",
     "vitest": "^4.1.7"

--- a/packages/pulse-core/src/CursorStore.ts
+++ b/packages/pulse-core/src/CursorStore.ts
@@ -1,0 +1,15 @@
+/**
+ * Pluggable durable store interface for the Horizon stream cursor.
+ */
+export interface CursorStore {
+  /**
+   * Retrieves the stored cursor for a given stream key.
+   * Returns null if no cursor has been stored yet.
+   */
+  get(streamKey: string): Promise<string | null>;
+
+  /**
+   * Stores or updates the cursor for a given stream key.
+   */
+  set(streamKey: string, cursor: string): Promise<void>;
+}

--- a/packages/pulse-core/src/PostgresCursorStore.ts
+++ b/packages/pulse-core/src/PostgresCursorStore.ts
@@ -1,0 +1,43 @@
+import { CursorStore } from "./CursorStore.js";
+
+/**
+ * Minimal interface required from a PostgreSQL client.
+ * Compatible with `pg` Pool or Client.
+ */
+export interface PgLike {
+  /**
+   * Execute a query with optional parameters.
+   * Should return an object with a `rows` field containing result rows.
+   */
+  query: (text: string, params?: any[]) => Promise<{ rows: any[] }>;
+}
+
+/**
+ * PostgreSQL implementation of {@link CursorStore}.
+ * Stores a cursor per `stream_key` with an upsert strategy.
+ */
+export class PostgresCursorStore implements CursorStore {
+  private readonly pg: PgLike;
+
+  constructor(pg: PgLike) {
+    this.pg = pg;
+  }
+
+  async get(streamKey: string): Promise<string | null> {
+    const result = await this.pg.query(
+      "SELECT cursor FROM cursor_store WHERE stream_key = $1",
+      [streamKey]
+    );
+    if (result.rows.length === 0) return null;
+    return result.rows[0].cursor as string;
+  }
+
+  async set(streamKey: string, cursor: string): Promise<void> {
+    await this.pg.query(
+      `INSERT INTO cursor_store (stream_key, cursor, updated_at)
+       VALUES ($1, $2, NOW())
+       ON CONFLICT (stream_key) DO UPDATE SET cursor = EXCLUDED.cursor, updated_at = NOW();`,
+      [streamKey, cursor]
+    );
+  }
+}

--- a/packages/pulse-core/src/index.ts
+++ b/packages/pulse-core/src/index.ts
@@ -2,6 +2,8 @@ export { EventEngine } from "./EventEngine.js";
 export { Watcher } from "./Watcher.js";
 export { EngineAlreadyStartedError } from "./errors.js";
 export { StrKey } from "@stellar/stellar-sdk";
+export { CursorStore } from "./CursorStore.js";
+export { PostgresCursorStore, PgLike } from "./PostgresCursorStore.js";
 
 /** The Stellar network to connect to. */
 export type Network = "mainnet" | "testnet";

--- a/packages/pulse-core/test/PostgresCursorStore.test.ts
+++ b/packages/pulse-core/test/PostgresCursorStore.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { PostgresCursorStore } from "../src/PostgresCursorStore.js";
+import pg from "pg";
+import fs from "fs";
+import path from "path";
+
+describe("PostgresCursorStore Integration Test", () => {
+  const isIntegrationTest = process.env.INTEGRATION_TESTS === "true";
+
+  // Skip all tests in this suite if not running integration tests
+  if (!isIntegrationTest) {
+    it("skipping PostgresCursorStore integration tests (INTEGRATION_TESTS is not true)", () => {
+      expect(true).toBe(true);
+    });
+    return;
+  }
+
+  const connectionString = process.env.PG_TEST_URL || "postgres://postgres:postgres@localhost:5432/postgres";
+  let pool: pg.Pool;
+  let store: PostgresCursorStore;
+
+  beforeAll(async () => {
+    pool = new pg.Pool({ connectionString });
+    store = new PostgresCursorStore(pool);
+
+    // Run the migration SQL file to set up the test database table
+    const migrationPath = path.resolve(__dirname, "../migrations/001_cursor_store.sql");
+    const migrationSql = fs.readFileSync(migrationPath, "utf8");
+    await pool.query(migrationSql);
+  });
+
+  afterAll(async () => {
+    if (pool) {
+      // Clean up test rows
+      await pool.query("DELETE FROM cursor_store WHERE stream_key LIKE $1", ["test-stream-%"]);
+      await pool.end();
+    }
+  });
+
+  it("should return null when getting a non-existent cursor", async () => {
+    const cursor = await store.get("test-stream-nonexistent");
+    expect(cursor).toBeNull();
+  });
+
+  it("should insert a new cursor on set and retrieve it on get", async () => {
+    const streamKey = "test-stream-1";
+    const cursorVal = "12345678";
+
+    await store.set(streamKey, cursorVal);
+
+    const retrieved = await store.get(streamKey);
+    expect(retrieved).toBe(cursorVal);
+  });
+
+  it("should upsert the cursor on set when it already exists", async () => {
+    const streamKey = "test-stream-2";
+    const cursor1 = "first-cursor";
+    const cursor2 = "second-cursor";
+
+    await store.set(streamKey, cursor1);
+    const retrieved1 = await store.get(streamKey);
+    expect(retrieved1).toBe(cursor1);
+
+    await store.set(streamKey, cursor2);
+    const retrieved2 = await store.get(streamKey);
+    expect(retrieved2).toBe(cursor2);
+
+    // Verify row count in database to ensure it upserted instead of creating multiple rows
+    const res = await pool.query("SELECT COUNT(*) FROM cursor_store WHERE stream_key = $1", [streamKey]);
+    expect(parseInt(res.rows[0].count, 10)).toBe(1);
+  });
+});


### PR DESCRIPTION
 This pr closes #339
Overview
This PR implements **PostgresCursorStore** (Phase 1 Milestone M4), introducing the core `CursorStore` interface, a PostgreSQL adapter, and integration tests to support crash-resilient streaming and webhook replaying in Orbital.

PostgreSQL is the standard cursor storage layer in regulated-money environments, and this addition allows consumers to resume SSE streams from the last successfully stored cursor position.

 Changes

1. Pluggable `CursorStore` Interface
- **Added `packages/pulse-core/src/CursorStore.ts`**: Standardizes the persistence mechanism for stream cursors with `get(streamKey)` and `set(streamKey, cursor)` methods.
- **Exported `CursorStore`** in `packages/pulse-core/src/index.ts`.

 2. `PostgresCursorStore` Adapter
- **Added `packages/pulse-core/src/PostgresCursorStore.ts`**: Adapts the `CursorStore` interface for PostgreSQL.
- **`PgLike` Client Interface**: Accepts any Postgres client (e.g. `pg` Client/Pool) implementing a `query(text, params)` method to keep `pulse-core` production dependencies lightweight and native-free.
- **Implementation Strategy**: Implements row-level reading in `get` and an atomic upsert strategy (`INSERT ... ON CONFLICT (stream_key) DO UPDATE`) in `set`.

 3. Database Schema Migration
- **Added `packages/pulse-core/migrations/001_cursor_store.sql`**: Provides the migration SQL file defining the `cursor_store` table schema:
  - `stream_key TEXT PRIMARY KEY`
  - `cursor TEXT NOT NULL`
  - `updated_at TIMESTAMP NOT NULL DEFAULT NOW()`

 4. Integration Tests
- **Added `packages/pulse-core/test/PostgresCursorStore.test.ts`**: Comprehensive integration tests checking:
  - Returning `null` on nonexistent cursor queries.
  - Setting a cursor and retrieving it.
  - Upserting and verifying row updates (ensuring multiple insertions do not cause duplicate keys).
- **Added `pg` and `@types/pg`** to `pulse-core` devDependencies to facilitate the integration suite without imposing production runtime dependencies.

 Verification & Testing
Integration tests run automatically under `INTEGRATION_TESTS=true`. 

To run the integration suite locally with a running Postgres instance:
```bash
INTEGRATION_TESTS=true PG_TEST_URL=postgres://postgres:postgres@localhost:5432/postgres pnpm test