### PR TITLE
feat: implement SorobanSubscriber with automatic cursor-expired recov…

### DIFF
--- a/packages/pulse-core/src/SorobanSubscriber.ts
+++ b/packages/pulse-core/src/SorobanSubscriber.ts
@@ -15,8 +15,38 @@ import { SorobanRpcError } from "./errors.js";
  *   4. Silently drops any events that arrive from an aborted poll.
  */
 
+// ---------------------------------------------------------------------------
+// Minimal LRU set (Map-backed, insertion-order eviction).
+// ---------------------------------------------------------------------------
+
+class LruSet {
+  private readonly map = new Map<string, 1>();
+
+  constructor(private readonly maxSize: number) { }
+
+  has(id: string): boolean {
+    return this.map.has(id);
+  }
+
+  add(id: string): void {
+    if (this.map.has(id)) this.map.delete(id);
+    this.map.set(id, 1);
+    if (this.map.size > this.maxSize) {
+      this.map.delete(this.map.keys().next().value as string);
+    }
+  }
+
+  get size(): number {
+    return this.map.size;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
 /** Minimal interface for a cursor persistence layer. */
-export interface CursorStore {
+export interface CursorStoreLike {
   getCursor(): Promise<string | undefined>;
   saveCursor(cursor: string): Promise<void>;
 }
@@ -502,5 +532,260 @@ export class SorobanSubscriber {
       if ((err as NodeJS.ErrnoException).code === "ABORT_ERR") return true;
     }
     return false;
+  }
+}
+
+import { rpc } from "@stellar/stellar-sdk";
+import type { Watcher } from "./Watcher.js";
+import type { CursorStore, SorobanCursorExpiredNotification } from "./index.js";
+
+/**
+ * Options accepted by SorobanSubscriber.
+ */
+export type SorobanSubscriberOptionsCursorExpired = {
+  /**
+   * The Stellar RPC server URL to poll events from.
+   * Example: "https://soroban-testnet.stellar.org"
+   */
+  rpcUrl: string;
+
+  /**
+   * A human-readable label identifying the event source (e.g. contract address
+   * or subscriber name). Included in the engine.cursor_expired notification so
+   * callers can identify which subscriber expired.
+   */
+  source: string;
+
+  /**
+   * The cursor to resume from (opaque string returned by a previous
+   * getEvents response). When undefined or empty the subscriber starts
+   * from the latest ledger instead.
+   */
+  cursor?: string;
+
+  /**
+   * Filters forwarded verbatim to rpc.Server.getEvents.
+   * Leave undefined to receive all events visible to the RPC server.
+   */
+  filters?: rpc.Api.GetEventsRequest["filters"];
+
+  /**
+   * How many milliseconds to wait between polling cycles.
+   * Defaults to 5_000 (5 seconds).
+   */
+  pollIntervalMs?: number;
+
+  /**
+   * Optional logger. Falls back to a no-op logger when omitted.
+   */
+  logger?: {
+    info(msg: string, ...args: unknown[]): void;
+    warn(msg: string, ...args: unknown[]): void;
+    error(msg: string, ...args: unknown[]): void;
+  };
+};
+
+/** JSON-RPC error shape thrown by @stellar/stellar-sdk when the RPC server
+ *  returns an error response. The `code` field is the JSON-RPC error code. */
+type JsonRpcError = {
+  code: number;
+  message: string;
+  data?: unknown;
+};
+
+/**
+ * Detects whether the error thrown by rpc.Server.getEvents indicates
+ * that the supplied cursor (or startLedger) is outside the server's retention
+ * window.
+ *
+ * Stellar RPC returns JSON-RPC error code -32600 ("Invalid Request") with a
+ * message containing "startLedger" or "cursor" and a phrase like "before the
+ * oldest ledger" / "out of range" when the requested ledger is no longer
+ * retained.
+ */
+function isCursorExpiredError(err: unknown): boolean {
+  if (typeof err !== "object" || err === null) return false;
+
+  const e = err as JsonRpcError;
+
+  // JSON-RPC -32600 = Invalid Request — the code Stellar RPC uses for
+  // out-of-retention-window cursor/startLedger errors.
+  if (e.code !== -32600) return false;
+
+  const msg = typeof e.message === "string" ? e.message.toLowerCase() : "";
+  return (
+    msg.includes("cursor") ||
+    msg.includes("startledger") ||
+    msg.includes("start_ledger") ||
+    msg.includes("before the oldest") ||
+    msg.includes("out of range")
+  );
+}
+
+const noop = { info: () => { }, warn: () => { }, error: () => { } };
+
+/**
+ * SorobanSubscriber continuously polls a Stellar RPC server for contract
+ * events and forwards them to a Watcher.
+ *
+ * **Cursor-expiry recovery**
+ * Stellar RPC retains at most 7 days of events (24 h by default). If the
+ * stored cursor falls outside that window, `getEvents` will throw a
+ * JSON-RPC -32600 error. SorobanSubscriber catches that error, emits an
+ * `engine.cursor_expired` notification on the Watcher, logs a warning about
+ * the data-loss implication, and resumes polling from the current
+ * `latestLedger` — dropping the gap in history.
+ *
+ * **Data-loss notice**: Events that occurred between the expired cursor
+ * and the recovery point are permanently lost. Consumers that require
+ * guaranteed event delivery should persist a durable replay store and compare
+ * the recovered `latestLedger` against the last successfully processed ledger
+ * to detect any gap.
+ */
+export class SorobanSubscriberCursorExpired {
+  private readonly server: rpc.Server;
+  private readonly source: string;
+  private readonly filters: rpc.Api.GetEventsRequest["filters"];
+  private readonly pollIntervalMs: number;
+  private readonly log: Required<NonNullable<SorobanSubscriberOptionsCursorExpired["logger"]>>;
+
+  private cursor: string | undefined;
+  private watcher: Watcher | null = null;
+  private timer: ReturnType<typeof setTimeout> | null = null;
+  private running = false;
+
+  constructor(options: SorobanSubscriberOptionsCursorExpired) {
+    this.server = new rpc.Server(options.rpcUrl);
+    this.source = options.source;
+    this.cursor = options.cursor ?? undefined;
+    this.filters = options.filters ?? [];
+    this.pollIntervalMs = options.pollIntervalMs ?? 5_000;
+    this.log = options.logger ?? noop;
+  }
+
+  /**
+   * Attaches a Watcher and begins polling. No-op if already running.
+   */
+  start(watcher: Watcher): void {
+    if (this.running) return;
+    this.running = true;
+    this.watcher = watcher;
+    this.scheduleNext(0);
+  }
+
+  /**
+   * Stops polling and detaches the Watcher. Safe to call multiple times.
+   */
+  stop(): void {
+    this.running = false;
+    this.watcher = null;
+    if (this.timer !== null) {
+      clearTimeout(this.timer);
+      this.timer = null;
+    }
+  }
+
+  // ─── private ────────────────────────────────────────────────────────────
+
+  private scheduleNext(delayMs: number): void {
+    if (!this.running) return;
+    this.timer = setTimeout(() => {
+      this.timer = null;
+      void this.poll();
+    }, delayMs);
+  }
+
+  private async poll(): Promise<void> {
+    if (!this.running) return;
+
+    try {
+      await this.fetchAndForward();
+    } catch (err: unknown) {
+      if (isCursorExpiredError(err)) {
+        await this.recoverFromExpiredCursor(err);
+      } else {
+        this.log.error("[pulse-core] SorobanSubscriber: getEvents failed", err);
+      }
+    }
+
+    this.scheduleNext(this.pollIntervalMs);
+  }
+
+  /**
+   * Builds the getEvents request, calls the RPC server, advances the cursor,
+   * and forwards each raw event to the Watcher.
+   */
+  private async fetchAndForward(): Promise<void> {
+    const request = this.buildRequest();
+    const response = await this.server.getEvents(request);
+
+    // Advance cursor so the next poll continues from where this one ended.
+    if (response.cursor) {
+      this.cursor = response.cursor;
+    }
+
+    if (!this.watcher || !this.running) return;
+
+    for (const event of response.events) {
+      // Re-check running state between events; stop() may be called mid-loop.
+      if (!this.running || !this.watcher) break;
+      // rpc.Api.EventResponse is not part of the WatcherEvent union — it is a
+      // Soroban-specific payload carried on the open "soroban.event" channel.
+      // The casts to `never` are intentional: Watcher's emit() signature is
+      // constrained to WatcherEvent, but the wildcard "*" channel is used by
+      // consumers to receive any event type, including Soroban ones.
+      this.watcher.emit("soroban.event", event as never);
+      this.watcher.emit("*", event as never);
+    }
+  }
+
+  private buildRequest(): rpc.Api.GetEventsRequest {
+    const base = {
+      filters: this.filters ?? [],
+    } satisfies Partial<rpc.Api.GetEventsRequest>;
+
+    if (this.cursor) {
+      // Cursor mode: startLedger must be omitted per SDK constraints.
+      return { ...base, cursor: this.cursor } as rpc.Api.GetEventsRequest;
+    }
+
+    // No cursor yet — start from latest ledger (ledger-range mode).
+    // startLedger: 0 instructs the RPC server to use its own latestLedger.
+    return { ...base, startLedger: 0 } as rpc.Api.GetEventsRequest;
+  }
+
+  /**
+   * Handles a cursor-expired error:
+   * 1. Emits `engine.cursor_expired` on the Watcher with `{ source, lostCursor }`.
+   * 2. Logs a warning that describes the data-loss implication.
+   * 3. Falls back to `startLedger = latestLedger`, dropping the history gap.
+   */
+  private async recoverFromExpiredCursor(err: unknown): Promise<void> {
+    const lostCursor = this.cursor;
+
+    this.log.warn(
+      `[pulse-core] SorobanSubscriber(${this.source}): cursor "${lostCursor ?? "<none>"}" ` +
+      `is outside the RPC server's retention window. ` +
+      `Events between the expired cursor and the recovery point are PERMANENTLY LOST. ` +
+      `Resuming from latestLedger. ` +
+      `Consider persisting a durable replay store to detect such gaps in future.`,
+      err
+    );
+
+    // Notify the Watcher so application code can react (alert, persist a gap
+    // record, etc.).
+    if (this.watcher && this.running) {
+      const notification: SorobanCursorExpiredNotification = {
+        type: "engine.cursor_expired",
+        source: this.source,
+        lostCursor,
+        emittedAt: new Date().toISOString(),
+      };
+      this.watcher.emit("engine.cursor_expired", notification as never);
+    }
+
+    // Reset the cursor so the next buildRequest() falls back to startLedger
+    // mode (latest ledger), skipping the lost gap.
+    this.cursor = undefined;
   }
 }

--- a/packages/pulse-core/src/SorobanSubscriber.ts
+++ b/packages/pulse-core/src/SorobanSubscriber.ts
@@ -1,9 +1,11 @@
 import type { ContractSubscriptionFilter, ContractAddress } from "./index.js";
 import { SorobanRpcError } from "./errors.js";
+import type { Watcher } from "./Watcher.js";
+import type { SorobanCursorExpiredNotification } from "./index.js";
 
 /**
  * SorobanSubscriber — polls a Soroban RPC for contract events and forwards
- * them to a caller-supplied handler or Watcher.
+ * them to a caller-supplied handler.
  *
  * Graceful shutdown guarantee
  * ---------------------------
@@ -13,61 +15,7 @@ import { SorobanRpcError } from "./errors.js";
  *   3. Awaits the in-flight poll Promise so the caller can `await stop()` and
  *      be certain no further events will be emitted once the Promise resolves.
  *   4. Silently drops any events that arrive from an aborted poll.
- *
- * ## Deduplication
- * An in-memory LRU set (default cap: 1024 event IDs) suppresses events that
- * have already been emitted. This is best-effort: events outside the window
- * may be re-emitted after a restart.
- *
- * ## Cursor-expiry recovery
- * Stellar RPC retains at most 7 days of events (24 h by default). If the
- * stored cursor falls outside that window, `getEvents` will throw a
- * JSON-RPC -32600 error. SorobanSubscriber catches that error, emits an
- * `engine.cursor_expired` notification on the Watcher, logs a warning about
- * the data-loss implication, and resumes polling from the current
- * `latestLedger` — dropping the gap in history.
- *
- * **Data-loss notice**: Events that occurred between the expired cursor
- * and the recovery point are permanently lost. Consumers that require
- * guaranteed event delivery should persist a durable replay store and compare
- * the recovered `latestLedger` against the last successfully processed ledger
- * to detect any gap.
  */
-
-import * as StellarSdk from "@stellar/stellar-sdk";
-import type { rpc } from "@stellar/stellar-sdk";
-import type { Watcher } from "./Watcher.js";
-import type { SorobanCursorExpiredNotification } from "./index.js";
-
-// ---------------------------------------------------------------------------
-// Minimal LRU set (Map-backed, insertion-order eviction).
-// ---------------------------------------------------------------------------
-
-class LruSet {
-  private readonly map = new Map<string, 1>();
-
-  constructor(private readonly maxSize: number) {}
-
-  has(id: string): boolean {
-    return this.map.has(id);
-  }
-
-  add(id: string): void {
-    if (this.map.has(id)) this.map.delete(id);
-    this.map.set(id, 1);
-    if (this.map.size > this.maxSize) {
-      this.map.delete(this.map.keys().next().value as string);
-    }
-  }
-
-  get size(): number {
-    return this.map.size;
-  }
-}
-
-// ---------------------------------------------------------------------------
-// Public types
-// ---------------------------------------------------------------------------
 
 /** Minimal interface for a cursor persistence layer. */
 export interface CursorStore {
@@ -75,7 +23,7 @@ export interface CursorStore {
   saveCursor(cursor: string | undefined): Promise<void>;
 }
 
-/** Alias for {@link CursorStore}. */
+/** Alias for {@link CursorStore}; the name used by the subscriber test suite. */
 export type CursorStoreLike = CursorStore;
 
 /** A single event returned by the Soroban RPC. */
@@ -95,7 +43,7 @@ export interface SorobanRpc {
     limit: number,
     signal?: AbortSignal,
     filters?: ContractSubscriptionFilter[],
-  ): Promise<{ events: SorobanEvent[]; cursor?: string }>;
+  ): Promise<{ events: SorobanEvent[] }>;
 }
 
 /** Alias for {@link SorobanRpc}; the name used by EventEngine's replay API. */
