### PR TITLE
feat(pulse-core): support structured logger metadata

### DIFF
--- a/packages/pulse-core/src/EventEngine.ts
+++ b/packages/pulse-core/src/EventEngine.ts
@@ -16,6 +16,7 @@ import type {
   DataEvent,
   DataEventType,
   EngineStatus,
+  Logger,
   LiquidityPoolDepositEvent,
   LiquidityPoolWithdrawEvent,
   Network,
@@ -73,7 +74,7 @@ const DEFAULT_RECONNECT: Required<ReconnectConfig> = {
 
 const STELLAR_MAX_TRUSTLINE_LIMIT = "922337203685.4775807";
 
-const noop = { info: () => {}, warn: () => {}, error: () => {} };
+const noop: Logger = { info: () => {}, warn: () => {}, error: () => {} };
 
 export class EventEngine {
   private server: Horizon.Server;
@@ -85,7 +86,7 @@ export class EventEngine {
   private readonly reconnectConfig: Required<ReconnectConfig>;
   private isRunning = false;
   private filters: Map<string, (event: NormalizedEvent) => boolean> = new Map();
-  private log: Required<NonNullable<CoreConfig["logger"]>>;
+  private log: Logger;
   private lastEventAt: string | null = null;
 
   /**
@@ -131,7 +132,8 @@ export class EventEngine {
     if (existingWatcher) {
       if (options?.filter) {
         this.log.warn(
-          `[pulse-core] subscribe() called for address ${address} which already has an active watcher — filter option ignored.`
+          "[pulse-core] subscribe() called for an address that already has an active watcher. Filter option ignored.",
+          { address, hasFilter: true }
         );
       }
       return existingWatcher;
@@ -177,7 +179,13 @@ export class EventEngine {
       if (options?.strict) {
         throw new EngineAlreadyStartedError();
       }
-      this.log.warn("[pulse-core] EventEngine.start() called while the SSE stream is already active.");
+      this.log.warn(
+        "[pulse-core] EventEngine.start() called while the SSE stream is already active.",
+        {
+          isRunning: this.isRunning,
+          reconnectTimerActive: this.reconnectTimer !== null,
+        }
+      );
       return false;
     }
 
@@ -233,7 +241,7 @@ export class EventEngine {
           const attempt = this.pendingReconnectSuccessAttempt;
           this.pendingReconnectSuccessAttempt = null;
           this.reconnectAttempt = 0;
-          this.log.info(`[pulse-core] SSE reconnect succeeded on attempt ${attempt}.`);
+          this.log.info("[pulse-core] SSE reconnect succeeded.", { attempt });
           this.notifyWatchers("engine.reconnected", {
             type: "engine.reconnected",
             attempt,
@@ -249,7 +257,7 @@ export class EventEngine {
         this.route(event);
       },
       onerror: (error) => {
-        this.log.error(`[pulse-core] SSE error: ${error}`);
+        this.log.error("[pulse-core] SSE error.", { error });
         this.handleStreamError(error);
       },
     };
@@ -271,7 +279,9 @@ export class EventEngine {
 
     const nextAttempt = this.reconnectAttempt + 1;
     if (nextAttempt > this.reconnectConfig.maxRetries) {
-      this.log.error(`[pulse-core] SSE reconnect stopped after ${this.reconnectAttempt} failed attempts.`);
+      this.log.error("[pulse-core] SSE reconnect stopped.", {
+        failedAttempts: this.reconnectAttempt,
+      });
       return;
     }
 
@@ -284,7 +294,10 @@ export class EventEngine {
       const retryAfterMs = this.parseRetryAfterMs(error);
       delayMs = retryAfterMs ?? 60000;
 
-      this.log.warn(`[pulse-core] SSE rate limited by Horizon, reconnect scheduled in ${delayMs}ms.`);
+      this.log.warn("[pulse-core] SSE rate limited by Horizon, reconnect scheduled.", {
+        attempt: nextAttempt,
+        delayMs,
+      });
       this.notifyWatchers("engine.rate_limited", {
         type: "engine.rate_limited",
         attempt: nextAttempt,
@@ -298,7 +311,10 @@ export class EventEngine {
       );
       delayMs = Math.floor(Math.random() * exponentialDelay);
 
-      this.log.warn(`[pulse-core] SSE reconnect attempt ${nextAttempt} scheduled in ${delayMs}ms.`);
+      this.log.warn("[pulse-core] SSE reconnect attempt scheduled.", {
+        attempt: nextAttempt,
+        delayMs,
+      });
       this.notifyWatchers("engine.reconnecting", {
         type: "engine.reconnecting",
         attempt: nextAttempt,
@@ -432,7 +448,12 @@ export class EventEngine {
       const requiredFields = ["to", "from", "amount", "created_at"] as const;
       for (const field of requiredFields) {
         if (typeof r[field] !== "string" || r[field] === "") {
-          this.log.warn(`[pulse-core] normalize() dropping payment record: field "${field}" is missing or not a non-empty string.`);
+          this.log.warn("[pulse-core] normalize() dropping payment record.", {
+            field,
+            record: raw,
+            source: r.from,
+            address: r.to,
+          });
           return null;
         }
       }
@@ -601,12 +622,19 @@ export class EventEngine {
     raw: unknown
   ): DataEvent | null {
     if (typeof r.source_account !== "string" || r.source_account === "") {
-      this.log.warn("[pulse-core] normalize() dropping manage_data record: source_account is missing.");
+      this.log.warn("[pulse-core] normalize() dropping manage_data record.", {
+        field: "source_account",
+        record: raw,
+      });
       return null;
     }
 
     if (typeof r.data_name !== "string" || r.data_name === "") {
-      this.log.warn("[pulse-core] normalize() dropping manage_data record: data_name is missing.");
+      this.log.warn("[pulse-core] normalize() dropping manage_data record.", {
+        field: "data_name",
+        record: raw,
+        source: r.source_account,
+      });
       return null;
     }
 
@@ -728,8 +756,8 @@ export class EventEngine {
     for (const field of requiredStringFields) {
       if (typeof r[field] !== "string" || r[field] === "") {
         this.log.warn(
-          `[pulse-core] normalize() dropping create_claimable_balance record: field "${field}" is missing or not a non-empty string.`,
-          { record: raw }
+          "[pulse-core] normalize() dropping create_claimable_balance record.",
+          { field, record: raw, source: r.source_account }
         );
         return null;
       }
@@ -747,8 +775,8 @@ export class EventEngine {
       )
     ) {
       this.log.warn(
-        '[pulse-core] normalize() dropping create_claimable_balance record: field "claimants" is missing or invalid.',
-        { record: raw }
+        "[pulse-core] normalize() dropping create_claimable_balance record.",
+        { field: "claimants", record: raw, source: r.source_account }
       );
       return null;
     }
@@ -786,8 +814,8 @@ export class EventEngine {
     for (const field of requiredStringFields) {
       if (typeof r[field] !== "string" || r[field] === "") {
         this.log.warn(
-          `[pulse-core] normalize() dropping claim_claimable_balance record: field "${field}" is missing or not a non-empty string.`,
-          { record: raw }
+          "[pulse-core] normalize() dropping claim_claimable_balance record.",
+          { field, record: raw, source: r.source_account }
         );
         return null;
       }
@@ -816,8 +844,8 @@ export class EventEngine {
     for (const field of requiredFields) {
       if (typeof r[field] !== "string" || r[field] === "") {
         this.log.warn(
-          `[pulse-core] normalize() dropping liquidity_pool_deposit record: field "${field}" is missing.`,
-          { record: raw }
+          "[pulse-core] normalize() dropping liquidity_pool_deposit record.",
+          { field, record: raw, source: r.source_account }
         );
         return null;
       }
@@ -825,8 +853,8 @@ export class EventEngine {
 
     if (!Array.isArray(r.reserves_deposited)) {
       this.log.warn(
-        "[pulse-core] normalize() dropping liquidity_pool_deposit record: reserves_deposited is not an array.",
-        { record: raw }
+        "[pulse-core] normalize() dropping liquidity_pool_deposit record.",
+        { field: "reserves_deposited", record: raw, source: r.source_account }
       );
       return null;
     }
@@ -856,8 +884,8 @@ export class EventEngine {
     for (const field of requiredFields) {
       if (typeof r[field] !== "string" || r[field] === "") {
         this.log.warn(
-          `[pulse-core] normalize() dropping liquidity_pool_withdraw record: field "${field}" is missing.`,
-          { record: raw }
+          "[pulse-core] normalize() dropping liquidity_pool_withdraw record.",
+          { field, record: raw, source: r.source_account }
         );
         return null;
       }
@@ -865,8 +893,8 @@ export class EventEngine {
 
     if (!Array.isArray(r.reserves_received)) {
       this.log.warn(
-        "[pulse-core] normalize() dropping liquidity_pool_withdraw record: reserves_received is not an array.",
-        { record: raw }
+        "[pulse-core] normalize() dropping liquidity_pool_withdraw record.",
+        { field: "reserves_received", record: raw, source: r.source_account }
       );
       return null;
     }
@@ -958,8 +986,8 @@ export class EventEngine {
       return filter(event);
     } catch (err) {
       this.log.warn(
-        `[pulse-core] subscribe() filter threw for address ${address} — treating as reject.`,
-        err
+        "[pulse-core] subscribe() filter threw for address. Treating as reject.",
+        { address, error: err }
       );
       return false;
     }

--- a/packages/pulse-core/src/index.ts
+++ b/packages/pulse-core/src/index.ts
@@ -303,6 +303,18 @@ export type ReconnectConfig = {
 };
 
 /**
+ * Structured logger interface accepted by EventEngine.
+ *
+ * The second argument carries metadata that downstream loggers can serialize as JSON
+ * or map into their own structured logging format.
+ */
+export interface Logger {
+  info(message: string, meta?: Record<string, unknown>): void;
+  warn(message: string, meta?: Record<string, unknown>): void;
+  error(message: string, meta?: Record<string, unknown>): void;
+}
+
+/**
  * Core configuration for initializing the EventEngine.
  *
  * @example
@@ -318,11 +330,7 @@ export type CoreConfig = {
   horizonUrl?: string;
   /** Optional reconnection configuration. */
   reconnect?: ReconnectConfig;
-  logger?: {
-    info(msg: string, ...args: unknown[]): void;
-    warn(msg: string, ...args: unknown[]): void;
-    error(msg: string, ...args: unknown[]): void;
-  };
+  logger?: Logger;
 };
 
 // Error class for invalid network validation

--- a/packages/pulse-core/test/pulse-core.test.ts
+++ b/packages/pulse-core/test/pulse-core.test.ts
@@ -178,7 +178,8 @@ describe("pulse-core EventEngine", () => {
 
     expect(result).toBeNull();
     expect(log.warn).toHaveBeenCalledWith(
-      '[pulse-core] normalize() dropping payment record: field "to" is missing or not a non-empty string.'
+      "[pulse-core] normalize() dropping payment record.",
+      expect.objectContaining({ field: "to", record: expect.any(Object) })
     );
   });
 
@@ -201,7 +202,8 @@ describe("pulse-core EventEngine", () => {
       const result = normalize(record);
       expect(result).toBeNull();
       expect(log.warn).toHaveBeenCalledWith(
-        `[pulse-core] normalize() dropping payment record: field "${field}" is missing or not a non-empty string.`
+        "[pulse-core] normalize() dropping payment record.",
+        expect.objectContaining({ field, record: expect.any(Object) })
       );
     }
   });
@@ -298,7 +300,11 @@ describe("pulse-core EventEngine", () => {
     expect(second).toBe(false);
     expect(streamInstances).toHaveLength(1);
     expect(log.warn).toHaveBeenCalledWith(
-      "[pulse-core] EventEngine.start() called while the SSE stream is already active."
+      "[pulse-core] EventEngine.start() called while the SSE stream is already active.",
+      expect.objectContaining({
+        isRunning: true,
+        reconnectTimerActive: false,
+      })
     );
   });
 
@@ -367,7 +373,10 @@ describe("pulse-core EventEngine", () => {
     expect(reconnecting).toHaveBeenCalledWith(
       expect.objectContaining({ type: "engine.reconnecting", attempt: 1, delayMs: expect.any(Number), emittedAt: expect.any(String) })
     );
-    expect(log.warn).toHaveBeenCalledWith("[pulse-core] SSE reconnect attempt 1 scheduled in 1000ms.");
+    expect(log.warn).toHaveBeenCalledWith(
+      "[pulse-core] SSE reconnect attempt scheduled.",
+      expect.objectContaining({ attempt: 1, delayMs: 1000 })
+    );
     expect(streamInstances).toHaveLength(1);
 
     vi.advanceTimersByTime(1000);
@@ -375,7 +384,10 @@ describe("pulse-core EventEngine", () => {
 
     latestStream().handlers.onerror(new Error("stream dropped again"));
     expect(streamInstances[1]?.close).toHaveBeenCalledTimes(1);
-    expect(log.warn).toHaveBeenLastCalledWith("[pulse-core] SSE reconnect attempt 2 scheduled in 2000ms.");
+    expect(log.warn).toHaveBeenLastCalledWith(
+      "[pulse-core] SSE reconnect attempt scheduled.",
+      expect.objectContaining({ attempt: 2, delayMs: 2000 })
+    );
 
     vi.advanceTimersByTime(2000);
     expect(streamInstances).toHaveLength(3);
@@ -387,7 +399,10 @@ describe("pulse-core EventEngine", () => {
     expect(reconnected).toHaveBeenCalledWith(
       expect.objectContaining({ type: "engine.reconnected", attempt: 2, emittedAt: expect.any(String) })
     );
-    expect(log.info).toHaveBeenCalledWith("[pulse-core] SSE reconnect succeeded on attempt 2.");
+    expect(log.info).toHaveBeenCalledWith(
+      "[pulse-core] SSE reconnect succeeded.",
+      expect.objectContaining({ attempt: 2 })
+    );
 
     latestStream().handlers.onerror(new Error("stream dropped after recovery"));
     expect(reconnecting).toHaveBeenLastCalledWith(
@@ -425,7 +440,8 @@ describe("pulse-core EventEngine", () => {
       })
     );
     expect(log.warn).toHaveBeenCalledWith(
-      "[pulse-core] SSE reconnect attempt 1 scheduled in 500ms."
+      "[pulse-core] SSE reconnect attempt scheduled.",
+      expect.objectContaining({ attempt: 1, delayMs: 500 })
     );
 
     // Advance timer to trigger reconnect
@@ -449,7 +465,8 @@ describe("pulse-core EventEngine", () => {
       })
     );
     expect(log.info).toHaveBeenCalledWith(
-      "[pulse-core] SSE reconnect succeeded on attempt 1."
+      "[pulse-core] SSE reconnect succeeded.",
+      expect.objectContaining({ attempt: 1 })
     );
   });
 
@@ -481,7 +498,8 @@ describe("pulse-core EventEngine", () => {
     );
     expect(reconnecting).not.toHaveBeenCalled();
     expect(log.warn).toHaveBeenCalledWith(
-      "[pulse-core] SSE rate limited by Horizon, reconnect scheduled in 5000ms."
+      "[pulse-core] SSE rate limited by Horizon, reconnect scheduled.",
+      expect.objectContaining({ attempt: 1, delayMs: 5000 })
     );
 
     vi.advanceTimersByTime(5000);
@@ -510,7 +528,8 @@ describe("pulse-core EventEngine", () => {
       })
     );
     expect(log.warn).toHaveBeenCalledWith(
-      "[pulse-core] SSE rate limited by Horizon, reconnect scheduled in 60000ms."
+      "[pulse-core] SSE rate limited by Horizon, reconnect scheduled.",
+      expect.objectContaining({ attempt: 1, delayMs: 60000 })
     );
   });
 
@@ -527,19 +546,31 @@ describe("pulse-core EventEngine", () => {
       vi.spyOn(Math, "random").mockReturnValue(0.999999);
 
       latestStream().handlers.onerror(new Error("err"));
-      expect(log.warn).toHaveBeenLastCalledWith(expect.stringContaining("scheduled in 999ms."));
+      expect(log.warn).toHaveBeenLastCalledWith(
+        "[pulse-core] SSE reconnect attempt scheduled.",
+        expect.objectContaining({ attempt: 1, delayMs: 999 })
+      );
       vi.advanceTimersByTime(1000);
 
       latestStream().handlers.onerror(new Error("err"));
-      expect(log.warn).toHaveBeenLastCalledWith(expect.stringContaining("scheduled in 1999ms."));
+      expect(log.warn).toHaveBeenLastCalledWith(
+        "[pulse-core] SSE reconnect attempt scheduled.",
+        expect.objectContaining({ attempt: 2, delayMs: 1999 })
+      );
       vi.advanceTimersByTime(2000);
 
       latestStream().handlers.onerror(new Error("err"));
-      expect(log.warn).toHaveBeenLastCalledWith(expect.stringContaining("scheduled in 3999ms."));
+      expect(log.warn).toHaveBeenLastCalledWith(
+        "[pulse-core] SSE reconnect attempt scheduled.",
+        expect.objectContaining({ attempt: 3, delayMs: 3999 })
+      );
       vi.advanceTimersByTime(4000);
 
       latestStream().handlers.onerror(new Error("err"));
-      expect(log.warn).toHaveBeenLastCalledWith(expect.stringContaining("scheduled in 4999ms."));
+      expect(log.warn).toHaveBeenLastCalledWith(
+        "[pulse-core] SSE reconnect attempt scheduled.",
+        expect.objectContaining({ attempt: 4, delayMs: 4999 })
+      );
     });
 
     it("max-retries terminates the loop", () => {
@@ -552,15 +583,24 @@ describe("pulse-core EventEngine", () => {
       engine.start();
 
       latestStream().handlers.onerror(new Error("err"));
-      expect(log.warn).toHaveBeenCalledWith(expect.stringContaining("attempt 1 scheduled"));
+      expect(log.warn).toHaveBeenCalledWith(
+        "[pulse-core] SSE reconnect attempt scheduled.",
+        expect.objectContaining({ attempt: 1 })
+      );
       vi.advanceTimersByTime(1000);
 
       latestStream().handlers.onerror(new Error("err"));
-      expect(log.warn).toHaveBeenCalledWith(expect.stringContaining("attempt 2 scheduled"));
+      expect(log.warn).toHaveBeenCalledWith(
+        "[pulse-core] SSE reconnect attempt scheduled.",
+        expect.objectContaining({ attempt: 2 })
+      );
       vi.advanceTimersByTime(1000);
 
       latestStream().handlers.onerror(new Error("err"));
-      expect(log.error).toHaveBeenLastCalledWith("[pulse-core] SSE reconnect stopped after 2 failed attempts.");
+      expect(log.error).toHaveBeenLastCalledWith(
+        "[pulse-core] SSE reconnect stopped.",
+        expect.objectContaining({ failedAttempts: 2 })
+      );
     });
 
     it("attempt counter resets after engine.reconnected", () => {
@@ -575,18 +615,30 @@ describe("pulse-core EventEngine", () => {
       vi.spyOn(Math, "random").mockReturnValue(0.999999);
 
       latestStream().handlers.onerror(new Error("err"));
-      expect(log.warn).toHaveBeenLastCalledWith(expect.stringContaining("attempt 1 scheduled in 999ms"));
+      expect(log.warn).toHaveBeenLastCalledWith(
+        "[pulse-core] SSE reconnect attempt scheduled.",
+        expect.objectContaining({ attempt: 1, delayMs: 999 })
+      );
       vi.advanceTimersByTime(1000);
 
       latestStream().handlers.onerror(new Error("err"));
-      expect(log.warn).toHaveBeenLastCalledWith(expect.stringContaining("attempt 2 scheduled in 1999ms"));
+      expect(log.warn).toHaveBeenLastCalledWith(
+        "[pulse-core] SSE reconnect attempt scheduled.",
+        expect.objectContaining({ attempt: 2, delayMs: 1999 })
+      );
       vi.advanceTimersByTime(2000);
 
       latestStream().handlers.onmessage({ type: "payment", to: "GABC", from: "X", amount: "1", created_at: "now" });
-      expect(log.info).toHaveBeenCalledWith("[pulse-core] SSE reconnect succeeded on attempt 2.");
+      expect(log.info).toHaveBeenCalledWith(
+        "[pulse-core] SSE reconnect succeeded.",
+        expect.objectContaining({ attempt: 2 })
+      );
 
       latestStream().handlers.onerror(new Error("err"));
-      expect(log.warn).toHaveBeenLastCalledWith(expect.stringContaining("attempt 1 scheduled in 999ms"));
+      expect(log.warn).toHaveBeenLastCalledWith(
+        "[pulse-core] SSE reconnect attempt scheduled.",
+        expect.objectContaining({ attempt: 1, delayMs: 999 })
+      );
     });
 
     it("jitter test using a seeded-like mock", () => {
@@ -600,12 +652,18 @@ describe("pulse-core EventEngine", () => {
 
       vi.spyOn(Math, "random").mockReturnValue(0.5);
       latestStream().handlers.onerror(new Error("err"));
-      expect(log.warn).toHaveBeenLastCalledWith(expect.stringContaining("scheduled in 500ms."));
+      expect(log.warn).toHaveBeenLastCalledWith(
+        "[pulse-core] SSE reconnect attempt scheduled.",
+        expect.objectContaining({ attempt: 1, delayMs: 500 })
+      );
 
       vi.advanceTimersByTime(500);
       vi.spyOn(Math, "random").mockReturnValue(0.1);
       latestStream().handlers.onerror(new Error("err"));
-      expect(log.warn).toHaveBeenLastCalledWith(expect.stringContaining("scheduled in 200ms."));
+      expect(log.warn).toHaveBeenLastCalledWith(
+        "[pulse-core] SSE reconnect attempt scheduled.",
+        expect.objectContaining({ attempt: 2, delayMs: 200 })
+      );
     });
   });
 
@@ -784,8 +842,8 @@ describe("pulse-core EventEngine", () => {
 
       expect(handler).not.toHaveBeenCalled();
       expect(log.warn).toHaveBeenCalledWith(
-        "[pulse-core] subscribe() filter threw for address GDEST — treating as reject.",
-        filterError
+        "[pulse-core] subscribe() filter threw for address. Treating as reject.",
+        expect.objectContaining({ address: "GDEST", error: filterError })
       );
 
       const unfiltered = engine.subscribe("GSRC");
@@ -802,7 +860,8 @@ describe("pulse-core EventEngine", () => {
 
       expect(second).toBe(first);
       expect(log.warn).toHaveBeenCalledWith(
-        "[pulse-core] subscribe() called for address GDEST which already has an active watcher — filter option ignored."
+        "[pulse-core] subscribe() called for an address that already has an active watcher. Filter option ignored.",
+        expect.objectContaining({ address: "GDEST", hasFilter: true })
       );
     });
   });
@@ -1468,8 +1527,8 @@ describe("pulse-core EventEngine", () => {
 
       expect(result).toBeNull();
       expect(log.warn).toHaveBeenCalledWith(
-        '[pulse-core] normalize() dropping create_claimable_balance record: field "balance_id" is missing or not a non-empty string.',
-        expect.objectContaining({ record: expect.any(Object) })
+        "[pulse-core] normalize() dropping create_claimable_balance record.",
+        expect.objectContaining({ field: "balance_id", record: expect.any(Object) })
       );
     });
 
@@ -1483,8 +1542,8 @@ describe("pulse-core EventEngine", () => {
 
       expect(result).toBeNull();
       expect(log.warn).toHaveBeenCalledWith(
-        '[pulse-core] normalize() dropping create_claimable_balance record: field "claimants" is missing or invalid.',
-        expect.objectContaining({ record: expect.any(Object) })
+        "[pulse-core] normalize() dropping create_claimable_balance record.",
+        expect.objectContaining({ field: "claimants", record: expect.any(Object) })
       );
     });
 
@@ -1596,8 +1655,8 @@ describe("pulse-core EventEngine", () => {
         const result = normalize(record);
         expect(result).toBeNull();
         expect(log.warn).toHaveBeenCalledWith(
-          `[pulse-core] normalize() dropping claim_claimable_balance record: field "${field}" is missing or not a non-empty string.`,
-          expect.objectContaining({ record: expect.any(Object) })
+          "[pulse-core] normalize() dropping claim_claimable_balance record.",
+          expect.objectContaining({ field, record: expect.any(Object) })
         );
       }
     });
@@ -1701,8 +1760,8 @@ describe("pulse-core EventEngine", () => {
 
       expect(result).toBeNull();
       expect(log.warn).toHaveBeenCalledWith(
-        '[pulse-core] normalize() dropping liquidity_pool_deposit record: field "liquidity_pool_id" is missing.',
-        expect.objectContaining({ record: expect.any(Object) })
+        "[pulse-core] normalize() dropping liquidity_pool_deposit record.",
+        expect.objectContaining({ field: "liquidity_pool_id", record: expect.any(Object) })
       );
     });
 
@@ -1716,8 +1775,8 @@ describe("pulse-core EventEngine", () => {
 
       expect(result).toBeNull();
       expect(log.warn).toHaveBeenCalledWith(
-        "[pulse-core] normalize() dropping liquidity_pool_deposit record: reserves_deposited is not an array.",
-        expect.objectContaining({ record: expect.any(Object) })
+        "[pulse-core] normalize() dropping liquidity_pool_deposit record.",
+        expect.objectContaining({ field: "reserves_deposited", record: expect.any(Object) })
       );
     });
   });
@@ -1787,8 +1846,8 @@ describe("pulse-core EventEngine", () => {
 
       expect(result).toBeNull();
       expect(log.warn).toHaveBeenCalledWith(
-        '[pulse-core] normalize() dropping liquidity_pool_withdraw record: field "shares" is missing.',
-        expect.objectContaining({ record: expect.any(Object) })
+        "[pulse-core] normalize() dropping liquidity_pool_withdraw record.",
+        expect.objectContaining({ field: "shares", record: expect.any(Object) })
       );
     });
   });


### PR DESCRIPTION
## Linked issue

Closes #317 

## What changed and why

Added a structured logger interface to `pulse-core` so `EventEngine` can send metadata as a second argument instead of embedding all context in strings. Internal log calls now include structured fields like `address`, `source`, `field`, `attempt`, and `delayMs`, which makes the engine easier to integrate with JSON loggers such as pino or winston while keeping the default no-op logger backward compatible.

## Test plan

- [ ] Existing tests pass (`pnpm test`)
- [x] New tests added for new behaviour
- [ ] Typechecks pass (`pnpm -r typecheck`)
- [ ] Manually tested against testnet / mainnet

I updated the `pulse-core` test suite to assert the new structured logger calls, but I couldn’t run the full test/typecheck commands in this workspace because dependencies are not installed here.

## Breaking changes

None

## Notes for reviewers

The public `CoreConfig.logger` type is now exported as `Logger` from `packages/pulse-core/src/index.ts`. Existing consumers that only provide `info/warn/error` methods should continue to work, and the new `meta` parameter is optional.