### PR TITLE
feat(pulse-core): SorobanRpcClient supports authenticated RPC providers (#316)

### DIFF
--- a/packages/pulse-core/src/SorobanRpcClient.ts
+++ b/packages/pulse-core/src/SorobanRpcClient.ts
@@ -1,0 +1,122 @@
+/**
+ * Options for creating a SorobanRpcClient.
+ */
+export interface SorobanRpcClientOptions {
+  /** The Soroban RPC server URL (e.g. a QuickNode or other hosted endpoint). */
+  url: string;
+  /**
+   * Optional HTTP headers to forward on every request.
+   *
+   * The recommended authentication pattern is:
+   * ```ts
+   * headers: { Authorization: "Bearer <your-api-key>" }
+   * ```
+   *
+   * **Security:** Header values are automatically redacted (`[REDACTED]`) in
+   * any log output to prevent credential leakage.
+   */
+  headers?: Record<string, string>;
+}
+
+/**
+ * Client for connecting to Soroban RPC providers.
+ *
+ * Supports authenticated endpoints via configurable headers. Every request
+ * includes the configured headers, and sensitive header values are
+ * automatically redacted from log output.
+ *
+ * @example
+ * ```ts
+ * const client = new SorobanRpcClient({
+ *   url: "https://soroban-rpc.quicknode.com/...",
+ *   headers: { Authorization: "Bearer your-api-key" },
+ * });
+ *
+ * const { events } = await client.getEvents();
+ * ```
+ */
+export class SorobanRpcClient {
+  private readonly url: string;
+  private readonly headers: Record<string, string>;
+
+  /**
+   * @param options - Configuration for the RPC client.
+   */
+  constructor(options: SorobanRpcClientOptions) {
+    this.url = options.url;
+    this.headers = { ...(options.headers ?? {}) };
+  }
+
+  /**
+   * Returns a copy of the configured headers with all values replaced by
+   * `[REDACTED]` so they can be safely included in log output.
+   */
+  private getRedactedHeaders(): Record<string, string> {
+    const redacted: Record<string, string> = {};
+    for (const key of Object.keys(this.headers)) {
+      redacted[key] = "[REDACTED]";
+    }
+    return redacted;
+  }
+
+  /**
+   * Sends a JSON-RPC 2.0 POST request to the Soroban RPC endpoint.
+   *
+   * @param method - The JSON-RPC method name.
+   * @param params - Optional JSON-RPC parameters.
+   * @returns The JSON-RPC response body.
+   */
+  async request(method: string, params?: unknown): Promise<unknown> {
+    const body = JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      method,
+      params,
+    });
+
+    console.log(
+      "[SorobanRpcClient] Sending request:",
+      method,
+      "with headers:",
+      this.getRedactedHeaders()
+    );
+
+    const response = await fetch(this.url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        ...this.headers,
+      },
+      body,
+    });
+
+    if (!response.ok) {
+      throw new Error(
+        `Soroban RPC request failed: ${response.status} ${response.statusText}`
+      );
+    }
+
+    return response.json();
+  }
+
+  /**
+   * Fetches Soroban events with optional cursor-based pagination.
+   *
+   * @param startCursor - Optional cursor to start fetching from.
+   * @param limit - Optional maximum number of events to return.
+   * @returns An object containing the events array.
+   */
+  async getEvents(
+    startCursor?: string,
+    limit?: number
+  ): Promise<{ events: unknown[] }> {
+    const params: Record<string, unknown> = {};
+    if (startCursor !== undefined) params.startCursor = startCursor;
+    if (limit !== undefined) params.limit = limit;
+
+    const result = (await this.request("getEvents", params)) as {
+      result?: { events?: unknown[] };
+    };
+    return { events: result?.result?.events ?? [] };
+  }
+}

--- a/packages/pulse-core/src/index.ts
+++ b/packages/pulse-core/src/index.ts
@@ -1,3 +1,5 @@
+export { SorobanRpcClient } from "./SorobanRpcClient.js";
+export type { SorobanRpcClientOptions } from "./SorobanRpcClient.js";
 export { EventEngine } from "./EventEngine.js";
 export { Watcher } from "./Watcher.js";
 export { EngineAlreadyStartedError, HorizonStreamError } from "./errors.js";