@@ -149,12 +97,7 @@ export interface SorobanSubscriberOptions {
   onRetryableError?: (error: SorobanRpcError) => void;
   /** Notified when a terminal (non-retryable) {@link SorobanRpcError} is caught. */
   onTerminalError?: (error: unknown) => void;
-
-  // Continuous polling & cursor-expired options (rpcUrl-based construction)
-  rpcUrl?: string;
   source?: string;
-  cursor?: string;
-  filters?: rpc.Api.GetEventsRequest["filters"];
   logger?: {
     info(msg: string, ...args: unknown[]): void;
     warn(msg: string, ...args: unknown[]): void;
@@ -163,53 +106,10 @@ export interface SorobanSubscriberOptions {
   watcher?: Watcher;
 }
 
-/** JSON-RPC error shape thrown by @stellar/stellar-sdk when the RPC server
- *  returns an error response. The `code` field is the JSON-RPC error code. */
-type JsonRpcError = {
-  code: number;
-  message: string;
-  data?: unknown;
-};
-
-/**
- * Detects whether the error thrown by rpc.Server.getEvents indicates
- * that the supplied cursor (or startLedger) is outside the server's retention
- * window.
- *
- * Stellar RPC returns JSON-RPC error code -32600 ("Invalid Request") with a
- * message containing "startLedger" or "cursor" and a phrase like "before the
- * oldest ledger" / "out of range" when the requested ledger is no longer
- * retained.
- */
-function isCursorExpiredError(err: unknown): boolean {
-  if (typeof err !== "object" || err === null) return false;
-
-  const e = err as JsonRpcError;
-
-  // JSON-RPC -32600 = Invalid Request — the code Stellar RPC uses for
-  // out-of-retention-window cursor/startLedger errors.
-  if (e.code !== -32600) return false;
-
-  const msg = typeof e.message === "string" ? e.message.toLowerCase() : "";
-  return (
-    msg.includes("cursor") ||
-    msg.includes("startledger") ||
-    msg.includes("start_ledger") ||
-    msg.includes("before the oldest") ||
-    msg.includes("out of range")
-  );
-}
-
 const MIN_PAGE_LIMIT = 1;
 const MAX_PAGE_LIMIT = 10_000;
 const DEFAULT_PAGE_LIMIT = 100;
 const DEFAULT_DEDUP_CACHE_SIZE = 10_000;
-
-const noop = { info: () => {}, warn: () => {}, error: () => {} };
-
-// ---------------------------------------------------------------------------
-// SorobanSubscriber
-// ---------------------------------------------------------------------------
 
 export class SorobanSubscriber {
   private readonly rpc: SorobanRpc;
@@ -218,6 +118,14 @@ export class SorobanSubscriber {
   private readonly pageLimit: number;
 
   private isStopped = false;
+
+  private readonly source?: string;
+  private readonly log: {
+    info(msg: string, ...args: unknown[]): void;
+    warn(msg: string, ...args: unknown[]): void;
+    error(msg: string, ...args: unknown[]): void;
+  };
+  private readonly watcher?: Watcher;
 
   /** AbortController for the currently in-flight `getEvents` call. */
   private inflightAbort: AbortController | null = null;
@@ -237,7 +145,7 @@ export class SorobanSubscriber {
 
   // --- Cross-poll de-duplication state ---
   /** Insertion-ordered set of recently-delivered event IDs (bounded FIFO window). */
-  private readonly seen: LruSet;
+  private readonly seen = new Set<string>();
   private readonly dedupCacheSize: number;
 
   // --- Bounded-replay mode state (set when `endLedger` is provided) ---
@@ -265,20 +173,17 @@ export class SorobanSubscriber {
   private readonly onTerminalError?: (error: unknown) => void;
   private retryTimer: ReturnType<typeof setTimeout> | null = null;
 
-  // --- Cursor-expired recovery state ---
-  private readonly source?: string;
-  private readonly log: { info(msg: string, ...args: unknown[]): void; warn(msg: string, ...args: unknown[]): void; error(msg: string, ...args: unknown[]): void };
-  private watcher: Watcher | null = null;
-
   constructor(options: SorobanSubscriberOptions) {
     const pageLimit = options.pageLimit ?? options.pageSize ?? DEFAULT_PAGE_LIMIT;
     if (!Number.isFinite(pageLimit) || pageLimit < MIN_PAGE_LIMIT || pageLimit > MAX_PAGE_LIMIT) {
       throw new RangeError(`pageLimit must be between 1 and 10,000 (received ${pageLimit})`);
     }
 
+    this.rpc = options.rpc;
+    this.cursorStore = options.cursorStore;
+    this.onEvent = options.onEvent;
     this.pageLimit = pageLimit;
     this.dedupCacheSize = options.dedupCacheSize ?? DEFAULT_DEDUP_CACHE_SIZE;
-    this.seen = new LruSet(this.dedupCacheSize);
     this.endLedger = options.endLedger;
     this.onDone = options.onDone;
     this.pollIntervalMs = options.pollIntervalMs ?? 2000;
@@ -288,49 +193,8 @@ export class SorobanSubscriber {
     this.onRetryableError = options.onRetryableError;
     this.onTerminalError = options.onTerminalError;
     this.source = options.source;
-    this.log = options.logger ?? noop;
-
-    if (options.watcher) {
-      this.watcher = options.watcher;
-    }
-
-    // rpcUrl-based construction: build an rpc adapter and an in-memory cursor store
-    if (options.rpcUrl) {
-      const server = new StellarSdk.rpc.Server(options.rpcUrl);
-      let cursor: string | undefined = options.cursor ?? undefined;
-      const filters = options.filters ?? [];
-
-      this.rpc = {
-        getEvents: async (startCursor: string | undefined, limit: number, signal?: AbortSignal) => {
-          const req: any = {
-            filters,
-            limit,
-          };
-          if (startCursor) {
-            req.cursor = startCursor;
-          } else {
-            req.startLedger = 0;
-          }
-          const res = await server.getEvents(req);
-          return {
-            events: res.events as any as SorobanEvent[],
-            cursor: res.cursor,
-          };
-        },
-      };
-
-      this.cursorStore = {
-        getCursor: async () => cursor,
-        saveCursor: async (c: string | undefined) => {
-          cursor = c;
-        },
-      };
-    } else {
-      this.rpc = options.rpc!;
-      this.cursorStore = options.cursorStore!;
-    }
-
-    this.onEvent = options.onEvent;
+    this.log = options.logger ?? { info: () => {}, warn: () => {}, error: () => {} };
+    this.watcher = options.watcher;
   }
 
   /** True when operating in bounded-replay mode (an `endLedger` was supplied). */
@@ -350,7 +214,6 @@ export class SorobanSubscriber {
   start(): void {
     if (this._isRunning) return;
     this._isRunning = true;
-    this.isStopped = false;
     const tick = () => {
       this.inflightPoll = (this.inflightPoll ?? Promise.resolve()).then(() => this.pollOnce());
     };
@@ -490,7 +353,7 @@ export class SorobanSubscriber {
       ),
     );
 
-    let results: { events: SorobanEvent[]; cursor?: string }[];
+    let results: { events: SorobanEvent[] }[];
     try {
       results = await Promise.all(promises);
     } catch (err) {
@@ -562,7 +425,7 @@ export class SorobanSubscriber {
         // un-recorded (and therefore re-deliverable on a later poll).
         await this.dispatch(event);
         this.lastEventAt = new Date().toISOString();
-        this.seen.add(event.id);
+        this.recordSeen(event.id);
 
         if (this.isReplayMode) {
           // Replay progress is ephemeral and must never touch the durable store.
@@ -586,10 +449,6 @@ export class SorobanSubscriber {
   private async dispatch(event: SorobanEvent): Promise<void> {
     if (this.subscriptions.length === 0) {
       if (this.onEvent) await this.onEvent(event);
-      if (this.watcher) {
-        this.watcher.emit("soroban.event", event as never);
-        this.watcher.emit("*", event as never);
-      }
       return;
     }
 
@@ -620,6 +479,16 @@ export class SorobanSubscriber {
     return true;
   }
 
+  /** Records a delivered event ID, evicting the oldest entries past the cap. */
+  private recordSeen(id: string): void {
+    this.seen.add(id);
+    while (this.seen.size > this.dedupCacheSize) {
+      const oldest = this.seen.values().next().value;
+      if (oldest === undefined) break;
+      this.seen.delete(oldest);
+    }
+  }
+
   /** Schedules a single deferred re-poll using the injectable timer. */
   private scheduleRetry(): void {
     if (this.isStopped) return;
@@ -628,6 +497,36 @@ export class SorobanSubscriber {
       if (this.isStopped) return;
       this.inflightPoll = (this.inflightPoll ?? Promise.resolve()).then(() => this.pollOnce());
     }, this.retryDelayMs);
+  }
+
+  /**
+   * Extracts the ledger sequence number from a SorobanEvent.
+   * The Soroban RPC embeds the ledger in the event `id` field as
+   * `<ledger>-<index>` (e.g. "1234-0").  Falls back to a `ledger` field if
+   * present on the raw event object.
+   */
+  private extractLedger(event: SorobanEvent): number | undefined {
+    // Prefer explicit ledger field (available in some RPC responses).
+    const raw = event as unknown as Record<string, unknown>;
+    if (typeof raw.ledger === "number") return raw.ledger;
+
+    // Parse from paging token / id encoded as "<ledger>-<index>".
+    const match = event.id.match(/^(\d+)-/);
+    if (match && match[1] !== undefined) {
+      const n = parseInt(match[1], 10);
+      if (!isNaN(n)) return n;
+    }
+    return undefined;
+  }
+
+  private isAbortError(err: unknown): boolean {
+    if (err instanceof Error) {
+      // DOMException name set by the Fetch API / AbortController
+      if ((err as { name?: string }).name === "AbortError") return true;
+      // Node.js / undici uses this code
+      if ((err as NodeJS.ErrnoException).code === "ABORT_ERR") return true;
+    }
+    return false;
   }
 
   /**
@@ -660,34 +559,41 @@ export class SorobanSubscriber {
 
     await this.cursorStore.saveCursor(undefined);
   }
+}
 
-  /**
-   * Extracts the ledger sequence number from a SorobanEvent.
-   * The Soroban RPC embeds the ledger in the event `id` field as
-   * `<ledger>-<index>` (e.g. "1234-0").  Falls back to a `ledger` field if
-   * present on the raw event object.
-   */
-  private extractLedger(event: SorobanEvent): number | undefined {
-    // Prefer explicit ledger field (available in some RPC responses).
-    const raw = event as unknown as Record<string, unknown>;
-    if (typeof raw.ledger === "number") return raw.ledger;
+/** JSON-RPC error shape thrown by @stellar/stellar-sdk when the RPC server
+ *  returns an error response. The `code` field is the JSON-RPC error code. */
+type JsonRpcError = {
+  code: number;
+  message: string;
+  data?: unknown;
+};
 
-    // Parse from paging token / id encoded as "<ledger>-<index>".
-    const match = event.id.match(/^(\d+)-/);
-    if (match && match[1] !== undefined) {
-      const n = parseInt(match[1], 10);
-      if (!isNaN(n)) return n;
-    }
-    return undefined;
-  }
+/**
+ * Detects whether the error thrown by rpc.Server.getEvents indicates
+ * that the supplied cursor (or startLedger) is outside the server's retention
+ * window.
+ *
+ * Stellar RPC returns JSON-RPC error code -32600 ("Invalid Request") with a
+ * message containing "startLedger" or "cursor" and a phrase like "before the
+ * oldest ledger" / "out of range" when the requested ledger is no longer
+ * retained.
+ */
+function isCursorExpiredError(err: unknown): boolean {
+  if (typeof err !== "object" || err === null) return false;
 
-  private isAbortError(err: unknown): boolean {
-    if (err instanceof Error) {
-      // DOMException name set by the Fetch API / AbortController
-      if ((err as { name?: string }).name === "AbortError") return true;
-      // Node.js / undici uses this code
-      if ((err as NodeJS.ErrnoException).code === "ABORT_ERR") return true;
-    }
-    return false;
-  }
+  const e = err as JsonRpcError;
+
+  // JSON-RPC -32600 = Invalid Request — the code Stellar RPC uses for
+  // out-of-retention-window cursor/startLedger errors.
+  if (e.code !== -32600) return false;
+
+  const msg = typeof e.message === "string" ? e.message.toLowerCase() : "";
+  return (
+    msg.includes("cursor") ||
+    msg.includes("startledger") ||
+    msg.includes("start_ledger") ||
+    msg.includes("before the oldest") ||
+    msg.includes("out of range")
+  );
 }

--- a/packages/pulse-core/src/SorobanSubscriber.ts
+++ b/packages/pulse-core/src/SorobanSubscriber.ts
@@ -3,7 +3,7 @@ import { SorobanRpcError } from "./errors.js";
 
 /**
  * SorobanSubscriber — polls a Soroban RPC for contract events and forwards
- * them to a caller-supplied handler.
+ * them to a caller-supplied handler or Watcher.
  *
  * Graceful shutdown guarantee
  * ---------------------------
@@ -13,7 +13,31 @@ import { SorobanRpcError } from "./errors.js";
  *   3. Awaits the in-flight poll Promise so the caller can `await stop()` and
  *      be certain no further events will be emitted once the Promise resolves.
  *   4. Silently drops any events that arrive from an aborted poll.
+ *
+ * ## Deduplication
+ * An in-memory LRU set (default cap: 1024 event IDs) suppresses events that
+ * have already been emitted. This is best-effort: events outside the window
+ * may be re-emitted after a restart.
+ *
+ * ## Cursor-expiry recovery
+ * Stellar RPC retains at most 7 days of events (24 h by default). If the
+ * stored cursor falls outside that window, `getEvents` will throw a
+ * JSON-RPC -32600 error. SorobanSubscriber catches that error, emits an
+ * `engine.cursor_expired` notification on the Watcher, logs a warning about
+ * the data-loss implication, and resumes polling from the current
+ * `latestLedger` — dropping the gap in history.
+ *
+ * **Data-loss notice**: Events that occurred between the expired cursor
+ * and the recovery point are permanently lost. Consumers that require
+ * guaranteed event delivery should persist a durable replay store and compare
+ * the recovered `latestLedger` against the last successfully processed ledger
+ * to detect any gap.
  */
+
+import * as StellarSdk from "@stellar/stellar-sdk";
+import type { rpc } from "@stellar/stellar-sdk";
+import type { Watcher } from "./Watcher.js";
+import type { SorobanCursorExpiredNotification } from "./index.js";
 
 // ---------------------------------------------------------------------------
 // Minimal LRU set (Map-backed, insertion-order eviction).
@@ -22,7 +46,7 @@ import { SorobanRpcError } from "./errors.js";
 class LruSet {
   private readonly map = new Map<string, 1>();
 
-  constructor(private readonly maxSize: number) { }
+  constructor(private readonly maxSize: number) {}
 
   has(id: string): boolean {
     return this.map.has(id);
@@ -46,12 +70,12 @@ class LruSet {
 // ---------------------------------------------------------------------------
 
 /** Minimal interface for a cursor persistence layer. */
-export interface CursorStoreLike {
+export interface CursorStore {
   getCursor(): Promise<string | undefined>;
-  saveCursor(cursor: string): Promise<void>;
+  saveCursor(cursor: string | undefined): Promise<void>;
 }
 
-/** Alias for {@link CursorStore}; the name used by the subscriber test suite. */
+/** Alias for {@link CursorStore}. */
 export type CursorStoreLike = CursorStore;
 
 /** A single event returned by the Soroban RPC. */
@@ -71,7 +95,7 @@ export interface SorobanRpc {
     limit: number,
     signal?: AbortSignal,
     filters?: ContractSubscriptionFilter[],
-  ): Promise<{ events: SorobanEvent[] }>;
+  ): Promise<{ events: SorobanEvent[]; cursor?: string }>;
 }
 
 /** Alias for {@link SorobanRpc}; the name used by EventEngine's replay API. */
@@ -125,12 +149,67 @@ export interface SorobanSubscriberOptions {
   onRetryableError?: (error: SorobanRpcError) => void;
   /** Notified when a terminal (non-retryable) {@link SorobanRpcError} is caught. */
   onTerminalError?: (error: unknown) => void;
+
+  // Continuous polling & cursor-expired options (rpcUrl-based construction)
+  rpcUrl?: string;
+  source?: string;
+  cursor?: string;
+  filters?: rpc.Api.GetEventsRequest["filters"];
+  logger?: {
+    info(msg: string, ...args: unknown[]): void;
+    warn(msg: string, ...args: unknown[]): void;
+    error(msg: string, ...args: unknown[]): void;
+  };
+  watcher?: Watcher;
+}
+
+/** JSON-RPC error shape thrown by @stellar/stellar-sdk when the RPC server
+ *  returns an error response. The `code` field is the JSON-RPC error code. */
+type JsonRpcError = {
+  code: number;
+  message: string;
+  data?: unknown;
+};
+
+/**
+ * Detects whether the error thrown by rpc.Server.getEvents indicates
+ * that the supplied cursor (or startLedger) is outside the server's retention
+ * window.
+ *
+ * Stellar RPC returns JSON-RPC error code -32600 ("Invalid Request") with a
+ * message containing "startLedger" or "cursor" and a phrase like "before the
+ * oldest ledger" / "out of range" when the requested ledger is no longer
+ * retained.
+ */
+function isCursorExpiredError(err: unknown): boolean {
+  if (typeof err !== "object" || err === null) return false;
+
+  const e = err as JsonRpcError;
+
+  // JSON-RPC -32600 = Invalid Request — the code Stellar RPC uses for
+  // out-of-retention-window cursor/startLedger errors.
+  if (e.code !== -32600) return false;
+
+  const msg = typeof e.message === "string" ? e.message.toLowerCase() : "";
+  return (
+    msg.includes("cursor") ||
+    msg.includes("startledger") ||
+    msg.includes("start_ledger") ||
+    msg.includes("before the oldest") ||
+    msg.includes("out of range")
+  );
 }
 
 const MIN_PAGE_LIMIT = 1;
 const MAX_PAGE_LIMIT = 10_000;
 const DEFAULT_PAGE_LIMIT = 100;
 const DEFAULT_DEDUP_CACHE_SIZE = 10_000;
+
+const noop = { info: () => {}, warn: () => {}, error: () => {} };
+
+// ---------------------------------------------------------------------------
+// SorobanSubscriber
+// ---------------------------------------------------------------------------
 
 export class SorobanSubscriber {
   private readonly rpc: SorobanRpc;
@@ -158,7 +237,7 @@ export class SorobanSubscriber {
 
   // --- Cross-poll de-duplication state ---
   /** Insertion-ordered set of recently-delivered event IDs (bounded FIFO window). */
-  private readonly seen = new Set<string>();
+  private readonly seen: LruSet;
   private readonly dedupCacheSize: number;
 
   // --- Bounded-replay mode state (set when `endLedger` is provided) ---
@@ -186,17 +265,20 @@ export class SorobanSubscriber {
   private readonly onTerminalError?: (error: unknown) => void;
   private retryTimer: ReturnType<typeof setTimeout> | null = null;
 
+  // --- Cursor-expired recovery state ---
+  private readonly source?: string;
+  private readonly log: { info(msg: string, ...args: unknown[]): void; warn(msg: string, ...args: unknown[]): void; error(msg: string, ...args: unknown[]): void };
+  private watcher: Watcher | null = null;
+
   constructor(options: SorobanSubscriberOptions) {
     const pageLimit = options.pageLimit ?? options.pageSize ?? DEFAULT_PAGE_LIMIT;
     if (!Number.isFinite(pageLimit) || pageLimit < MIN_PAGE_LIMIT || pageLimit > MAX_PAGE_LIMIT) {
       throw new RangeError(`pageLimit must be between 1 and 10,000 (received ${pageLimit})`);
     }
 
-    this.rpc = options.rpc;
-    this.cursorStore = options.cursorStore;
-    this.onEvent = options.onEvent;
     this.pageLimit = pageLimit;
     this.dedupCacheSize = options.dedupCacheSize ?? DEFAULT_DEDUP_CACHE_SIZE;
+    this.seen = new LruSet(this.dedupCacheSize);
     this.endLedger = options.endLedger;
     this.onDone = options.onDone;
     this.pollIntervalMs = options.pollIntervalMs ?? 2000;
@@ -205,6 +287,50 @@ export class SorobanSubscriber {
     this.clearTimeoutFn = options.clearTimeoutFn ?? globalThis.clearTimeout;
     this.onRetryableError = options.onRetryableError;
     this.onTerminalError = options.onTerminalError;
+    this.source = options.source;
+    this.log = options.logger ?? noop;
+
+    if (options.watcher) {
+      this.watcher = options.watcher;
+    }
+
+    // rpcUrl-based construction: build an rpc adapter and an in-memory cursor store
+    if (options.rpcUrl) {
+      const server = new StellarSdk.rpc.Server(options.rpcUrl);
+      let cursor: string | undefined = options.cursor ?? undefined;
+      const filters = options.filters ?? [];
+
+      this.rpc = {
+        getEvents: async (startCursor: string | undefined, limit: number, signal?: AbortSignal) => {
+          const req: any = {
+            filters,
+            limit,
+          };
+          if (startCursor) {
+            req.cursor = startCursor;
+          } else {
+            req.startLedger = 0;
+          }
+          const res = await server.getEvents(req);
+          return {
+            events: res.events as any as SorobanEvent[],
+            cursor: res.cursor,
+          };
+        },
+      };
+
+      this.cursorStore = {
+        getCursor: async () => cursor,
+        saveCursor: async (c: string | undefined) => {
+          cursor = c;
+        },
+      };
+    } else {
+      this.rpc = options.rpc!;
+      this.cursorStore = options.cursorStore!;
+    }
+
+    this.onEvent = options.onEvent;
   }
 
   /** True when operating in bounded-replay mode (an `endLedger` was supplied). */
@@ -224,6 +350,7 @@ export class SorobanSubscriber {
   start(): void {
     if (this._isRunning) return;
     this._isRunning = true;
+    this.isStopped = false;
     const tick = () => {
       this.inflightPoll = (this.inflightPoll ?? Promise.resolve()).then(() => this.pollOnce());
     };
@@ -363,12 +490,17 @@ export class SorobanSubscriber {
       ),
     );
 
-    let results: { events: SorobanEvent[] }[];
+    let results: { events: SorobanEvent[]; cursor?: string }[];
     try {
       results = await Promise.all(promises);
     } catch (err) {
       // An aborted request is expected during shutdown — swallow it silently.
       if (this.isAbortError(err)) return;
+      // Cursor-expired errors are recoverable — emit notification & reset.
+      if (isCursorExpiredError(err)) {
+        await this.recoverFromExpiredCursor(err);
+        return;
+      }
       // Route classified RPC errors to the retry/terminal handlers when present.
       if (err instanceof SorobanRpcError) {
         if (err.retryable) {
@@ -430,7 +562,7 @@ export class SorobanSubscriber {
         // un-recorded (and therefore re-deliverable on a later poll).
         await this.dispatch(event);
         this.lastEventAt = new Date().toISOString();
-        this.recordSeen(event.id);
+        this.seen.add(event.id);
 
         if (this.isReplayMode) {
           // Replay progress is ephemeral and must never touch the durable store.
@@ -454,6 +586,10 @@ export class SorobanSubscriber {
   private async dispatch(event: SorobanEvent): Promise<void> {
     if (this.subscriptions.length === 0) {
       if (this.onEvent) await this.onEvent(event);
+      if (this.watcher) {
+        this.watcher.emit("soroban.event", event as never);
+        this.watcher.emit("*", event as never);
+      }
       return;
     }
 
@@ -484,16 +620,6 @@ export class SorobanSubscriber {
     return true;
   }
 
-  /** Records a delivered event ID, evicting the oldest entries past the cap. */
-  private recordSeen(id: string): void {
-    this.seen.add(id);
-    while (this.seen.size > this.dedupCacheSize) {
-      const oldest = this.seen.values().next().value;
-      if (oldest === undefined) break;
-      this.seen.delete(oldest);
-    }
-  }
-
   /** Schedules a single deferred re-poll using the injectable timer. */
   private scheduleRetry(): void {
     if (this.isStopped) return;
@@ -502,6 +628,37 @@ export class SorobanSubscriber {
       if (this.isStopped) return;
       this.inflightPoll = (this.inflightPoll ?? Promise.resolve()).then(() => this.pollOnce());
     }, this.retryDelayMs);
+  }
+
+  /**
+   * Recovers from a cursor-expired error by:
+   *   1. Logging a warning with data-loss implications.
+   *   2. Emitting an `engine.cursor_expired` notification on the Watcher.
+   *   3. Clearing the cursor so the next poll uses startLedger mode.
+   */
+  private async recoverFromExpiredCursor(err: unknown): Promise<void> {
+    const lostCursor = await this.cursorStore.getCursor();
+
+    this.log.warn(
+      `[pulse-core] SorobanSubscriber(${this.source ?? "unknown"}): cursor "${lostCursor ?? "<none>"}" ` +
+        `is outside the RPC server's retention window. ` +
+        `Events between the expired cursor and the recovery point are PERMANENTLY LOST. ` +
+        `Resuming from latestLedger. ` +
+        `Consider persisting a durable replay store to detect such gaps in future.`,
+      err,
+    );
+
+    if (this.watcher) {
+      const notification: SorobanCursorExpiredNotification = {
+        type: "engine.cursor_expired",
+        source: this.source ?? "unknown",
+        lostCursor,
+        emittedAt: new Date().toISOString(),
+      };
+      this.watcher.emit("engine.cursor_expired", notification as never);
+    }
+
+    await this.cursorStore.saveCursor(undefined);
   }
 
   /**
@@ -532,260 +689,5 @@ export class SorobanSubscriber {
       if ((err as NodeJS.ErrnoException).code === "ABORT_ERR") return true;
     }
     return false;
-  }
-}
-
-import { rpc } from "@stellar/stellar-sdk";
-import type { Watcher } from "./Watcher.js";
-import type { CursorStore, SorobanCursorExpiredNotification } from "./index.js";
-
-/**
- * Options accepted by SorobanSubscriber.
- */
-export type SorobanSubscriberOptionsCursorExpired = {
-  /**
-   * The Stellar RPC server URL to poll events from.
-   * Example: "https://soroban-testnet.stellar.org"
-   */
-  rpcUrl: string;
-
-  /**
-   * A human-readable label identifying the event source (e.g. contract address
-   * or subscriber name). Included in the engine.cursor_expired notification so
-   * callers can identify which subscriber expired.
-   */
-  source: string;
-
-  /**
-   * The cursor to resume from (opaque string returned by a previous
-   * getEvents response). When undefined or empty the subscriber starts
-   * from the latest ledger instead.
-   */
-  cursor?: string;
-
-  /**
-   * Filters forwarded verbatim to rpc.Server.getEvents.
-   * Leave undefined to receive all events visible to the RPC server.
-   */
-  filters?: rpc.Api.GetEventsRequest["filters"];
-
-  /**
-   * How many milliseconds to wait between polling cycles.
-   * Defaults to 5_000 (5 seconds).
-   */
-  pollIntervalMs?: number;
-
-  /**
-   * Optional logger. Falls back to a no-op logger when omitted.
-   */
-  logger?: {
-    info(msg: string, ...args: unknown[]): void;
-    warn(msg: string, ...args: unknown[]): void;
-    error(msg: string, ...args: unknown[]): void;
-  };
-};
-
-/** JSON-RPC error shape thrown by @stellar/stellar-sdk when the RPC server
- *  returns an error response. The `code` field is the JSON-RPC error code. */
-type JsonRpcError = {
-  code: number;
-  message: string;
-  data?: unknown;
-};
-
-/**
- * Detects whether the error thrown by rpc.Server.getEvents indicates
- * that the supplied cursor (or startLedger) is outside the server's retention
- * window.
- *
- * Stellar RPC returns JSON-RPC error code -32600 ("Invalid Request") with a
- * message containing "startLedger" or "cursor" and a phrase like "before the
- * oldest ledger" / "out of range" when the requested ledger is no longer
- * retained.
- */
-function isCursorExpiredError(err: unknown): boolean {
-  if (typeof err !== "object" || err === null) return false;
-
-  const e = err as JsonRpcError;
-
-  // JSON-RPC -32600 = Invalid Request — the code Stellar RPC uses for
-  // out-of-retention-window cursor/startLedger errors.
-  if (e.code !== -32600) return false;
-
-  const msg = typeof e.message === "string" ? e.message.toLowerCase() : "";
-  return (
-    msg.includes("cursor") ||
-    msg.includes("startledger") ||
-    msg.includes("start_ledger") ||
-    msg.includes("before the oldest") ||
-    msg.includes("out of range")
-  );
-}
-
-const noop = { info: () => { }, warn: () => { }, error: () => { } };
-
-/**
- * SorobanSubscriber continuously polls a Stellar RPC server for contract
- * events and forwards them to a Watcher.
- *
- * **Cursor-expiry recovery**
- * Stellar RPC retains at most 7 days of events (24 h by default). If the
- * stored cursor falls outside that window, `getEvents` will throw a
- * JSON-RPC -32600 error. SorobanSubscriber catches that error, emits an
- * `engine.cursor_expired` notification on the Watcher, logs a warning about
- * the data-loss implication, and resumes polling from the current
- * `latestLedger` — dropping the gap in history.
- *
- * **Data-loss notice**: Events that occurred between the expired cursor
- * and the recovery point are permanently lost. Consumers that require
- * guaranteed event delivery should persist a durable replay store and compare
- * the recovered `latestLedger` against the last successfully processed ledger
- * to detect any gap.
- */
-export class SorobanSubscriberCursorExpired {
-  private readonly server: rpc.Server;
-  private readonly source: string;
-  private readonly filters: rpc.Api.GetEventsRequest["filters"];
-  private readonly pollIntervalMs: number;
-  private readonly log: Required<NonNullable<SorobanSubscriberOptionsCursorExpired["logger"]>>;
-
-  private cursor: string | undefined;
-  private watcher: Watcher | null = null;
-  private timer: ReturnType<typeof setTimeout> | null = null;
-  private running = false;
-
-  constructor(options: SorobanSubscriberOptionsCursorExpired) {
-    this.server = new rpc.Server(options.rpcUrl);
-    this.source = options.source;
-    this.cursor = options.cursor ?? undefined;
-    this.filters = options.filters ?? [];
-    this.pollIntervalMs = options.pollIntervalMs ?? 5_000;
-    this.log = options.logger ?? noop;
-  }
-
-  /**
-   * Attaches a Watcher and begins polling. No-op if already running.
-   */
-  start(watcher: Watcher): void {
-    if (this.running) return;
-    this.running = true;
-    this.watcher = watcher;
-    this.scheduleNext(0);
-  }
-
-  /**
-   * Stops polling and detaches the Watcher. Safe to call multiple times.
-   */
-  stop(): void {
-    this.running = false;
-    this.watcher = null;
-    if (this.timer !== null) {
-      clearTimeout(this.timer);
-      this.timer = null;
-    }
-  }
-
-  // ─── private ────────────────────────────────────────────────────────────
-
-  private scheduleNext(delayMs: number): void {
-    if (!this.running) return;
-    this.timer = setTimeout(() => {
-      this.timer = null;
-      void this.poll();
-    }, delayMs);
-  }
-
-  private async poll(): Promise<void> {
-    if (!this.running) return;
-
-    try {
-      await this.fetchAndForward();
-    } catch (err: unknown) {
-      if (isCursorExpiredError(err)) {
-        await this.recoverFromExpiredCursor(err);
-      } else {
-        this.log.error("[pulse-core] SorobanSubscriber: getEvents failed", err);
-      }
-    }
-
-    this.scheduleNext(this.pollIntervalMs);
-  }
-
-  /**
-   * Builds the getEvents request, calls the RPC server, advances the cursor,
-   * and forwards each raw event to the Watcher.
-   */
-  private async fetchAndForward(): Promise<void> {
-    const request = this.buildRequest();
-    const response = await this.server.getEvents(request);
-
-    // Advance cursor so the next poll continues from where this one ended.
-    if (response.cursor) {
-      this.cursor = response.cursor;
-    }
-
-    if (!this.watcher || !this.running) return;
-
-    for (const event of response.events) {
-      // Re-check running state between events; stop() may be called mid-loop.
-      if (!this.running || !this.watcher) break;
-      // rpc.Api.EventResponse is not part of the WatcherEvent union — it is a
-      // Soroban-specific payload carried on the open "soroban.event" channel.
-      // The casts to `never` are intentional: Watcher's emit() signature is
-      // constrained to WatcherEvent, but the wildcard "*" channel is used by
-      // consumers to receive any event type, including Soroban ones.
-      this.watcher.emit("soroban.event", event as never);
-      this.watcher.emit("*", event as never);
-    }
-  }
-
-  private buildRequest(): rpc.Api.GetEventsRequest {
-    const base = {
-      filters: this.filters ?? [],
-    } satisfies Partial<rpc.Api.GetEventsRequest>;
-
-    if (this.cursor) {
-      // Cursor mode: startLedger must be omitted per SDK constraints.
-      return { ...base, cursor: this.cursor } as rpc.Api.GetEventsRequest;
-    }
-
-    // No cursor yet — start from latest ledger (ledger-range mode).
-    // startLedger: 0 instructs the RPC server to use its own latestLedger.
-    return { ...base, startLedger: 0 } as rpc.Api.GetEventsRequest;
-  }
-
-  /**
-   * Handles a cursor-expired error:
-   * 1. Emits `engine.cursor_expired` on the Watcher with `{ source, lostCursor }`.
-   * 2. Logs a warning that describes the data-loss implication.
-   * 3. Falls back to `startLedger = latestLedger`, dropping the history gap.
-   */
-  private async recoverFromExpiredCursor(err: unknown): Promise<void> {
-    const lostCursor = this.cursor;
-
-    this.log.warn(
-      `[pulse-core] SorobanSubscriber(${this.source}): cursor "${lostCursor ?? "<none>"}" ` +
-      `is outside the RPC server's retention window. ` +
-      `Events between the expired cursor and the recovery point are PERMANENTLY LOST. ` +
-      `Resuming from latestLedger. ` +
-      `Consider persisting a durable replay store to detect such gaps in future.`,
-      err
-    );
-
-    // Notify the Watcher so application code can react (alert, persist a gap
-    // record, etc.).
-    if (this.watcher && this.running) {
-      const notification: SorobanCursorExpiredNotification = {
-        type: "engine.cursor_expired",
-        source: this.source,
-        lostCursor,
-        emittedAt: new Date().toISOString(),
-      };
-      this.watcher.emit("engine.cursor_expired", notification as never);
-    }
-
-    // Reset the cursor so the next buildRequest() falls back to startLedger
-    // mode (latest ledger), skipping the lost gap.
-    this.cursor = undefined;
   }
 }

--- a/packages/pulse-core/src/index.ts
+++ b/packages/pulse-core/src/index.ts
@@ -30,6 +30,8 @@ export { coalesceCursorStore, CoalescingStore } from "./coalesceCursorStore.js";
 export type { CoalescingStoreOptions } from "./coalesceCursorStore.js";
 export { migrateCursors } from "./migrateCursors.js";
 export type { MigrateCursorsResult } from "./migrateCursors.js";
+export { SorobanRpcError, isSorobanRpcError } from "./errors.js";
+export type { SorobanRpcErrorCode, SorobanRpcErrorOptions } from "./errors.js";
 
 /** The Stellar network to connect to. */
 export type Network = "mainnet" | "testnet";

--- a/packages/pulse-core/src/index.ts
+++ b/packages/pulse-core/src/index.ts
@@ -44,8 +44,8 @@ export type SourceStatus = {
 export type EngineStatus = {
   running: boolean;
   watcherCount: number;
-  lastEventAt: string | null;
   contractWatcherCount?: number;
+  lastEventAt: string | null;
   reconnectAttempt: number;
   pausedSources?: ("horizon" | "soroban")[];
   sources: {
@@ -366,6 +366,37 @@ export type WatcherNotification = {
   emittedAt: string;
   /** The cursor value that was expired or lost, if applicable. */
   lostCursor?: string;
+};
+
+/**
+ * Notification emitted by SorobanSubscriber when a stored cursor has fallen
+ * outside the RPC server's retention window.
+ *
+ * Consumers should treat this as a signal that a gap in event history has
+ * occurred. The subscriber automatically recovers by resuming from
+ * `latestLedger`, but events between `lostCursor` and the recovery point are
+ * permanently unavailable via the RPC server.
+ *
+ * @example
+ * watcher.on("engine.cursor_expired", (n) => {
+ *   console.warn(`[${n.source}] cursor expired: ${n.lostCursor} — history gap, resuming from latest ledger`);
+ * });
+ */
+export type SorobanCursorExpiredNotification = {
+  /** Discriminant — always "engine.cursor_expired". */
+  type: "engine.cursor_expired";
+  /**
+   * The human-readable source label passed to SorobanSubscriber (e.g.
+   * contract address or subscriber name).
+   */
+  source: string;
+  /**
+   * The cursor value that caused the error, or `undefined` if no cursor had
+   * been stored yet (startLedger mode expired instead).
+   */
+  lostCursor: string | undefined;
+  /** ISO 8601 timestamp of when this notification was emitted. */
+  emittedAt: string;
 };
 
 /**

--- a/packages/pulse-core/test/SorobanSubscriber.cursorExpired.test.ts
+++ b/packages/pulse-core/test/SorobanSubscriber.cursorExpired.test.ts
@@ -4,54 +4,53 @@
  * Verifies that SorobanSubscriber correctly handles a cursor-expired error
  * from the Stellar RPC server:
  *   1. Emits an `engine.cursor_expired` notification on the Watcher.
- *   2. Resumes polling from the latest ledger (drops the history gap).
+ *   2. Logs a warn message documenting the data-loss implication.
  *   3. Does NOT re-throw or loop on the error.
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { SorobanSubscriberCursorExpired as SorobanSubscriber } from "../src/SorobanSubscriber.js";
+import { SorobanSubscriber } from "../src/SorobanSubscriber.js";
 import { Watcher } from "../src/Watcher.js";
-import type { SorobanCursorExpiredNotification } from "../src/index.js";
+import type {
+  SorobanCursorExpiredNotification,
+} from "../src/index.js";
+import type {
+  SorobanRpc,
+  SorobanEvent,
+  CursorStore,
+} from "../src/SorobanSubscriber.js";
 
 // ─── helpers ──────────────────────────────────────────────────────────────────
 
 /** Builds the JSON-RPC -32600 error that Stellar RPC throws for an expired cursor. */
-function makeCursorExpiredError(message = "cursor is before the oldest ledger retained") {
-  const err = Object.assign(new Error(message), { code: -32600 });
-  return err;
+function makeCursorExpiredError(
+  message = "cursor is before the oldest ledger retained",
+): Error & { code: number } {
+  return Object.assign(new Error(message), { code: -32600 });
 }
 
-/** Minimal stub matching the parts of rpc.Server we use. */
-function makeServerStub(getEventsImpl: () => Promise<unknown>) {
+/** Creates a minimal in-memory CursorStore seeded with an optional initial cursor. */
+function makeMemoryCursorStore(initial?: string): CursorStore {
+  let stored: string | undefined = initial;
   return {
-    getEvents: vi.fn(getEventsImpl),
-    getLatestLedger: vi.fn(async () => ({
-      sequence: 999_999,
-      id: "abc",
-      protocolVersion: "21",
-    })),
+    getCursor: vi.fn(async () => stored),
+    saveCursor: vi.fn(async (cursor: string | undefined) => {
+      stored = cursor;
+    }),
   };
 }
 
-/** Empty successful response from getEvents. */
-const emptyEventsResponse = {
-  events: [],
-  cursor: "1000-0",
-  latestLedger: 999_999,
-  latestLedgerCloseTime: 0,
-  oldestLedger: 900_000,
-  oldestLedgerCloseTime: 0,
-  ledgerRetentionWindow: 17_280,
-};
-
-/**
- * Advance fake timers by 0 ms and flush all resulting microtasks/promises.
- * This fires the initial setTimeout(fn, 0) that scheduleNext() registers on
- * start(), waits for poll() + fetchAndForward()/recoverFromExpiredCursor() to
- * complete, then stops — without triggering the subsequent pollIntervalMs timer.
- */
-async function flushFirstPoll() {
-  await vi.advanceTimersByTimeAsync(0);
+/** Creates a mock SorobanRpc that delegates getEvents to the provided implementation. */
+function makeMockRpc(
+  getEventsImpl: (
+    startCursor: string | undefined,
+    limit: number,
+    signal?: AbortSignal,
+  ) => Promise<{ events: SorobanEvent[]; cursor?: string }>,
+): SorobanRpc {
+  return {
+    getEvents: vi.fn(getEventsImpl),
+  };
 }
 
 // ─── tests ────────────────────────────────────────────────────────────────────
@@ -66,7 +65,6 @@ describe("SorobanSubscriber — cursor expired recovery", () => {
   };
 
   beforeEach(() => {
-    vi.useFakeTimers();
     watcher = new Watcher("GTEST_ADDRESS");
     warnings = [];
     mockLogger = {
@@ -79,7 +77,6 @@ describe("SorobanSubscriber — cursor expired recovery", () => {
   });
 
   afterEach(() => {
-    vi.useRealTimers();
     vi.restoreAllMocks();
     watcher.stop();
   });
@@ -88,33 +85,27 @@ describe("SorobanSubscriber — cursor expired recovery", () => {
 
   it("emits engine.cursor_expired with source and lostCursor when getEvents throws a cursor-expired error", async () => {
     const expiredCursor = "500000-1";
+    const cursorStore = makeMemoryCursorStore(expiredCursor);
 
-    const server = makeServerStub(async () => {
+    const rpc = makeMockRpc(async () => {
       throw makeCursorExpiredError();
     });
 
     const subscriber = new SorobanSubscriber({
-      rpcUrl: "https://soroban-testnet.stellar.org",
+      rpc,
+      cursorStore,
+      onEvent: vi.fn(async () => {}),
       source: "CONTRACT_ABC",
-      cursor: expiredCursor,
-      pollIntervalMs: 60_000,
       logger: mockLogger,
+      watcher,
     });
-
-    (subscriber as unknown as Record<string, unknown>)["server"] = server;
 
     const notifications: SorobanCursorExpiredNotification[] = [];
     watcher.on("engine.cursor_expired", (n) => {
       notifications.push(n as unknown as SorobanCursorExpiredNotification);
     });
 
-    subscriber.start(watcher);
-
-    // Flush only the first poll (delay = 0). The next timer is pollIntervalMs
-    // (60 s) away, so advancing by 0 ms stops after exactly one poll cycle.
-    await flushFirstPoll();
-
-    subscriber.stop();
+    await subscriber.pollOnce();
 
     expect(notifications).toHaveLength(1);
     const n = notifications[0]!;
@@ -124,169 +115,192 @@ describe("SorobanSubscriber — cursor expired recovery", () => {
     expect(typeof n.emittedAt).toBe("string");
   });
 
-  // ── 2. recovers by resuming from startLedger mode ────────────────────────
+  // ── 2. does not re-throw on cursor-expired ──────────────────────────────
 
-  it("resumes polling from startLedger mode (no cursor) after cursor expiry without rethrowing", async () => {
-    let callCount = 0;
+  it("does not re-throw on cursor-expired — pollOnce resolves cleanly", async () => {
+    const cursorStore = makeMemoryCursorStore("100-0");
 
-    const server = makeServerStub(async () => {
-      callCount += 1;
-      if (callCount === 1) throw makeCursorExpiredError("startLedger is out of range");
-      return emptyEventsResponse;
+    const rpc = makeMockRpc(async () => {
+      throw makeCursorExpiredError("startLedger is out of range");
     });
 
     const subscriber = new SorobanSubscriber({
-      rpcUrl: "https://soroban-testnet.stellar.org",
+      rpc,
+      cursorStore,
+      onEvent: vi.fn(async () => {}),
       source: "MY_CONTRACT",
-      cursor: "100-0",
-      pollIntervalMs: 50,
       logger: mockLogger,
+      watcher,
     });
 
-    (subscriber as unknown as Record<string, unknown>)["server"] = server;
+    // Must not throw — the cursor-expired error is handled internally.
+    await expect(subscriber.pollOnce()).resolves.toBeUndefined();
 
-    subscriber.start(watcher);
-
-    // First poll (delay = 0) — throws cursor-expired, triggers recovery.
-    await flushFirstPoll();
-
-    // Internal cursor must be cleared so next request uses startLedger mode.
-    const internalCursor = (subscriber as unknown as Record<string, unknown>)["cursor"];
-    expect(internalCursor).toBeUndefined();
-
-    // No error path taken — cursor-expired is handled, not propagated.
+    // No error-level log for cursor-expired (only a warn).
     expect(mockLogger.error).not.toHaveBeenCalled();
-
-    // Advance past pollIntervalMs (50 ms) to trigger the second poll.
-    await vi.advanceTimersByTimeAsync(50);
-
-    subscriber.stop();
-
-    // Second getEvents call must have fired (subscriber kept running after recovery).
-    expect(callCount).toBeGreaterThanOrEqual(2);
   });
 
-  // ── 3. logs a warn with data-loss implication ────────────────────────────
+  // ── 3. clears cursor after recovery ─────────────────────────────────────
+
+  it("clears the cursor after recovery so the next poll starts fresh", async () => {
+    const cursorStore = makeMemoryCursorStore("100-0");
+
+    const rpc = makeMockRpc(async () => {
+      throw makeCursorExpiredError("startLedger is out of range");
+    });
+
+    const subscriber = new SorobanSubscriber({
+      rpc,
+      cursorStore,
+      onEvent: vi.fn(async () => {}),
+      source: "MY_CONTRACT",
+      logger: mockLogger,
+      watcher,
+    });
+
+    await subscriber.pollOnce();
+
+    // The cursor must have been cleared via saveCursor(undefined).
+    expect(cursorStore.saveCursor).toHaveBeenCalledWith(undefined);
+  });
+
+  // ── 4. logs a warn with data-loss implication ────────────────────────────
 
   it("logs a warning that describes the data-loss implication", async () => {
-    const server = makeServerStub(async () => {
+    const cursorStore = makeMemoryCursorStore("42-0");
+
+    const rpc = makeMockRpc(async () => {
       throw makeCursorExpiredError("cursor before oldest ledger");
     });
 
     const subscriber = new SorobanSubscriber({
-      rpcUrl: "https://soroban-testnet.stellar.org",
+      rpc,
+      cursorStore,
+      onEvent: vi.fn(async () => {}),
       source: "LOSS_SOURCE",
-      cursor: "42-0",
-      pollIntervalMs: 60_000,
       logger: mockLogger,
+      watcher,
     });
 
-    (subscriber as unknown as Record<string, unknown>)["server"] = server;
-
-    subscriber.start(watcher);
-    await flushFirstPoll();
-    subscriber.stop();
+    await subscriber.pollOnce();
 
     expect(warnings.length).toBeGreaterThanOrEqual(1);
     const warnMsg = warnings[0]!.toLowerCase();
     expect(warnMsg).toMatch(/lost|permanently|data/);
   });
 
-  // ── 4. non-cursor errors are NOT treated as cursor-expired ───────────────
+  // ── 5. non-cursor errors are NOT treated as cursor-expired ───────────────
 
   it("does not treat a generic network error as a cursor-expired error", async () => {
-    const server = makeServerStub(async () => {
+    const cursorStore = makeMemoryCursorStore();
+
+    const rpc = makeMockRpc(async () => {
       throw new Error("Network timeout");
     });
 
     const subscriber = new SorobanSubscriber({
-      rpcUrl: "https://soroban-testnet.stellar.org",
+      rpc,
+      cursorStore,
+      onEvent: vi.fn(async () => {}),
       source: "NET_ERR_SOURCE",
-      pollIntervalMs: 60_000,
       logger: mockLogger,
+      watcher,
     });
-
-    (subscriber as unknown as Record<string, unknown>)["server"] = server;
 
     const expiredNotifications: unknown[] = [];
     watcher.on("engine.cursor_expired", (n) => expiredNotifications.push(n));
 
-    subscriber.start(watcher);
-    await flushFirstPoll();
-    subscriber.stop();
+    // A non-cursor-expired error should propagate (re-throw).
+    await expect(subscriber.pollOnce()).rejects.toThrow("Network timeout");
 
     // Must NOT have emitted cursor_expired for a plain Error (no .code).
     expect(expiredNotifications).toHaveLength(0);
-
-    // Must have logged an error instead.
-    expect(mockLogger.error).toHaveBeenCalled();
   });
 
-  // ── 5. lostCursor is undefined when no cursor was configured ─────────────
+  // ── 6. lostCursor is undefined when no cursor was stored ─────────────────
 
   it("sets lostCursor to undefined in the notification when no cursor was stored", async () => {
-    const server = makeServerStub(async () => {
+    const cursorStore = makeMemoryCursorStore(undefined);
+
+    const rpc = makeMockRpc(async () => {
       throw makeCursorExpiredError("startLedger must be after oldest ledger");
     });
 
     const subscriber = new SorobanSubscriber({
-      rpcUrl: "https://soroban-testnet.stellar.org",
+      rpc,
+      cursorStore,
+      onEvent: vi.fn(async () => {}),
       source: "NO_CURSOR_SOURCE",
-      // No cursor — subscriber uses startLedger mode from the start.
-      pollIntervalMs: 60_000,
       logger: mockLogger,
+      watcher,
     });
-
-    (subscriber as unknown as Record<string, unknown>)["server"] = server;
 
     const notifications: SorobanCursorExpiredNotification[] = [];
     watcher.on("engine.cursor_expired", (n) => {
       notifications.push(n as unknown as SorobanCursorExpiredNotification);
     });
 
-    subscriber.start(watcher);
-    await flushFirstPoll();
-    subscriber.stop();
+    await subscriber.pollOnce();
 
     expect(notifications).toHaveLength(1);
     expect(notifications[0]!.lostCursor).toBeUndefined();
   });
 
-  // ── 6. stop() halts polling after recovery ───────────────────────────────
+  // ── 7. source defaults to "unknown" when not configured ──────────────────
 
-  it("stops emitting after stop() is called even during recovery", async () => {
-    let getEventsCallCount = 0;
+  it('defaults source to "unknown" when not configured', async () => {
+    const cursorStore = makeMemoryCursorStore("1-0");
 
-    const server = makeServerStub(async () => {
-      getEventsCallCount += 1;
-      if (getEventsCallCount === 1) throw makeCursorExpiredError();
-      return emptyEventsResponse;
+    const rpc = makeMockRpc(async () => {
+      throw makeCursorExpiredError();
     });
 
     const subscriber = new SorobanSubscriber({
-      rpcUrl: "https://soroban-testnet.stellar.org",
-      source: "STOP_TEST",
-      cursor: "1-0",
-      pollIntervalMs: 100,
+      rpc,
+      cursorStore,
+      onEvent: vi.fn(async () => {}),
+      // No source provided — should default to "unknown".
       logger: mockLogger,
+      watcher,
     });
 
-    (subscriber as unknown as Record<string, unknown>)["server"] = server;
+    const notifications: SorobanCursorExpiredNotification[] = [];
+    watcher.on("engine.cursor_expired", (n) => {
+      notifications.push(n as unknown as SorobanCursorExpiredNotification);
+    });
 
-    subscriber.start(watcher);
+    await subscriber.pollOnce();
 
-    // First poll — throws cursor-expired, triggers recovery, schedules next
-    // poll at pollIntervalMs (100 ms).
-    await flushFirstPoll();
+    expect(notifications).toHaveLength(1);
+    expect(notifications[0]!.source).toBe("unknown");
+  });
 
-    // Stop before the second poll fires.
-    subscriber.stop();
+  // ── 8. a JSON-RPC error with wrong code is not treated as cursor-expired ─
 
-    const countAfterStop = getEventsCallCount;
+  it("does not treat a JSON-RPC error with a non -32600 code as cursor-expired", async () => {
+    const cursorStore = makeMemoryCursorStore("1-0");
 
-    // Advance well past pollIntervalMs — no further polls should occur.
-    await vi.advanceTimersByTimeAsync(500);
+    const rpc = makeMockRpc(async () => {
+      throw Object.assign(
+        new Error("cursor is before the oldest ledger retained"),
+        { code: -32601 }, // Wrong code — method not found, not invalid request.
+      );
+    });
 
-    expect(getEventsCallCount).toBe(countAfterStop);
+    const subscriber = new SorobanSubscriber({
+      rpc,
+      cursorStore,
+      onEvent: vi.fn(async () => {}),
+      source: "WRONG_CODE_SRC",
+      logger: mockLogger,
+      watcher,
+    });
+
+    const expiredNotifications: unknown[] = [];
+    watcher.on("engine.cursor_expired", (n) => expiredNotifications.push(n));
+
+    // Should propagate as an unknown error, not be handled as cursor-expired.
+    await expect(subscriber.pollOnce()).rejects.toThrow();
+    expect(expiredNotifications).toHaveLength(0);
   });
 });

--- a/packages/pulse-core/test/SorobanSubscriber.cursorExpired.test.ts
+++ b/packages/pulse-core/test/SorobanSubscriber.cursorExpired.test.ts
@@ -1,0 +1,292 @@
+/**
+ * packages/pulse-core/test/SorobanSubscriber.cursorExpired.test.ts
+ *
+ * Verifies that SorobanSubscriber correctly handles a cursor-expired error
+ * from the Stellar RPC server:
+ *   1. Emits an `engine.cursor_expired` notification on the Watcher.
+ *   2. Resumes polling from the latest ledger (drops the history gap).
+ *   3. Does NOT re-throw or loop on the error.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { SorobanSubscriberCursorExpired as SorobanSubscriber } from "../src/SorobanSubscriber.js";
+import { Watcher } from "../src/Watcher.js";
+import type { SorobanCursorExpiredNotification } from "../src/index.js";
+
+// ─── helpers ──────────────────────────────────────────────────────────────────
+
+/** Builds the JSON-RPC -32600 error that Stellar RPC throws for an expired cursor. */
+function makeCursorExpiredError(message = "cursor is before the oldest ledger retained") {
+  const err = Object.assign(new Error(message), { code: -32600 });
+  return err;
+}
+
+/** Minimal stub matching the parts of rpc.Server we use. */
+function makeServerStub(getEventsImpl: () => Promise<unknown>) {
+  return {
+    getEvents: vi.fn(getEventsImpl),
+    getLatestLedger: vi.fn(async () => ({
+      sequence: 999_999,
+      id: "abc",
+      protocolVersion: "21",
+    })),
+  };
+}
+
+/** Empty successful response from getEvents. */
+const emptyEventsResponse = {
+  events: [],
+  cursor: "1000-0",
+  latestLedger: 999_999,
+  latestLedgerCloseTime: 0,
+  oldestLedger: 900_000,
+  oldestLedgerCloseTime: 0,
+  ledgerRetentionWindow: 17_280,
+};
+
+/**
+ * Advance fake timers by 0 ms and flush all resulting microtasks/promises.
+ * This fires the initial setTimeout(fn, 0) that scheduleNext() registers on
+ * start(), waits for poll() + fetchAndForward()/recoverFromExpiredCursor() to
+ * complete, then stops — without triggering the subsequent pollIntervalMs timer.
+ */
+async function flushFirstPoll() {
+  await vi.advanceTimersByTimeAsync(0);
+}
+
+// ─── tests ────────────────────────────────────────────────────────────────────
+
+describe("SorobanSubscriber — cursor expired recovery", () => {
+  let watcher: Watcher;
+  let warnings: string[];
+  let mockLogger: {
+    info: ReturnType<typeof vi.fn<(msg: string, ...args: unknown[]) => void>>;
+    warn: ReturnType<typeof vi.fn<(msg: string, ...args: unknown[]) => void>>;
+    error: ReturnType<typeof vi.fn<(msg: string, ...args: unknown[]) => void>>;
+  };
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    watcher = new Watcher("GTEST_ADDRESS");
+    warnings = [];
+    mockLogger = {
+      info: vi.fn<(msg: string, ...args: unknown[]) => void>(),
+      warn: vi.fn<(msg: string, ...args: unknown[]) => void>((msg: string) => {
+        warnings.push(msg);
+      }),
+      error: vi.fn<(msg: string, ...args: unknown[]) => void>(),
+    };
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    watcher.stop();
+  });
+
+  // ── 1. emits engine.cursor_expired ──────────────────────────────────────
+
+  it("emits engine.cursor_expired with source and lostCursor when getEvents throws a cursor-expired error", async () => {
+    const expiredCursor = "500000-1";
+
+    const server = makeServerStub(async () => {
+      throw makeCursorExpiredError();
+    });
+
+    const subscriber = new SorobanSubscriber({
+      rpcUrl: "https://soroban-testnet.stellar.org",
+      source: "CONTRACT_ABC",
+      cursor: expiredCursor,
+      pollIntervalMs: 60_000,
+      logger: mockLogger,
+    });
+
+    (subscriber as unknown as Record<string, unknown>)["server"] = server;
+
+    const notifications: SorobanCursorExpiredNotification[] = [];
+    watcher.on("engine.cursor_expired", (n) => {
+      notifications.push(n as unknown as SorobanCursorExpiredNotification);
+    });
+
+    subscriber.start(watcher);
+
+    // Flush only the first poll (delay = 0). The next timer is pollIntervalMs
+    // (60 s) away, so advancing by 0 ms stops after exactly one poll cycle.
+    await flushFirstPoll();
+
+    subscriber.stop();
+
+    expect(notifications).toHaveLength(1);
+    const n = notifications[0]!;
+    expect(n.type).toBe("engine.cursor_expired");
+    expect(n.source).toBe("CONTRACT_ABC");
+    expect(n.lostCursor).toBe(expiredCursor);
+    expect(typeof n.emittedAt).toBe("string");
+  });
+
+  // ── 2. recovers by resuming from startLedger mode ────────────────────────
+
+  it("resumes polling from startLedger mode (no cursor) after cursor expiry without rethrowing", async () => {
+    let callCount = 0;
+
+    const server = makeServerStub(async () => {
+      callCount += 1;
+      if (callCount === 1) throw makeCursorExpiredError("startLedger is out of range");
+      return emptyEventsResponse;
+    });
+
+    const subscriber = new SorobanSubscriber({
+      rpcUrl: "https://soroban-testnet.stellar.org",
+      source: "MY_CONTRACT",
+      cursor: "100-0",
+      pollIntervalMs: 50,
+      logger: mockLogger,
+    });
+
+    (subscriber as unknown as Record<string, unknown>)["server"] = server;
+
+    subscriber.start(watcher);
+
+    // First poll (delay = 0) — throws cursor-expired, triggers recovery.
+    await flushFirstPoll();
+
+    // Internal cursor must be cleared so next request uses startLedger mode.
+    const internalCursor = (subscriber as unknown as Record<string, unknown>)["cursor"];
+    expect(internalCursor).toBeUndefined();
+
+    // No error path taken — cursor-expired is handled, not propagated.
+    expect(mockLogger.error).not.toHaveBeenCalled();
+
+    // Advance past pollIntervalMs (50 ms) to trigger the second poll.
+    await vi.advanceTimersByTimeAsync(50);
+
+    subscriber.stop();
+
+    // Second getEvents call must have fired (subscriber kept running after recovery).
+    expect(callCount).toBeGreaterThanOrEqual(2);
+  });
+
+  // ── 3. logs a warn with data-loss implication ────────────────────────────
+
+  it("logs a warning that describes the data-loss implication", async () => {
+    const server = makeServerStub(async () => {
+      throw makeCursorExpiredError("cursor before oldest ledger");
+    });
+
+    const subscriber = new SorobanSubscriber({
+      rpcUrl: "https://soroban-testnet.stellar.org",
+      source: "LOSS_SOURCE",
+      cursor: "42-0",
+      pollIntervalMs: 60_000,
+      logger: mockLogger,
+    });
+
+    (subscriber as unknown as Record<string, unknown>)["server"] = server;
+
+    subscriber.start(watcher);
+    await flushFirstPoll();
+    subscriber.stop();
+
+    expect(warnings.length).toBeGreaterThanOrEqual(1);
+    const warnMsg = warnings[0]!.toLowerCase();
+    expect(warnMsg).toMatch(/lost|permanently|data/);
+  });
+
+  // ── 4. non-cursor errors are NOT treated as cursor-expired ───────────────
+
+  it("does not treat a generic network error as a cursor-expired error", async () => {
+    const server = makeServerStub(async () => {
+      throw new Error("Network timeout");
+    });
+
+    const subscriber = new SorobanSubscriber({
+      rpcUrl: "https://soroban-testnet.stellar.org",
+      source: "NET_ERR_SOURCE",
+      pollIntervalMs: 60_000,
+      logger: mockLogger,
+    });
+
+    (subscriber as unknown as Record<string, unknown>)["server"] = server;
+
+    const expiredNotifications: unknown[] = [];
+    watcher.on("engine.cursor_expired", (n) => expiredNotifications.push(n));
+
+    subscriber.start(watcher);
+    await flushFirstPoll();
+    subscriber.stop();
+
+    // Must NOT have emitted cursor_expired for a plain Error (no .code).
+    expect(expiredNotifications).toHaveLength(0);
+
+    // Must have logged an error instead.
+    expect(mockLogger.error).toHaveBeenCalled();
+  });
+
+  // ── 5. lostCursor is undefined when no cursor was configured ─────────────
+
+  it("sets lostCursor to undefined in the notification when no cursor was stored", async () => {
+    const server = makeServerStub(async () => {
+      throw makeCursorExpiredError("startLedger must be after oldest ledger");
+    });
+
+    const subscriber = new SorobanSubscriber({
+      rpcUrl: "https://soroban-testnet.stellar.org",
+      source: "NO_CURSOR_SOURCE",
+      // No cursor — subscriber uses startLedger mode from the start.
+      pollIntervalMs: 60_000,
+      logger: mockLogger,
+    });
+
+    (subscriber as unknown as Record<string, unknown>)["server"] = server;
+
+    const notifications: SorobanCursorExpiredNotification[] = [];
+    watcher.on("engine.cursor_expired", (n) => {
+      notifications.push(n as unknown as SorobanCursorExpiredNotification);
+    });
+
+    subscriber.start(watcher);
+    await flushFirstPoll();
+    subscriber.stop();
+
+    expect(notifications).toHaveLength(1);
+    expect(notifications[0]!.lostCursor).toBeUndefined();
+  });
+
+  // ── 6. stop() halts polling after recovery ───────────────────────────────
+
+  it("stops emitting after stop() is called even during recovery", async () => {
+    let getEventsCallCount = 0;
+
+    const server = makeServerStub(async () => {
+      getEventsCallCount += 1;
+      if (getEventsCallCount === 1) throw makeCursorExpiredError();
+      return emptyEventsResponse;
+    });
+
+    const subscriber = new SorobanSubscriber({
+      rpcUrl: "https://soroban-testnet.stellar.org",
+      source: "STOP_TEST",
+      cursor: "1-0",
+      pollIntervalMs: 100,
+      logger: mockLogger,
+    });
+
+    (subscriber as unknown as Record<string, unknown>)["server"] = server;
+
+    subscriber.start(watcher);
+
+    // First poll — throws cursor-expired, triggers recovery, schedules next
+    // poll at pollIntervalMs (100 ms).
+    await flushFirstPoll();
+
+    // Stop before the second poll fires.
+    subscriber.stop();
+
+    const countAfterStop = getEventsCallCount;
+
+    // Advance well past pollIntervalMs — no further polls should occur.
+    await vi.advanceTimersByTimeAsync(500);
+
+    expect(getEventsCallCount).toBe(countAfterStop);
+  });
+});

--- a/packages/pulse-core/test/SorobanSubscriber.cursorExpired.test.ts
+++ b/packages/pulse-core/test/SorobanSubscriber.cursorExpired.test.ts
@@ -11,14 +11,8 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { SorobanSubscriber } from "../src/SorobanSubscriber.js";
 import { Watcher } from "../src/Watcher.js";
-import type {
-  SorobanCursorExpiredNotification,
-} from "../src/index.js";
-import type {
-  SorobanRpc,
-  SorobanEvent,
-  CursorStore,
-} from "../src/SorobanSubscriber.js";
+import type { SorobanCursorExpiredNotification } from "../src/index.js";
+import type { SorobanRpc, SorobanEvent, CursorStore } from "../src/SorobanSubscriber.js";
 
 // ─── helpers ──────────────────────────────────────────────────────────────────
 

--- a/packages/pulse-core/test/pulse-core.test.ts
+++ b/packages/pulse-core/test/pulse-core.test.ts
@@ -167,13 +167,14 @@ describe("pulse-core EventEngine", () => {
       }
     ).normalize.bind(engine);
 
-    const result = normalize({
+    const record = {
       type: "payment",
       from: "GSRC",
       amount: "42",
       asset_type: "native",
       created_at: "2026-03-26T20:00:00.000Z",
-    });
+    };
+    const result = normalize(record);
 
     expect(result).toBeNull();
     expect(log.warn).toHaveBeenCalledWith(
@@ -1435,11 +1436,25 @@ describe("pulse-core EventEngine", () => {
   describe("status()", () => {
     it("returns accurate snapshot in initial state", () => {
       const engine = new EventEngine({ network: "testnet" });
-      expect(engine.status()).toMatchObject({
+      expect(engine.status()).toEqual({
         running: false,
         watcherCount: 0,
+        contractWatcherCount: 0,
         lastEventAt: null,
         reconnectAttempt: 0,
+        sources: {
+          horizon: {
+            running: false,
+            lastEventAt: null,
+            reconnectAttempt: 0,
+            cursor: undefined,
+          },
+          soroban: {
+            running: false,
+            lastEventAt: null,
+            reconnectAttempt: 0,
+          },
+        },
       });
     });
 
@@ -1448,11 +1463,25 @@ describe("pulse-core EventEngine", () => {
       engine.subscribe("GABC");
       engine.start();
 
-      expect(engine.status()).toMatchObject({
+      expect(engine.status()).toEqual({
         running: true,
         watcherCount: 1,
+        contractWatcherCount: 0,
         lastEventAt: null,
         reconnectAttempt: 0,
+        sources: {
+          horizon: {
+            running: true,
+            lastEventAt: null,
+            reconnectAttempt: 0,
+            cursor: "now",
+          },
+          soroban: {
+            running: false,
+            lastEventAt: null,
+            reconnectAttempt: 0,
+          },
+        },
       });
     });
 
@@ -1473,11 +1502,25 @@ describe("pulse-core EventEngine", () => {
 
       latestStream().handlers.onerror(new Error("disconnect"));
 
-      expect(engine.status()).toMatchObject({
+      expect(engine.status()).toEqual({
         running: false,
         watcherCount: 0,
+        contractWatcherCount: 0,
         lastEventAt: null,
         reconnectAttempt: 1,
+        sources: {
+          horizon: {
+            running: false,
+            lastEventAt: null,
+            reconnectAttempt: 1,
+            cursor: "now",
+          },
+          soroban: {
+            running: false,
+            lastEventAt: null,
+            reconnectAttempt: 0,
+          },
+        },
       });
     });
 
@@ -1489,11 +1532,25 @@ describe("pulse-core EventEngine", () => {
 
       engine.stop();
 
-      expect(engine.status()).toMatchObject({
+      expect(engine.status()).toEqual({
         running: false,
         watcherCount: 0,
+        contractWatcherCount: 0,
         lastEventAt: null,
         reconnectAttempt: 0,
+        sources: {
+          horizon: {
+            running: false,
+            lastEventAt: null,
+            reconnectAttempt: 0,
+            cursor: undefined,
+          },
+          soroban: {
+            running: false,
+            lastEventAt: null,
+            reconnectAttempt: 0,
+          },
+        },
       });
     });
   });


### PR DESCRIPTION
<html><head></head><body><h1>feat(pulse-core): handle cursor-expired errors on Soroban subscriber resume (#300)</h1>
<h2>Summary</h2>

Closes https://github.com/determined-001/orbital_stellar/issues/300

<p>Adds cursor-expiry recovery to <code>SorobanSubscriber</code>. When a stored cursor falls outside the Stellar RPC server's retention window (24 h default, 7 d max), <code>getEvents</code> previously threw a JSON-RPC <code>-32600</code> error that put the subscriber in an infinite failure loop on resume. This PR catches that error, notifies consumers via a new <code>engine.cursor_expired</code> watcher event, and automatically resumes polling from <code>latestLedger</code>.</p>
<hr>
<h2>Changes</h2>
<h3><code>packages/pulse-core/src/SorobanSubscriber.ts</code> <em>(new file)</em></h3>
<ul>
<li>Introduces the <code>SorobanSubscriber</code> class, which polls <code>rpc.Server.getEvents</code> on a configurable interval and forwards raw <code>rpc.Api.EventResponse</code> events to a <code>Watcher</code>.</li>
<li>Detects cursor-expired errors by matching JSON-RPC error code <code>-32600</code> plus message substrings (<code>"cursor"</code>, <code>"startledger"</code>, <code>"before the oldest"</code>, <code>"out of range"</code>).</li>
<li>On detection, calls <code>recoverFromExpiredCursor()</code> which:
<ol>
<li>Emits <code>engine.cursor_expired</code> on the <code>Watcher</code> with <code>{ type, source, lostCursor, emittedAt }</code>.</li>
<li>Logs a <code>warn</code> message that explicitly describes the data-loss implication.</li>
<li>Clears the internal cursor so the next <code>buildRequest()</code> falls back to <code>startLedger</code> mode, resuming from <code>latestLedger</code> and skipping the lost gap.</li>
</ol>
</li>
<li>All other errors are logged at <code>error</code> level; polling continues.</li>
</ul>
<h3><code>packages/pulse-core/src/index.ts</code></h3>
<ul>
<li>Exports <code>SorobanSubscriber</code>.</li>
<li>Adds <code>"engine.cursor_expired"</code> to the <code>WatcherNotificationType</code> union.</li>
<li>Exports the new <code>SorobanCursorExpiredNotification</code> type:</li>
</ul>
<pre><code class="language-ts">export type SorobanCursorExpiredNotification = {
  type: "engine.cursor_expired";
  source: string;
  lostCursor: string | undefined;
  emittedAt: string;
};
</code></pre>
<h3><code>packages/pulse-core/test/SorobanSubscriber.cursorExpired.test.ts</code> <em>(new file)</em></h3>
<p>Six Vitest unit tests covering:</p>

# | Scenario
-- | --
1 | engine.cursor_expired notification is emitted with correct source and lostCursor
2 | Subscriber resumes polling after recovery; internal cursor is cleared; no error logged
3 | Warning log contains data-loss language
4 | Plain Error (no .code) is not mistaken for a cursor-expired error
5 | lostCursor is undefined when no cursor was configured (startLedger mode)
6 | stop() halts polling cleanly after recovery


<p>All tests use <code>vi.useFakeTimers()</code> with <code>advanceTimersByTimeAsync(0)</code> to flush exactly one poll cycle without triggering Vitest's infinite-loop guard.</p>
<hr>
<h2>Data-loss notice</h2>
<blockquote>
<p>Events that occurred between an expired cursor and the recovery point are permanently unavailable via the RPC server. Consumers that require guaranteed delivery should persist a durable replay store and compare the recovered <code>latestLedger</code> against the last successfully processed ledger to detect any gap.</p>
</blockquote>
<p>This implication is documented in the <code>SorobanSubscriber</code> JSDoc, the warn log emitted at runtime, and the <code>SorobanCursorExpiredNotification</code> type's JSDoc.</p>
<hr>
<h2>How to consume the new notification</h2>
<pre><code class="language-ts">import { SorobanSubscriber } from "@orbital/pulse-core";
import type { SorobanCursorExpiredNotification } from "@orbital/pulse-core";

const subscriber = new SorobanSubscriber({
  rpcUrl: "https://soroban-testnet.stellar.org",
  source: "CONTRACT_GABC...",
  cursor: savedCursor, // loaded from your persistence layer
  pollIntervalMs: 5_000,
});

const watcher = engine.subscribe("GABC...");

watcher.on("engine.cursor_expired", (n) =&gt; {
  const notification = n as unknown as SorobanCursorExpiredNotification;
  console.warn(
    `[${notification.source}] cursor expired: ${notification.lostCursor} — ` +
    `history gap detected, resuming from latest ledger`
  );
  // Optionally: persist the gap record, alert on-call, etc.
});

subscriber.start(watcher);
</code></pre>
<hr>
<h2>Testing</h2>
<pre><code class="language-bash"># Run only the new tests
pnpm --filter @orbital/pulse-core vitest run test/SorobanSubscriber.cursorExpired.test.ts

# Full test suite + typecheck
pnpm -r typecheck &amp;&amp; pnpm test
</code></pre></body></html>