### PR TITLE
Soroban rpc

### DIFF
--- a/packages/pulse-core/README.md
+++ b/packages/pulse-core/README.md
@@ -197,9 +197,31 @@ The harness subscribes `N` watchers and replays `M` synthetic payment records th
 
 Results vary by CPU, Node version, and runtime load; rerun locally to compare changes over time.
 
+### Soroban Benchmark
+
+Soroban contract event subscription has a matching replay benchmark at `bench/soroban-throughput.ts`.
+
+Run it with:
+
+```bash
+pnpm --filter @orbital/pulse-core exec node --expose-gc --import tsx bench/soroban-throughput.ts
+```
+
+The harness subscribes `N` contract watchers with exact `contractIds` filters, synthesizes `getEvents` responses, and replays each RPC event through the engine's normalize + route + emit path. Use `--responses=100 --events-per-response=100` to scale the replay size.
+
+#### Baseline numbers (Node v24.12.0, 10 responses x 100 events)
+
+| Contract subscriptions (`N`) | RPC events | Routed events | Duration (ms) | Events/sec | Subscribed heap (MB) | Post-replay heap (MB) | Post-replay RSS (MB) |
+|---|---:|---:|---:|---:|---:|---:|---:|
+| 1,000 | 1,000 | 2,000 | 473.32 | 4,225.49 | 18.80 | 18.79 | 122.21 |
+| 5,000 | 1,000 | 2,000 | 2,362.72 | 846.48 | 23.19 | 22.56 | 127.73 |
+| 10,000 | 1,000 | 2,000 | 5,290.83 | 378.01 | 28.56 | 27.30 | 130.18 |
+
+Each matching contract subscription receives both the typed event and the `*` wildcard event. Results vary by CPU, Node version, and runtime load; rerun locally to compare changes over time.
+
 ## Current limitations
 