--- a/packages/pulse-core/test/SorobanRpcClient.auth.test.ts
+++ b/packages/pulse-core/test/SorobanRpcClient.auth.test.ts
@@ -1,0 +1,253 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { SorobanRpcClient } from "../src/SorobanRpcClient.js";
+
+describe("SorobanRpcClient — authenticated RPC providers", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("constructor", () => {
+    it("accepts a URL with no headers", () => {
+      const client = new SorobanRpcClient({
+        url: "https://soroban-rpc.example.com",
+      });
+      expect(client).toBeInstanceOf(SorobanRpcClient);
+    });
+
+    it("accepts a URL with custom headers", () => {
+      const client = new SorobanRpcClient({
+        url: "https://soroban-rpc.example.com",
+        headers: { Authorization: "Bearer test-token-123" },
+      });
+      expect(client).toBeInstanceOf(SorobanRpcClient);
+    });
+  });
+
+  describe("request() — header forwarding", () => {
+    it("forwards configured headers on every request", async () => {
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({ jsonrpc: "2.0", id: 1, result: {} }),
+      });
+      vi.stubGlobal("fetch", fetchMock);
+
+      const client = new SorobanRpcClient({
+        url: "https://soroban-rpc.example.com",
+        headers: {
+          Authorization: "Bearer secret-api-key",
+          "X-Custom-Header": "custom-value",
+        },
+      });
+
+      await client.request("ping");
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      const [calledUrl, callOptions] = fetchMock.mock.calls[0] as [
+        string,
+        RequestInit
+      ];
+      expect(calledUrl).toBe("https://soroban-rpc.example.com");
+      expect(callOptions.method).toBe("POST");
+      expect(callOptions.headers).toEqual({
+        "Content-Type": "application/json",
+        Authorization: "Bearer secret-api-key",
+        "X-Custom-Header": "custom-value",
+      });
+    });
+
+    it("sends headers even when no custom headers are configured", async () => {
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({ jsonrpc: "2.0", id: 1, result: {} }),
+      });
+      vi.stubGlobal("fetch", fetchMock);
+
+      const client = new SorobanRpcClient({
+        url: "https://soroban-rpc.example.com",
+      });
+
+      await client.request("ping");
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      const [, callOptions] = fetchMock.mock.calls[0] as [string, RequestInit];
+      expect(callOptions.headers).toEqual({
+        "Content-Type": "application/json",
+      });
+    });
+
+    it("sends JSON-RPC 2.0 payload", async () => {
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({ jsonrpc: "2.0", id: 1, result: {} }),
+      });
+      vi.stubGlobal("fetch", fetchMock);
+
+      const client = new SorobanRpcClient({
+        url: "https://soroban-rpc.example.com",
+      });
+
+      await client.request("getHealth");
+
+      const [, callOptions] = fetchMock.mock.calls[0] as [string, RequestInit];
+      const parsedBody = JSON.parse(callOptions.body as string);
+      expect(parsedBody).toEqual({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "getHealth",
+        params: undefined,
+      });
+    });
+  });
+
+  describe("request() — error handling", () => {
+    it("throws when the server responds with a non-OK status", async () => {
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 401,
+        statusText: "Unauthorized",
+      });
+      vi.stubGlobal("fetch", fetchMock);
+
+      const client = new SorobanRpcClient({
+        url: "https://soroban-rpc.example.com",
+        headers: { Authorization: "Bearer invalid-token" },
+      });
+
+      await expect(client.request("getHealth")).rejects.toThrow(
+        "Soroban RPC request failed: 401 Unauthorized"
+      );
+    });
+  });
+
+  describe("log redaction of header values", () => {
+    it("does not log raw header values", async () => {
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({ jsonrpc: "2.0", id: 1, result: {} }),
+      });
+      vi.stubGlobal("fetch", fetchMock);
+      const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+      const client = new SorobanRpcClient({
+        url: "https://soroban-rpc.example.com",
+        headers: {
+          Authorization: "Bearer super-secret-token-abc-123",
+        },
+      });
+
+      await client.request("ping");
+
+      expect(consoleSpy).toHaveBeenCalledWith(
+        "[SorobanRpcClient] Sending request:",
+        "ping",
+        "with headers:",
+        { Authorization: "[REDACTED]" }
+      );
+      // Verify the actual secret value does not appear in any log call
+      expect(consoleSpy).not.toHaveBeenCalledWith(
+        expect.stringContaining("super-secret-token-abc-123")
+      );
+    });
+
+    it("redacts all header values regardless of header name", async () => {
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({ jsonrpc: "2.0", id: 1, result: {} }),
+      });
+      vi.stubGlobal("fetch", fetchMock);
+      const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+      const client = new SorobanRpcClient({
+        url: "https://soroban-rpc.example.com",
+        headers: {
+          "X-Api-Key": "my-api-key",
+          "X-Secret": "my-secret-value",
+        },
+      });
+
+      await client.request("ping");
+
+      expect(consoleSpy).toHaveBeenCalledWith(
+        "[SorobanRpcClient] Sending request:",
+        "ping",
+        "with headers:",
+        { "X-Api-Key": "[REDACTED]", "X-Secret": "[REDACTED]" }
+      );
+    });
+  });
+
+  describe("getEvents()", () => {
+    it("returns events from the RPC response", async () => {
+      const mockEvents = [
+        { id: "event-1", value: "hello" },
+        { id: "event-2", value: "world" },
+      ];
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          jsonrpc: "2.0",
+          id: 1,
+          result: { events: mockEvents },
+        }),
+      });
+      vi.stubGlobal("fetch", fetchMock);
+
+      const client = new SorobanRpcClient({
+        url: "https://soroban-rpc.example.com",
+      });
+
+      const { events } = await client.getEvents();
+
+      expect(events).toEqual(mockEvents);
+    });
+
+    it("passes startCursor and limit as parameters", async () => {
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          jsonrpc: "2.0",
+          id: 1,
+          result: { events: [] },
+        }),
+      });
+      vi.stubGlobal("fetch", fetchMock);
+
+      const client = new SorobanRpcClient({
+        url: "https://soroban-rpc.example.com",
+      });
+
+      await client.getEvents("000001", 50);
+
+      const [, callOptions] = fetchMock.mock.calls[0] as [string, RequestInit];
+      const parsedBody = JSON.parse(callOptions.body as string);
+      expect(parsedBody.params).toEqual({
+        startCursor: "000001",
+        limit: 50,
+      });
+    });
+
+    it("returns empty events array when result is missing", async () => {
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({ jsonrpc: "2.0", id: 1, result: {} }),
+      });
+      vi.stubGlobal("fetch", fetchMock);
+
+      const client = new SorobanRpcClient({
+        url: "https://soroban-rpc.example.com",
+      });
+
+      const { events } = await client.getEvents();
+
+      expect(events).toEqual([]);
+    });
+  });
+});


### PR DESCRIPTION
## Description

Resolves **Issue #316** — SorobanRpcClient supports authenticated RPC providers.

## Changes

### `packages/pulse-core/src/SorobanRpcClient.ts` (new)
- `SorobanRpcClient` class with constructor accepting `url` + optional `headers?: Record<string, string>`
- `request(method, params?)` sends JSON-RPC 2.0 POST requests with configured headers forwarded
- `getEvents(startCursor?, limit?)` supporting cursor-based pagination
- **Log redaction**: header values are replaced with `[REDACTED]` in log output
- JSDoc documents `Authorization: Bearer <token>` as the recommended auth pattern

### `packages/pulse-core/test/SorobanRpcClient.auth.test.ts` (new)
- 11 tests covering constructor, header forwarding, JSON-RPC payload, error handling, log redaction, `getEvents` parameter passing

### `packages/pulse-core/src/index.ts` (modified)
- Added exports for `SorobanRpcClient` and `SorobanRpcClientOptions`

## Closes

Closes #316