### PR TITLE
feat(#327): add isEventType discriminator helper with README examples

### DIFF
--- a/packages/pulse-core/README.md
+++ b/packages/pulse-core/README.md
@@ -116,6 +116,46 @@ type NormalizedEvent =
 
 Every event includes a `timestamp` (ISO 8601) and a `raw` field with the original Horizon record. See [`docs/ARCHITECTURE.md` § 4 The normalization layer](../../docs/ARCHITECTURE.md#4-the-normalization-layer) for the full per-event shape table and the routing rules that decide which watcher receives which event.
 
+### Type narrowing with `isEventType`
+
+Use the `isEventType` helper to narrow events to specific types in a type-safe way:
+
+```ts
+import { EventEngine, isEventType } from "@orbital/pulse-core";
+
+const engine = new EventEngine({ network: "testnet" });
+engine.start();
+
+const watcher = engine.subscribe("GABC...");
+
+// Narrow to a single type
+watcher.on("*", (event) => {
+  if (isEventType(event, "payment.received")) {
+    console.log(`Received ${event.amount} ${event.asset} from ${event.from}`);
+  }
+});
+
+// Narrow to multiple types
+watcher.on("*", (event) => {
+  if (isEventType(event, "payment.received", "payment.sent", "payment.self")) {
+    console.log(`Payment of ${event.amount} ${event.asset}`);
+  }
+});
+
+// Filter an array of events
+const allEvents: NormalizedEvent[] = [];
+const paymentEvents = allEvents.filter((e) =>
+  isEventType(e, "payment.received", "payment.sent", "payment.self")
+);
+
+// Combine with other checks
+watcher.on("*", (event) => {
+  if (isEventType(event, "trustline.added", "trustline.updated")) {
+    console.log(`Trustline for ${event.asset} on account ${event.account}`);
+  }
+});
+```
+
 ## Design principles
 
 - **Amounts are strings.** Stellar uses 7-decimal fixed-point. JavaScript numbers lose precision. Treat all amounts as strings and delegate arithmetic to `bignumber.js` or similar.

--- a/packages/pulse-core/src/eventTypeGuard.ts
+++ b/packages/pulse-core/src/eventTypeGuard.ts
@@ -1,0 +1,36 @@
+import type { NormalizedEvent } from "./index.js";
+
+/**
+ * Type guard to narrow a NormalizedEvent to one or more specific event types.
+ *
+ * Useful for filtering events by type in a type-safe way without needing
+ * a full switch statement. Works with any combination of event type strings.
+ *
+ * @param event - The event to check
+ * @param types - One or more event type strings to match against
+ * @returns true if the event's type matches any of the provided types
+ *
+ * @example
+ * // Narrow to a single type
+ * if (isEventType(event, "payment.received")) {
+ *   console.log(`Received ${event.amount} ${event.asset}`);
+ * }
+ *
+ * @example
+ * // Narrow to multiple types
+ * if (isEventType(event, "payment.received", "payment.sent")) {
+ *   console.log(`Payment of ${event.amount} ${event.asset}`);
+ * }
+ *
+ * @example
+ * // Filter an array of events
+ * const payments = events.filter((e) =>
+ *   isEventType(e, "payment.received", "payment.sent", "payment.self")
+ * );
+ */
+export function isEventType<T extends NormalizedEvent["type"]>(
+  event: NormalizedEvent,
+  ...types: T[]
+): event is Extract<NormalizedEvent, { type: T }> {
+  return types.includes(event.type as T);
+}

--- a/packages/pulse-core/src/index.ts
+++ b/packages/pulse-core/src/index.ts
@@ -6,6 +6,7 @@ export { CursorStore } from "./CursorStore.js";
 export { PostgresCursorStore, PgLike } from "./PostgresCursorStore.js";
 export { evaluatePredicate, normalizeClaimPredicate, isClaimPredicateType } from "./claimPredicate.js";
 export type { ClaimPredicate } from "./claimPredicate.js";
+export { isEventType } from "./eventTypeGuard.js";
 
 /** The Stellar network to connect to. */
 export type Network = "mainnet" | "testnet";


### PR DESCRIPTION
Closes #327

## Changes
- Created `packages/pulse-core/src/eventTypeGuard.ts` with exported `isEventType` helper
- `isEventType(event, ...types)` narrows a discriminated union event using TypeScript's Extract utility
- Accepts variadic type arguments for single or multiple type narrowing
- Exported from `packages/pulse-core/src/index.ts`
- Added "Type narrowing with isEventType" section to README with 4 usage examples covering single type, multiple types, array filtering, and combining with other checks

## Usage
\`\`\`typescript
// Single type
if (isEventType(event, "contract.invoked")) {
  // event is narrowed here
}

// Multiple types
if (isEventType(event, "contract.invoked", "contract.emitted")) {
  // event is narrowed to either type
}
\`\`\`