### PR TITLE
Fix shared connected state for pulse-notify event connection pool

### DIFF
--- a/packages/pulse-notify/src/connectionPool.ts
+++ b/packages/pulse-notify/src/connectionPool.ts
@@ -80,7 +80,9 @@ export function acquireEventConnection(
   entry.subscribers.add(subscriber);
 
   return {
-    connected: entry.connected,
+    get connected() {
+      return entry.connected;
+    },
     unsubscribe: () => {
       entry.subscribers.delete(subscriber);
 

--- a/packages/pulse-notify/src/index.ts
+++ b/packages/pulse-notify/src/index.ts
@@ -114,14 +114,22 @@ export function useStellarEvent<T extends NormalizedEvent = NormalizedEvent>(
   return state;
 }
 
-export function useStellarPayment(serverUrl: string, address: string) {
+export function useStellarPayment(
+  serverUrl: string,
+  address: string,
+  options?: Pick<UseEventConfig, "filter">
+) {
   return useStellarEvent<Extract<NormalizedEvent, { type: "payment.received" }>>(
     serverUrl,
     address,
-    { event: "payment.received" }
+    { event: "payment.received", ...options }
   );
 }
 
-export function useStellarActivity(serverUrl: string, address: string) {
-  return useStellarEvent(serverUrl, address, { event: "*" });
+export function useStellarActivity(
+  serverUrl: string,
+  address: string,
+  options?: Pick<UseEventConfig, "filter">
+) {
+  return useStellarEvent(serverUrl, address, { event: "*", ...options });
 }

--- a/packages/pulse-notify/src/index.ts
+++ b/packages/pulse-notify/src/index.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import type { NormalizedEvent } from "@orbital/pulse-core";
 
 export type UseEventConfig = {
@@ -7,6 +7,7 @@ export type UseEventConfig = {
   event?: string | string[]; // "*" = all events; array = allowlist of types
   /** API key forwarded as ?token= query param — required when the server has authentication enabled */
   token?: string;
+  filter?: (event: NormalizedEvent) => boolean;
 };
 
 export type EventState<T extends NormalizedEvent = NormalizedEvent> = {
@@ -21,12 +22,12 @@ export function useStellarEvent<T extends NormalizedEvent = NormalizedEvent>(
 export function useStellarEvent<T extends NormalizedEvent = NormalizedEvent>(
   serverUrl: string,
   address: string,
-  options?: Pick<UseEventConfig, "event" | "token">
+  options?: Pick<UseEventConfig, "event" | "token" | "filter">
 ): EventState<T>;
 export function useStellarEvent<T extends NormalizedEvent = NormalizedEvent>(
   configOrUrl: UseEventConfig | string,
   address?: string,
-  options?: Pick<UseEventConfig, "event" | "token">
+  options?: Pick<UseEventConfig, "event" | "token" | "filter">
 ): EventState<T> {
   // Normalise the two call signatures down to four primitives.
   const serverUrl =
@@ -41,6 +42,10 @@ export function useStellarEvent<T extends NormalizedEvent = NormalizedEvent>(
     typeof configOrUrl === "string"
       ? options?.token
       : configOrUrl.token;
+  const filter =
+    typeof configOrUrl === "string"
+      ? options?.filter
+      : configOrUrl.filter;
 
   // Serialise eventType to a stable string for the dep array.
   // An array literal passed by the caller would otherwise be a new reference
@@ -48,6 +53,11 @@ export function useStellarEvent<T extends NormalizedEvent = NormalizedEvent>(
   const eventKey = Array.isArray(eventType)
     ? [...eventType].sort().join(",")
     : eventType;
+
+  const filterRef = useRef(filter);
+  useEffect(() => {
+    filterRef.current = filter;
+  });
 
   const [state, setState] = useState<EventState<T>>({
     event: null,
@@ -78,6 +88,7 @@ export function useStellarEvent<T extends NormalizedEvent = NormalizedEvent>(
             : incoming.type === eventType);
 
         if (!allowed) return;
+        if (filterRef.current && !filterRef.current(incoming)) return;
 
         setState((prev) => ({ ...prev, event: incoming as T }));
       } catch {

--- a/packages/pulse-notify/src/index.ts
+++ b/packages/pulse-notify/src/index.ts
@@ -9,9 +9,6 @@ export type UseEventConfig<T extends NormalizedEvent = NormalizedEvent> = {
   event?: string | string[];
   /** API key forwarded as ?token= query param — required when the server has authentication enabled */
   token?: string;
-<<<<<<< HEAD
-  filter?: (event: NormalizedEvent) => boolean;
-=======
   /** SSR initial state; replaced on first live event */
   initialEvent?: T | null;
   /** Client-side predicate; events that return false are suppressed before state update */
@@ -20,7 +17,6 @@ export type UseEventConfig<T extends NormalizedEvent = NormalizedEvent> = {
   withCredentials?: boolean;
   /** Side-effect callback fired for every incoming event, before filter is applied */
   onEvent?: (event: NormalizedEvent) => void;
->>>>>>> upstream/main
 };
 
 export type EventState<T extends NormalizedEvent = NormalizedEvent> = {
@@ -35,20 +31,18 @@ export function useStellarEvent<T extends NormalizedEvent = NormalizedEvent>(
 export function useStellarEvent<T extends NormalizedEvent = NormalizedEvent>(
   serverUrl: string,
   address: string,
-<<<<<<< HEAD
-  options?: Pick<UseEventConfig, "event" | "token" | "filter">
-=======
-  options?: Pick<UseEventConfig<T>, "event" | "token" | "initialEvent" | "filter" | "withCredentials" | "onEvent">
->>>>>>> upstream/main
+  options?: Pick<
+    UseEventConfig<T>,
+    "event" | "token" | "initialEvent" | "filter" | "withCredentials" | "onEvent"
+  >
 ): EventState<T>;
 export function useStellarEvent<T extends NormalizedEvent = NormalizedEvent>(
   configOrUrl: UseEventConfig<T> | string,
   address?: string,
-<<<<<<< HEAD
-  options?: Pick<UseEventConfig, "event" | "token" | "filter">
-=======
-  options?: Pick<UseEventConfig<T>, "event" | "token" | "initialEvent" | "filter" | "withCredentials" | "onEvent">
->>>>>>> upstream/main
+  options?: Pick<
+    UseEventConfig<T>,
+    "event" | "token" | "initialEvent" | "filter" | "withCredentials" | "onEvent"
+  >
 ): EventState<T> {
   const serverUrl =
     typeof configOrUrl === "string" ? configOrUrl : configOrUrl.serverUrl;
@@ -59,11 +53,6 @@ export function useStellarEvent<T extends NormalizedEvent = NormalizedEvent>(
       ? options?.event ?? "*"
       : configOrUrl.event ?? "*";
   const token =
-<<<<<<< HEAD
-    typeof configOrUrl === "string" ? options?.token : configOrUrl.token;
-  const filter =
-    typeof configOrUrl === "string" ? options?.filter : configOrUrl.filter;
-=======
     typeof configOrUrl === "string"
       ? options?.token
       : configOrUrl.token;
@@ -80,12 +69,6 @@ export function useStellarEvent<T extends NormalizedEvent = NormalizedEvent>(
   const onEvent =
     typeof configOrUrl === "string" ? options?.onEvent : configOrUrl.onEvent;
 
-  const filterRef = useRef(filter);
-  useEffect(() => { filterRef.current = filter; });
-  const onEventRef = useRef(onEvent);
-  useEffect(() => { onEventRef.current = onEvent; });
->>>>>>> upstream/main
-
   const eventKey = Array.isArray(eventType)
     ? [...eventType].sort().join(",")
     : eventType;
@@ -93,6 +76,11 @@ export function useStellarEvent<T extends NormalizedEvent = NormalizedEvent>(
   const filterRef = useRef(filter);
   useEffect(() => {
     filterRef.current = filter;
+  });
+
+  const onEventRef = useRef(onEvent);
+  useEffect(() => {
+    onEventRef.current = onEvent;
   });
 
   const [state, setState] = useState<EventState<T>>({
@@ -109,13 +97,8 @@ export function useStellarEvent<T extends NormalizedEvent = NormalizedEvent>(
           setState((prev) => ({ ...prev, connected: true, error: null }));
         },
         onEvent: (incoming) => {
-<<<<<<< HEAD
-=======
           onEventRef.current?.(incoming);
 
-          // Filter by event type: pass if "*", if type matches the string,
-          // or if type is included in the allowlist array.
->>>>>>> upstream/main
           const allowed =
             eventType === "*" ||
             (Array.isArray(eventType)
@@ -147,36 +130,23 @@ export function useStellarEvent<T extends NormalizedEvent = NormalizedEvent>(
     return () => {
       connection.unsubscribe();
     };
-<<<<<<< HEAD
-  }, [serverUrl, addr, eventKey, token]);
-=======
     // ✅ eventKey is a serialised string — stable even when the caller passes
     // an array literal, which would otherwise be a new reference every render.
   }, [serverUrl, addr, eventKey, token, withCredentials]);
 
->>>>>>> upstream/main
-
   return state;
 }
 
-<<<<<<< HEAD
-export function useStellarPayment(
-  serverUrl: string,
-  address: string,
-  options?: Pick<UseEventConfig, "filter">
-) {
-  return useStellarEvent<Extract<NormalizedEvent, { type: "payment.received" }>>(
-    serverUrl,
-    address,
-    { event: "payment.received", ...options }
-  );
-=======
-type PaymentEvent = Extract<NormalizedEvent, { type: "payment.received" }>;
+export type PaymentEvent = Extract<NormalizedEvent, { type: "payment.received" }>;
 
 export function useStellarPayment(
   serverUrl: string,
   address: string,
-  options?: { initialEvent?: PaymentEvent | null; filter?: (event: NormalizedEvent) => boolean; withCredentials?: boolean }
+  options?: {
+    initialEvent?: PaymentEvent | null;
+    filter?: (event: NormalizedEvent) => boolean;
+    withCredentials?: boolean;
+  }
 ) {
   const base = useStellarEvent<PaymentEvent>(serverUrl, address, {
     event: "payment.received",
@@ -189,18 +159,16 @@ export function useStellarPayment(
       ? BigInt(Math.round(parseFloat(base.event.amount) * 10_000_000))
       : null;
   return { ...base, amountStroop };
->>>>>>> upstream/main
 }
 
 export function useStellarActivity(
   serverUrl: string,
   address: string,
-<<<<<<< HEAD
-  options?: Pick<UseEventConfig, "filter">
-) {
-  return useStellarEvent(serverUrl, address, { event: "*", ...options });
-=======
-  options?: { initialEvent?: NormalizedEvent | null; filter?: (event: NormalizedEvent) => boolean; withCredentials?: boolean }
+  options?: {
+    initialEvent?: NormalizedEvent | null;
+    filter?: (event: NormalizedEvent) => boolean;
+    withCredentials?: boolean;
+  }
 ) {
   return useStellarEvent(serverUrl, address, {
     event: "*",
@@ -208,7 +176,6 @@ export function useStellarActivity(
     filter: options?.filter,
     withCredentials: options?.withCredentials,
   });
->>>>>>> upstream/main
 }
 
 export {

--- a/packages/pulse-notify/test/connectionPool.test.ts
+++ b/packages/pulse-notify/test/connectionPool.test.ts
@@ -59,6 +59,12 @@ const second = acquireEventConnection(
 assert.equal(MockEventSource.instances.length, 1);
 assert.equal(__getConnectionPoolSizeForTests(), 1);
 
+assert.equal(first.connected, false);
+assert.equal(second.connected, false);
+MockEventSource.instances[0]?.onopen?.();
+assert.equal(first.connected, true);
+assert.equal(second.connected, true);
+
 MockEventSource.instances[0]?.onmessage?.({
   data: JSON.stringify({ type: "payment.received" }),
 });


### PR DESCRIPTION
### Summary

Ensure useStellarEvent hooks share the same live connection state when they reuse a pooled SSE connection.
### What changed
- connectionPool.ts
  - acquireEventConnection() now returns connected as a getter so it reflects the current shared pool entry state instead of a stale snapshot.
- index.ts
  - Cleaned up merge conflict artifacts and restored the stable useStellarEvent implementation.
- connectionPool.test.ts
  - Added regression coverage verifying two subscribers on the same pooled connection both see connected = true after onopen.
### Why
Without this fix, multiple hooks sharing the same underlying connection could drift on whether the connection was considered open, causing inconsistent UI/status behavior across hooks using the same event stream.

Closes #419