### PR TITLE
refactor(pulse-core): add events namespace and JSDoc on NormalizedEve…

### DIFF
--- a/packages/pulse-core/src/events.ts
+++ b/packages/pulse-core/src/events.ts
@@ -1,0 +1,26 @@
+/**
+ * Per-event named types for pulse-core, grouped for precise type narrowing.
+ * Accessible via the `events` namespace export from "@orbital/pulse-core".
+ *
+ * @example
+ * import type { events } from "@orbital/pulse-core";
+ * type Payment = events.PaymentEvent;
+ */
+export type {
+  PaymentEvent,
+  AccountOptionsEvent,
+  AccountCreatedEvent,
+  TrustlineEvent,
+  AccountMergeEvent,
+  OfferEvent,
+  BumpSequenceEvent,
+  DataEvent,
+  ClaimableCreatedEvent,
+  ClaimableClaimedEvent,
+  LiquidityPoolDepositEvent,
+  LiquidityPoolWithdrawEvent,
+  TrustAuthEvent,
+  ContractInvokedEvent,
+  ContractEmittedEvent,
+  ContractEvent,
+} from "./index.js";

--- a/packages/pulse-core/src/index.ts
+++ b/packages/pulse-core/src/index.ts
@@ -283,6 +283,18 @@ export type AccountMergeEvent = {
 
 /**
  * A union of all normalized events supported by pulse-core.
+ *
+ * This is the broad catch-all type. For precise type narrowing and better
+ * autocompletion, prefer the per-event types available under the `events`
+ * namespace export:
+ *
+ * ```ts
+ * import type { events } from "@orbital/pulse-core";
+ * type Payment = events.PaymentEvent;
+ * type AccountCreated = events.AccountCreatedEvent;
+ * ```
+ *
+ * @see {@link events} for the full list of narrower per-event types.
  */
 export type NormalizedEvent =
   | PaymentEvent
@@ -465,3 +477,13 @@ export type ContractSubscribeOptions = {
   /** Optional human-friendly label for observability — appears in log lines and lifecycle notifications. */
   name?: string;
 };
+
+/**
+ * Namespace grouping all per-event named types for precise type narrowing.
+ * @see {@link events} for the full list of narrower per-event types.
+ *
+ * @example
+ * import type { events } from "@orbital/pulse-core";
+ * function handlePayment(e: events.PaymentEvent) { ... }
+ */
+export * as events from "./events.js";


### PR DESCRIPTION
 Description:
  
  Closes #336
  
  ## What
  
  - Adds `export * as events from "./events.js"` in `packages/pulse-core/src/index.ts`, backed by a new `src/events.ts` barrel that re-exports all 16
  per-event named types (`PaymentEvent`, `AccountCreatedEvent`, etc.)
  - Expands the JSDoc on `NormalizedEvent` to explain it is the broad union type and points consumers toward the narrower per-event types available under
  the `events` namespace
  
  ## Why
  
  Consumers importing `NormalizedEvent` had no autocompletion guidance toward the narrower types. The `events` namespace makes all per-event types
  discoverable via IDE autocompletion (`events.`) and the updated JSDoc surfaces the guidance on hover.
  
  ## What was NOT changed
  
  - `NormalizedEvent` is not removed or deprecated — this is documentation only
  - No runtime behavior changed
  - No existing exports were modified
  
  ## Usage after this change
  
  ```ts
  import type { events } from "@orbital/pulse-core";
  
  function handlePayment(e: events.PaymentEvent) { ... }
  
  Testing
  
  pnpm -r typecheck — no new errors introduced (pre-existing errors in abi-registry and EventEngine.ts are unrelated to this change).
  
  ---
  
  Open the PR against `determined-001/orbital_stellar` (upstream), not your fork's `main`.