### PR TITLE
feat(pulse-core): add FileCursorStore for disk-backed cursor persistence

### DIFF
--- a/packages/pulse-core/src/FileCursorStore.ts
+++ b/packages/pulse-core/src/FileCursorStore.ts
@@ -1,0 +1,84 @@
+import { promises as fsPromises, constants as fsConstants } from "fs";
+import fs from "fs";
+import path from "path";
+import { CursorStore } from "./CursorStore.js";
+
+function safeFilename(streamKey: string): string {
+  return encodeURIComponent(streamKey) + ".json";
+}
+
+export class FileCursorStore implements CursorStore {
+  private readonly dir: string;
+
+  constructor(dir: string) {
+    this.dir = dir;
+  }
+
+  private filePathFor(streamKey: string): string {
+    return path.join(this.dir, safeFilename(streamKey));
+  }
+
+  private async ensureDir(): Promise<void> {
+    await fsPromises.mkdir(this.dir, { recursive: true });
+  }
+
+  async get(streamKey: string): Promise<string | null> {
+    const file = this.filePathFor(streamKey);
+    try {
+      const data = await fsPromises.readFile(file, "utf8");
+      try {
+        const parsed = JSON.parse(data);
+        if (parsed && typeof parsed.cursor === "string") return parsed.cursor;
+        return null;
+      } catch (err) {
+        console.warn(
+          `FileCursorStore: failed to parse cursor file ${file}, treating as missing`,
+        );
+        return null;
+      }
+    } catch (err: any) {
+      if (err.code === "ENOENT") return null;
+      throw err;
+    }
+  }
+
+  async set(streamKey: string, cursor: string): Promise<void> {
+    await this.ensureDir();
+    const file = this.filePathFor(streamKey);
+    const tmp = `${file}.tmp-${Math.random().toString(36).slice(2)}`;
+    const payload = JSON.stringify({
+      cursor,
+      updated_at: new Date().toISOString(),
+    });
+
+    // Write to tmp file, fsync, rename, fsync directory
+    const fd = await fsPromises.open(tmp, "w");
+    try {
+      await fd.writeFile(payload, "utf8");
+      await fd.sync();
+    } finally {
+      await fd.close();
+    }
+
+    // Rename tmp -> final
+    await fsPromises.rename(tmp, file);
+
+    // fsync directory to ensure rename durable (best-effort)
+    try {
+      const dirFd = await fsPromises.open(this.dir, "r");
+      try {
+        // Node's fsPromises doesn't expose fsync on DirHandle, so use fs.fsync with numeric fd
+        // @ts-ignore - access internal fd
+        await fsPromises.fsync((dirFd as any).fd);
+      } catch (_) {
+        // ignore
+      } finally {
+        await dirFd.close();
+      }
+    } catch (_) {
+      // ignore
+    }
+  }
+}
+
+export default FileCursorStore;

--- a/packages/pulse-core/test/FileCursorStore.test.ts
+++ b/packages/pulse-core/test/FileCursorStore.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { FileCursorStore } from "../src/FileCursorStore.js";
+import fs from "fs";
+import path from "path";
+import os from "os";
+
+const mkdtemp = (prefix = "filecursor-") =>
+  fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+
+describe("FileCursorStore", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtemp();
+  });
+
+  afterEach(() => {
+    // remove temp dir recursively
+    try {
+      fs.rmSync(dir, { recursive: true, force: true });
+    } catch (_) {}
+  });
+
+  it("round-trips cursors across instances", async () => {
+    const store1 = new FileCursorStore(dir);
+    const key = "test-stream-rt";
+    const val = "cursor-abc-123";
+
+    await store1.set(key, val);
+
+    const store2 = new FileCursorStore(dir);
+    const read = await store2.get(key);
+    expect(read).toBe(val);
+  });
+
+  it("returns null and warns on corrupted JSON file", async () => {
+    const store = new FileCursorStore(dir);
+    const key = "test-corrupt";
+    const filename = path.join(dir, encodeURIComponent(key) + ".json");
+
+    // create dir and write invalid JSON
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(filename, "{ not valid json", "utf8");
+
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const result = await store.get(key);
+    expect(result).toBeNull();
+    expect(warnSpy).toHaveBeenCalled();
+
+    warnSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
Closes #337

---

What: Add a new FileCursorStore adapter that persists a JSON file per stream key on disk, using an atomic-write pattern and tolerant reads.
Behavior: Writes via .tmp -> fsync -> rename and best-effort directory fsync; corrupted JSON is logged as a warning and treated as missing (no throw).
Files: [FileCursorStore.ts](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html), [FileCursorStore.test.ts](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Tests: Adds unit tests to verify round-trip persistence and corrupted-file handling.