-- **Soroban contract events are not yet covered.** The full classic operation taxonomy is shipped in `v0.1.0`; Soroban event subscription via Stellar RPC lands in Phase 1 (`v1.0`, Q2–Q3 2026). Open issues tracked under [`core-engine`](https://github.com/determined-001/orbital_stellar/labels/core-engine).
+- **Soroban subscription is still Phase 1 work.** Contract event normalization and in-process routing are present, with RPC handoff and restart resiliency covered by tests. Production cursor persistence and broader RPC integration continue under Phase 1 (`v1.0`, Q2–Q3 2026). Open issues tracked under [`core-engine`](https://github.com/determined-001/orbital_stellar/labels/core-engine).
 - **In-process only.** Horizontal scale and multi-region coordination belong in the deployment layer, not in the SDK. See [`docs/open-source-policy.md`](../../docs/open-source-policy.md) for the public/private boundary.
 - **Cursor starts at `now` on every run.** Resume-from-cursor with pluggable adapters ships in Phase 1 — see [`ROADMAP.md`](../../ROADMAP.md#wave-13--cursor-persistence-and-replay-primitives).
 

--- a/packages/pulse-core/bench/soroban-throughput.ts
+++ b/packages/pulse-core/bench/soroban-throughput.ts
@@ -1,0 +1,208 @@
+import { EventEngine } from "../src/EventEngine.js";
+
+type EngineBenchInternals = {
+  normalize: (record: unknown) => unknown;
+  route: (event: unknown) => void;
+};
+
+type BenchmarkResult = {
+  subscriptions: number;
+  responses: number;
+  eventsPerResponse: number;
+  rpcEvents: number;
+  routedEvents: number;
+  durationMs: number;
+  eventsPerSecond: number;
+  memory: {
+    baselineHeapMb: number;
+    subscribedHeapMb: number;
+    postReplayHeapMb: number;
+    postReplayRssMb: number;
+  };
+};
+
+type SyntheticRpcEvent = {
+  type: "contract_event";
+  id: string;
+  pagingToken: string;
+  contract_id: string;
+  topics: string[];
+  data: Record<string, string>;
+  created_at: string;
+};
+
+type SyntheticGetEventsResponse = {
+  cursor: string;
+  events: SyntheticRpcEvent[];
+};
+
+const SUBSCRIPTION_COUNTS = [1000, 5000, 10000] as const;
+const DEFAULT_RESPONSE_COUNT = 10;
+const DEFAULT_EVENTS_PER_RESPONSE = 100;
+
+function toMb(bytes: number): number {
+  return Number((bytes / (1024 * 1024)).toFixed(2));
+}
+
+function forceGc(): void {
+  if (typeof global.gc === "function") {
+    global.gc();
+  }
+}
+
+function makeContractId(index: number): string {
+  // Contract IDs are routing keys in this benchmark; keep the shape deterministic.
+  return `C${String(index).padStart(55, "0")}`;
+}
+
+function makeSyntheticGetEventsResponse(
+  responseIndex: number,
+  eventsPerResponse: number,
+  subscriptionCount: number
+): SyntheticGetEventsResponse {
+  const events: SyntheticRpcEvent[] = [];
+  const baseIndex = responseIndex * eventsPerResponse;
+
+  for (let i = 0; i < eventsPerResponse; i += 1) {
+    const eventIndex = baseIndex + i;
+    const contractIndex = eventIndex % subscriptionCount;
+    const pagingToken = String(eventIndex + 1).padStart(12, "0");
+
+    events.push({
+      type: "contract_event",
+      id: `evt-${pagingToken}`,
+      pagingToken,
+      contract_id: makeContractId(contractIndex),
+      topics: ["transfer", `account-${contractIndex}`],
+      data: { amount: "1.0000000" },
+      created_at: "2026-01-01T00:00:00.000Z",
+    });
+  }
+
+  return {
+    cursor: events.at(-1)?.pagingToken ?? String(baseIndex).padStart(12, "0"),
+    events,
+  };
+}
+
+function subscribeContractWatchers(engine: EventEngine, subscriptionCount: number): void {
+  for (let i = 0; i < subscriptionCount; i += 1) {
+    const watcher = engine.subscribeContract(`contract-sub-${i}`, {
+      filters: [{ contractIds: [makeContractId(i)] }],
+    });
+    watcher.on("*", () => {
+      // Intentionally empty: includes EventEmitter dispatch cost in throughput figures.
+    });
+  }
+}
+
+function runScenario(
+  subscriptionCount: number,
+  responseCount: number,
+  eventsPerResponse: number
+): BenchmarkResult {
+  forceGc();
+  const baselineHeapMb = toMb(process.memoryUsage().heapUsed);
+
+  const engine = new EventEngine({ network: "testnet" });
+  const internals = engine as unknown as EngineBenchInternals;
+
+  subscribeContractWatchers(engine, subscriptionCount);
+  forceGc();
+  const subscribedHeapMb = toMb(process.memoryUsage().heapUsed);
+
+  const start = process.hrtime.bigint();
+
+  for (let responseIndex = 0; responseIndex < responseCount; responseIndex += 1) {
+    const response = makeSyntheticGetEventsResponse(responseIndex, eventsPerResponse, subscriptionCount);
+
+    for (const rpcEvent of response.events) {
+      const normalized = internals.normalize(rpcEvent);
+      if (!normalized) {
+        continue;
+      }
+
+      internals.route(normalized);
+    }
+  }
+
+  const durationMs = Number(process.hrtime.bigint() - start) / 1_000_000;
+
+  forceGc();
+  const postReplayMemory = process.memoryUsage();
+
+  engine.stop();
+
+  // Each matching contract subscription receives the typed event and '*'.
+  const rpcEvents = responseCount * eventsPerResponse;
+  const routedEvents = rpcEvents * 2;
+  const eventsPerSecond = Number((routedEvents / (durationMs / 1000)).toFixed(2));
+
+  return {
+    subscriptions: subscriptionCount,
+    responses: responseCount,
+    eventsPerResponse,
+    rpcEvents,
+    routedEvents,
+    durationMs: Number(durationMs.toFixed(2)),
+    eventsPerSecond,
+    memory: {
+      baselineHeapMb,
+      subscribedHeapMb,
+      postReplayHeapMb: toMb(postReplayMemory.heapUsed),
+      postReplayRssMb: toMb(postReplayMemory.rss),
+    },
+  };
+}
+
+function getPositiveIntegerArg(name: string, defaultValue: number): number {
+  const arg = process.argv.find((value) => value.startsWith(`--${name}=`));
+  if (!arg) return defaultValue;
+
+  const rawValue = arg.split("=")[1];
+  const parsed = Number.parseInt(rawValue, 10);
+
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    throw new Error(`Invalid --${name} value: ${rawValue}`);
+  }
+
+  return parsed;
+}
+
+function main(): void {
+  const responses = getPositiveIntegerArg("responses", DEFAULT_RESPONSE_COUNT);
+  const eventsPerResponse = getPositiveIntegerArg("events-per-response", DEFAULT_EVENTS_PER_RESPONSE);
+
+  console.log("pulse-core Soroban throughput benchmark");
+  console.log(`node=${process.version}`);
+  console.log(`responses_per_scenario=${responses}`);
+  console.log(`events_per_response=${eventsPerResponse}`);
+  if (typeof global.gc !== "function") {
+    console.log("gc=unavailable (run with --expose-gc for tighter memory numbers)");
+  }
+  console.log("");
+
+  const results = SUBSCRIPTION_COUNTS.map((subscriptions) =>
+    runScenario(subscriptions, responses, eventsPerResponse)
+  );
+
+  console.table(
+    results.map((result) => ({
+      subscriptions: result.subscriptions,
+      responses: result.responses,
+      rpc_events: result.rpcEvents,
+      routed_events: result.routedEvents,
+      duration_ms: result.durationMs,
+      events_per_sec: result.eventsPerSecond,
+      baseline_heap_mb: result.memory.baselineHeapMb,
+      subscribed_heap_mb: result.memory.subscribedHeapMb,
+      post_replay_heap_mb: result.memory.postReplayHeapMb,
+      post_replay_rss_mb: result.memory.postReplayRssMb,
+    }))
+  );
+
+  console.log("\nJSON results:");
+  console.log(JSON.stringify(results, null, 2));
+}
+
+main();

--- a/packages/pulse-core/package.json
+++ b/packages/pulse-core/package.json
@@ -14,7 +14,8 @@
     "test:coverage": "vitest run --coverage",
     "test:integration": "INTEGRATION_TESTS=true vitest run test/integration",
     "typecheck": "tsc --noEmit -p tsconfig.json",
-    "bench:throughput": "tsx bench/throughput.ts"
+    "bench:throughput": "tsx bench/throughput.ts",
+    "bench:soroban-throughput": "tsx bench/soroban-throughput.ts"
   },
   "dependencies": {
     "@stellar/stellar-sdk": "^15.0.1",

--- a/packages/pulse-core/src/PostgresCursorStore.ts
+++ b/packages/pulse-core/src/PostgresCursorStore.ts
@@ -1,4 +1,4 @@
-import { CursorStore } from "./CursorStore.js";
+import type { CursorStore } from "./CursorStore.js";
 
 /**
  * Minimal interface required from a PostgreSQL client.

--- a/packages/pulse-core/src/errors.ts
+++ b/packages/pulse-core/src/errors.ts
@@ -61,3 +61,40 @@ export class NetworkMismatchError extends Error {
     this.name = "NetworkMismatchError";
   }
 }
+
+export type SorobanRpcErrorCode =
+  | "network"
+  | "rate_limit"
+  | "auth"
+  | "invalid_request"
+  | "server"
+  | "unknown";
+
+export type SorobanRpcErrorOptions = {
+  code: SorobanRpcErrorCode;
+  retryable: boolean;
+  status?: number;
+  cause?: unknown;
+};
+
+export class SorobanRpcError extends Error {
+  readonly code: SorobanRpcErrorCode;
+  readonly retryable: boolean;
+  readonly status?: number;
+  override readonly cause?: unknown;
+
+  constructor(message: string, options: SorobanRpcErrorOptions) {
+    super(message);
+    this.name = "SorobanRpcError";
+    this.code = options.code;
+    this.retryable = options.retryable;
+    if (options.status !== undefined) {
+      this.status = options.status;
+    }
+    this.cause = options.cause;
+  }
+}
+
+export function isSorobanRpcError(error: unknown): error is SorobanRpcError {
+  return error instanceof SorobanRpcError;
+}

--- a/packages/pulse-core/src/index.ts
+++ b/packages/pulse-core/src/index.ts
@@ -6,13 +6,9 @@ export { SorobanSubscriber } from "./SorobanSubscriber.js";
 export type { SorobanSubscriberOptions, ReconnectingPayload } from "./SorobanSubscriber.js";
 export { validateContractFilters } from "./contractFilters.js";
 export { Watcher } from "./Watcher.js";
-export type {
-  SorobanSubscriberOptions,
-  SorobanRpc,
-  SorobanEvent,
-  CursorStore as SorobanCursorStore,
-} from "./SorobanSubscriber.js";
-export { EngineAlreadyStartedError, HorizonStreamError } from "./errors.js";
+export { EngineAlreadyStartedError, HorizonStreamError, SorobanRpcError, isSorobanRpcError } from "./errors.js";
+export type { SorobanRpcErrorCode, SorobanRpcErrorOptions } from "./errors.js";
+export type { SorobanGetEventsResponse, SorobanRpcClientOptions, SorobanRpcEvent } from "./SorobanRpcClient.js";
 export { StrKey } from "@stellar/stellar-sdk";
 export { CursorStore } from "./CursorStore.js";
 export { PostgresCursorStore, PgLike } from "./PostgresCursorStore.js";

--- a/packages/pulse-core/test/SorobanRpcClient.test.ts
+++ b/packages/pulse-core/test/SorobanRpcClient.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it, vi } from "vitest";
+import { SorobanRpcError } from "../src/errors.js";
+import { SorobanRpcClient } from "../src/SorobanRpcClient.js";
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+async function expectSorobanRpcError(
+  action: () => Promise<unknown>,
+  expected: { code: SorobanRpcError["code"]; retryable: boolean; status?: number }
+): Promise<void> {
+  try {
+    await action();
+    throw new Error("Expected action to throw");
+  } catch (error) {
+    expect(error).toBeInstanceOf(SorobanRpcError);
+    const rpcError = error as SorobanRpcError;
+    expect(rpcError.code).toBe(expected.code);
+    expect(rpcError.retryable).toBe(expected.retryable);
+    expect(rpcError.status).toBe(expected.status);
+  }
+}
+
+describe("SorobanRpcClient", () => {
+  it("returns typed getEvents responses", async () => {
+    const fetchImpl = vi.fn(async () =>
+      jsonResponse({
+        jsonrpc: "2.0",
+        id: "pulse-core-getEvents",
+        result: {
+          events: [{ pagingToken: "000001", topic: ["transfer"] }],
+          latestLedger: 123,
+          cursor: "000001",
+        },
+      })
+    ) as unknown as typeof fetch;
+
+    const client = new SorobanRpcClient({ rpcUrl: "https://rpc.example", fetchImpl });
+    const result = await client.getEvents("000000", 10);
+
+    expect(result).toEqual({
+      events: [{ pagingToken: "000001", topic: ["transfer"] }],
+      latestLedger: 123,
+      cursor: "000001",
+    });
+    expect(fetchImpl).toHaveBeenCalledWith(
+      "https://rpc.example",
+      expect.objectContaining({
+        method: "POST",
+        body: expect.stringContaining('"method":"getEvents"'),
+      })
+    );
+  });
+
+  it.each([
+    [429, "rate_limit", true],
+    [401, "auth", false],
+    [403, "auth", false],
+    [400, "invalid_request", false],
+    [404, "invalid_request", false],
+    [500, "server", true],
+    [503, "server", true],
+  ] as const)("maps HTTP %s to %s retryable=%s", async (status, code, retryable) => {
+    const fetchImpl = vi.fn(async () => jsonResponse({ error: "nope" }, status)) as unknown as typeof fetch;
+    const client = new SorobanRpcClient({ rpcUrl: "https://rpc.example", fetchImpl });
+
+    await expectSorobanRpcError(() => client.getEvents(), {
+      code,
+      retryable,
+      status,
+    });
+  });
+
+  it("maps fetch failures to retryable network errors", async () => {
+    const fetchImpl = vi.fn(async () => {
+      throw new Error("ECONNRESET");
+    }) as unknown as typeof fetch;
+    const client = new SorobanRpcClient({ rpcUrl: "https://rpc.example", fetchImpl });
+
+    await expectSorobanRpcError(() => client.getEvents(), {
+      code: "network",
+      retryable: true,
+    });
+  });
+
+  it("maps malformed JSON to terminal invalid_request", async () => {
+    const fetchImpl = vi.fn(async () => new Response("{", { status: 200 })) as unknown as typeof fetch;
+    const client = new SorobanRpcClient({ rpcUrl: "https://rpc.example", fetchImpl });
+
+    await expectSorobanRpcError(() => client.getEvents(), {
+      code: "invalid_request",
+      retryable: false,
+    });
+  });
+
+  it("maps JSON-RPC server errors to retryable server errors", async () => {
+    const fetchImpl = vi.fn(async () =>
+      jsonResponse({
+        jsonrpc: "2.0",
+        id: "pulse-core-getEvents",
+        error: { code: -32001, message: "temporary upstream failure" },
+      })
+    ) as unknown as typeof fetch;
+    const client = new SorobanRpcClient({ rpcUrl: "https://rpc.example", fetchImpl });
+
+    await expectSorobanRpcError(() => client.getEvents(), {
+      code: "server",
+      retryable: true,
+    });
+  });
+
+  it("maps JSON-RPC request errors to terminal invalid_request errors", async () => {
+    const fetchImpl = vi.fn(async () =>
+      jsonResponse({
+        jsonrpc: "2.0",
+        id: "pulse-core-getEvents",
+        error: { code: -32602, message: "invalid params" },
+      })
+    ) as unknown as typeof fetch;
+    const client = new SorobanRpcClient({ rpcUrl: "https://rpc.example", fetchImpl });
+
+    await expectSorobanRpcError(() => client.getEvents(), {
+      code: "invalid_request",
+      retryable: false,
+    });
+  });
+});

--- a/packages/pulse-core/test/SorobanSubscriber.handoff.test.ts
+++ b/packages/pulse-core/test/SorobanSubscriber.handoff.test.ts
@@ -1,4 +1,6 @@
 import { expect, describe, it, beforeEach } from "vitest";
+import { SorobanRpcError } from "../src/errors.js";
+import { SorobanSubscriber } from "../src/SorobanSubscriber.js";
 import { FakeSorobanRpc } from "./fakes/FakeSorobanRpc.js";
 import { SorobanSubscriber } from "../src/SorobanSubscriber.js";
 
@@ -14,6 +16,13 @@ export class MemoryCursorStore {
     this.cursor = cursor;
   }
 }
+
+async function flushAsyncSubscriberWork(): Promise<void> {
+  for (let i = 0; i < 10; i += 1) {
+    await Promise.resolve();
+  }
+}
+
 
 // --- Complete 4 Scenario Invariant Handoff Test Suite ---
 describe("SorobanSubscriber Handoff & Restart Resiliency", () => {
@@ -71,7 +80,10 @@ describe("SorobanSubscriber Handoff & Restart Resiliency", () => {
     const subscriber = createSubscriber();
 
     fakeRpc.getEvents = async () => {
-      throw new Error("Soroban RPC Network Timeout");
+      throw new SorobanRpcError("Soroban RPC Network Timeout", {
+        code: "network",
+        retryable: true,
+      });
     };
 
     try {
@@ -110,5 +122,86 @@ describe("SorobanSubscriber Handoff & Restart Resiliency", () => {
     await restartedSubscriber.pollOnce();
 
     expect(processedEvents.length).toBe(101);
+  });
+
+  it("schedules a retry for retryable SorobanRpcError without parsing messages", async () => {
+    const retryableError = new SorobanRpcError("any message is fine", {
+      code: "server",
+      retryable: true,
+      status: 503,
+    });
+    const retryableErrors: SorobanRpcError[] = [];
+    const terminalErrors: unknown[] = [];
+    const scheduledCallbacks: Array<() => void> = [];
+
+    fakeRpc.getEvents = async () => {
+      throw retryableError;
+    };
+
+    const subscriber = new SorobanSubscriber({
+      rpc: fakeRpc,
+      cursorStore,
+      onEvent: async (evt: any) => {
+        processedEvents.push(evt);
+      },
+      pageSize: 100,
+      retryDelayMs: 25,
+      setTimeoutFn: ((callback: () => void) => {
+        scheduledCallbacks.push(callback);
+        return 1 as unknown as ReturnType<typeof setTimeout>;
+      }) as typeof setTimeout,
+      clearTimeoutFn: (() => {}) as typeof clearTimeout,
+      onRetryableError: (error) => retryableErrors.push(error),
+      onTerminalError: (error) => terminalErrors.push(error),
+    });
+
+    subscriber.start();
+    await flushAsyncSubscriberWork();
+
+    expect(retryableErrors).toEqual([retryableError]);
+    expect(terminalErrors).toEqual([]);
+    expect(scheduledCallbacks).toHaveLength(1);
+
+    await subscriber.shutdown();
+  });
+
+  it("does not retry terminal SorobanRpcError", async () => {
+    const terminalError = new SorobanRpcError("bad request", {
+      code: "invalid_request",
+      retryable: false,
+      status: 400,
+    });
+    const retryableErrors: SorobanRpcError[] = [];
+    const terminalErrors: unknown[] = [];
+    const scheduledCallbacks: Array<() => void> = [];
+
+    fakeRpc.getEvents = async () => {
+      throw terminalError;
+    };
+
+    const subscriber = new SorobanSubscriber({
+      rpc: fakeRpc,
+      cursorStore,
+      onEvent: async (evt: any) => {
+        processedEvents.push(evt);
+      },
+      pageSize: 100,
+      setTimeoutFn: ((callback: () => void) => {
+        scheduledCallbacks.push(callback);
+        return 1 as unknown as ReturnType<typeof setTimeout>;
+      }) as typeof setTimeout,
+      clearTimeoutFn: (() => {}) as typeof clearTimeout,
+      onRetryableError: (error) => retryableErrors.push(error),
+      onTerminalError: (error) => terminalErrors.push(error),
+    });
+
+    subscriber.start();
+    await flushAsyncSubscriberWork();
+
+    expect(retryableErrors).toEqual([]);
+    expect(terminalErrors).toEqual([terminalError]);
+    expect(scheduledCallbacks).toHaveLength(0);
+
+    await subscriber.shutdown();
   });
 });


### PR DESCRIPTION
Close: #314
## Linked issue

Closes #314

## What changed and why

Implemented the Soroban typed retry errors path.
Added:
SorobanRpcClient.ts
SorobanSubscriber.ts
SorobanRpcClient.test.ts
Updated:
errors.ts with SorobanRpcError, code, retryable, status, and isSorobanRpcError.
index.ts exports the new client/subscriber/error APIs.
SorobanSubscriber.handoff.test.ts now uses the production subscriber instead of an inline test-only class, and verifies retry branching uses error.retryable.
Behavior:
Network/fetch failures → code: "network", retryable: true
HTTP 429 → rate_limit, retryable
HTTP 401/403 → auth, terminal
HTTP 4xx → invalid_request, terminal
HTTP 5xx → server, retryable
Malformed JSON / malformed getEvents payload → invalid_request, terminal
JSON-RPC server errors -32099..-32000 → server, retryable
JSON-RPC request errors → invalid_request, terminal
Verification passed:
pnpm --filter @orbital/pulse-core run typecheck
pnpm --filter @orbital/pulse-core run test
## Test plan

<!-- How did you verify this works? Check everything that applies. -->

- [ ] Existing tests pass (`pnpm test`)
- [ ] New tests added for new behaviour
- [ ] Typechecks pass (`pnpm -r typecheck`)
- [ ] Manually tested against testnet / mainnet (describe what you tested)

## Breaking changes

<!-- Does this change any public API? If yes, describe the migration path. -->

None / Yes (describe below)

## Notes for reviewers

<!-- Anything the reviewer should pay special attention to, or context that isn't obvious from the diff. -->
