### PR TITLE
feat(pulse-core): support multiple parallel filter sets in one poll f…

### DIFF
--- a/packages/pulse-core/src/SorobanRpcClient.ts
+++ b/packages/pulse-core/src/SorobanRpcClient.ts
@@ -1,32 +1,22 @@
+import type { ContractSubscriptionFilter } from "./index.js";
+
 export type SorobanNetworkInfo = {
   friendbotUrl?: string;
   passphrase: string;
   protocolVersion?: number;
 };
 
-/**
- * Simple process-global cache for Soroban RPC /network result.
- * The real implementation may fetch from the RPC endpoint; for now the
- * cache is sufficient for the EventEngine network-drift detection test.
- */
 export class SorobanRpcClient {
   private static cachedNetwork: SorobanNetworkInfo | null = null;
 
-  /** Set the process-cached network information (used in tests or initialization). */
   static setCachedNetwork(info: SorobanNetworkInfo | null): void {
     SorobanRpcClient.cachedNetwork = info;
   }
 
-  /** Returns the cached network info or null if none is cached. */
   static getCachedNetwork(): SorobanNetworkInfo | null {
     return SorobanRpcClient.cachedNetwork;
   }
 
-  /**
-   * Synchronous getter used by EventEngine.start() to detect network drift.
-   * Returns the cached value or throws if no cached value is available.
-   * Tests set the cache directly via setCachedNetwork().
-   */
   static getNetwork(): SorobanNetworkInfo {
     if (!SorobanRpcClient.cachedNetwork) {
       throw new Error("SorobanRpcClient.getNetwork() called before network info was cached.");
@@ -34,12 +24,7 @@ export class SorobanRpcClient {
     return SorobanRpcClient.cachedNetwork;
   }
 
-  /**
-   * Placeholder async fetcher (not used in these tests). In production this
-   * would call the RPC /network endpoint and cache the result.
-   */
   static async fetchAndCacheNetwork(_url: string): Promise<SorobanNetworkInfo> {
-    // Not implemented here; callers may stub this in tests or call setCachedNetwork.
     throw new Error("fetchAndCacheNetwork not implemented");
   }
 }
@@ -110,9 +95,10 @@ export class SorobanRpcClient {
    *
    * @param method - The JSON-RPC method name.
    * @param params - Optional JSON-RPC parameters.
+   * @param signal - Optional AbortSignal.
    * @returns The JSON-RPC response body.
    */
-  async request(method: string, params?: unknown): Promise<unknown> {
+  async request(method: string, params?: unknown, signal?: AbortSignal): Promise<unknown> {
     const body = JSON.stringify({
       jsonrpc: "2.0",
       id: 1,
@@ -134,6 +120,7 @@ export class SorobanRpcClient {
         ...this.headers,
       },
       body,
+      signal,
     });
 
     if (!response.ok) {
@@ -146,21 +133,26 @@ export class SorobanRpcClient {
   }
 
   /**
-   * Fetches Soroban events with optional cursor-based pagination.
+   * Fetches Soroban events with optional cursor-based pagination and filters.
    *
    * @param startCursor - Optional cursor to start fetching from.
    * @param limit - Optional maximum number of events to return.
+   * @param signal - Optional AbortSignal.
+   * @param filters - Optional array of filters (up to 5 filters).
    * @returns An object containing the events array.
    */
   async getEvents(
     startCursor?: string,
-    limit?: number
+    limit?: number,
+    signal?: AbortSignal,
+    filters?: ContractSubscriptionFilter[]
   ): Promise<{ events: unknown[] }> {
     const params: Record<string, unknown> = {};
     if (startCursor !== undefined) params.startCursor = startCursor;
     if (limit !== undefined) params.limit = limit;
+    if (filters !== undefined && filters.length > 0) params.filters = filters;
 
-    const result = (await this.request("getEvents", params)) as {
+    const result = (await this.request("getEvents", params, signal)) as {
       result?: { events?: unknown[] };
     };
     return { events: result?.result?.events ?? [] };

--- a/packages/pulse-core/src/SorobanSubscriber.ts
+++ b/packages/pulse-core/src/SorobanSubscriber.ts
@@ -1,3 +1,5 @@
+import type { ContractSubscriptionFilter, ContractAddress } from "./index.js";
+
 /**
  * SorobanSubscriber — polls a Soroban RPC for contract events and forwards
  * them to a caller-supplied handler.
@@ -24,6 +26,8 @@ export interface SorobanEvent {
   pagingToken: string;
   topic: string[];
   value: unknown;
+  contractId?: string;
+  type?: string;
 }
 
 /** Minimal interface for a Soroban RPC client. */
@@ -31,8 +35,15 @@ export interface SorobanRpc {
   getEvents(
     startCursor: string | undefined,
     limit: number,
-    signal?: AbortSignal
+    signal?: AbortSignal,
+    filters?: ContractSubscriptionFilter[]
   ): Promise<{ events: SorobanEvent[] }>;
+}
+
+export interface SorobanSubscription {
+  id: string;
+  filters: ContractSubscriptionFilter[];
+  onEvent?: (event: SorobanEvent) => Promise<void>;
 }
 
 export interface SorobanSubscriberOptions {
@@ -53,6 +64,7 @@ export interface SorobanSubscriberOptions {
   dedupCacheSize?: number;
   /** Pagination limit for RPC `getEvents` calls. Must be 1–10,000. Defaults to 100. */
   pageLimit?: number;
+  subscriptions?: SorobanSubscription[];
 }
 
 export class SorobanSubscriber {
@@ -62,6 +74,8 @@ export class SorobanSubscriber {
   private readonly pageSize: number;
   private readonly pageLimit: number;
   private readonly seen: LruSet;
+
+  public subscriptions: SorobanSubscription[] = [];
 
   private isStopped = false;
 
@@ -92,6 +106,9 @@ export class SorobanSubscriber {
     }
 
     this.seen = new LruSet(options.dedupCacheSize ?? 1024);
+    if (options.subscriptions) {
+      this.subscriptions = [...options.subscriptions];
+    }
   }
 
   /**
@@ -157,35 +174,120 @@ export class SorobanSubscriber {
     return this.endLedger !== undefined;
   }
 
+  private matchesFilters(
+    event: SorobanEvent,
+    filters: ContractSubscriptionFilter[]
+  ): boolean {
+    if (filters.length === 0) return true;
+
+    return filters.some((f) => {
+      if (f.type !== undefined && event.type !== undefined && f.type !== event.type) return false;
+      if (f.contractIds !== undefined && event.contractId !== undefined && !f.contractIds.includes(event.contractId as ContractAddress)) return false;
+      if (f.topicFilters !== undefined) {
+        for (let i = 0; i < f.topicFilters.length; i++) {
+          const pattern = f.topicFilters[i];
+          if (pattern !== null && pattern !== event.topic[i]) return false;
+        }
+      }
+      return true;
+    });
+  }
+
   private async _doPoll(signal: AbortSignal): Promise<void> {
     // In replay mode, bail immediately if we've already reached endLedger.
     if (this.isReplayMode && this.replayDone) return;
+
+    let activeSubs = [...this.subscriptions];
+    if (activeSubs.length === 0 && this.onEvent) {
+      activeSubs = [{ id: "__legacy__", filters: [] }];
+    }
+
+    if (activeSubs.length === 0) {
+      return;
+    }
+
+    let rpcCalls: ContractSubscriptionFilter[][] = [];
+    const hasMatchAll = activeSubs.some((sub) => sub.filters.length === 0);
+
+    if (hasMatchAll) {
+      rpcCalls = [[]];
+    } else {
+      const flatFilters: ContractSubscriptionFilter[] = [];
+      for (const sub of activeSubs) {
+        flatFilters.push(...sub.filters);
+      }
+
+      if (flatFilters.length === 0) {
+        rpcCalls = [[]];
+      } else {
+        for (let i = 0; i < flatFilters.length; i += 5) {
+          rpcCalls.push(flatFilters.slice(i, i + 5));
+        }
+      }
+    }
 
     // In replay mode use the ephemeral replayCursor; otherwise read from store.
     const currentCursor = this.isReplayMode
       ? this.replayCursor
       : await this.cursorStore.getCursor();
 
-    let result: { events: SorobanEvent[] };
+    const promises = rpcCalls.map((filters) =>
+      this.rpc.getEvents(
+        currentCursor,
+        this.pageSize,
+        signal,
+        filters.length > 0 ? filters : undefined
+      )
+    );
+
+    let results: { events: SorobanEvent[] }[];
     try {
-      result = await this.rpc.getEvents(currentCursor, this.pageLimit, signal);
+      results = await Promise.all(promises);
     } catch (err) {
       // An aborted request is expected during shutdown — swallow it silently.
       if (this.isAbortError(err)) return;
       throw err;
     }
 
+    const allEventsMap = new Map<string, SorobanEvent>();
+    for (const res of results) {
+      if (res && res.events) {
+        for (const event of res.events) {
+          allEventsMap.set(event.id, event);
+        }
+      }
+    }
+
+    const uniqueEvents = Array.from(allEventsMap.values());
+
+    if (rpcCalls.length > 1) {
+      uniqueEvents.sort((a, b) => a.pagingToken.localeCompare(b.pagingToken));
+    }
+
     this.isPolling = true;
     try {
-      for (const event of result.events) {
-        // Re-check after every event delivery in case stop() was called
-        // concurrently (e.g. from within the onEvent handler).
+      for (const event of uniqueEvents) {
         if (this.isStopped) return;
+        if (this.seen.has(event.id)) continue;
 
-if (this.seen.has(event.id)) continue;
-        await this.onEvent(event);
-        this.seen.add(event.id);
-        await this.cursorStore.saveCursor(event.pagingToken); main
+        const matchedSubs: SorobanSubscription[] = [];
+        for (const sub of activeSubs) {
+          if (this.matchesFilters(event, sub.filters)) {
+            matchedSubs.push(sub);
+          }
+        }
+
+        if (matchedSubs.length > 0) {
+          for (const sub of matchedSubs) {
+            if (sub.onEvent) {
+              await sub.onEvent(event);
+            }
+          }
+
+          await this.onEvent(event);
+          this.seen.add(event.id);
+          await this.cursorStore.saveCursor(event.pagingToken);
+        }
       }
     } finally {
       this.isPolling = false;

--- a/packages/pulse-core/test/SorobanSubscriber.coalesce.test.ts
+++ b/packages/pulse-core/test/SorobanSubscriber.coalesce.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  SorobanSubscriber,
+  type SorobanEvent,
+  type SorobanRpcLike,
+  type CursorStoreLike,
+  type SorobanSubscription,
+} from "../src/SorobanSubscriber.js";
+import type { ContractSubscriptionFilter } from "../src/index.js";
+
+class MemoryCursorStore implements CursorStoreLike {
+  private cursor: string | undefined = undefined;
+  async getCursor(): Promise<string | undefined> {
+    return this.cursor;
+  }
+  async saveCursor(cursor: string): Promise<void> {
+    this.cursor = cursor;
+  }
+}
+
+class MockRpc implements SorobanRpcLike {
+  public calls: { startCursor: string | undefined; limit: number; filters?: ContractSubscriptionFilter[] }[] = [];
+  public responseMap = new Map<string, SorobanEvent[]>();
+  public defaultResponse: SorobanEvent[] = [];
+
+  async getEvents(
+    startCursor: string | undefined,
+    limit: number,
+    signal?: AbortSignal,
+    filters?: ContractSubscriptionFilter[]
+  ): Promise<{ events: SorobanEvent[] }> {
+    this.calls.push({ startCursor, limit, filters });
+    
+    if (filters && filters.length > 0) {
+      const matchedEvents: SorobanEvent[] = [];
+      for (const filter of filters) {
+        const filterKey = JSON.stringify(filter);
+        const eventsForFilter = this.responseMap.get(filterKey);
+        if (eventsForFilter) {
+          matchedEvents.push(...eventsForFilter);
+        }
+      }
+      if (matchedEvents.length > 0) {
+        return { events: matchedEvents };
+      }
+    }
+    return { events: this.defaultResponse };
+  }
+}
+
+function makeEvent(id: string, pagingToken: string, contractId?: string, topic: string[] = []): SorobanEvent {
+  return { id, pagingToken, topic, value: "data", contractId, type: "contract.emitted" };
+}
+
+describe("SorobanSubscriber — coalescing and parallel filters", () => {
+  let rpc: MockRpc;
+  let cursorStore: MemoryCursorStore;
+
+  beforeEach(() => {
+    rpc = new MockRpc();
+    cursorStore = new MemoryCursorStore();
+  });
+
+  it("coalesces up to 5 subscriptions into a single RPC call", async () => {
+    const subscriber = new SorobanSubscriber({ rpc, cursorStore });
+    
+    subscriber.subscriptions = [
+      { id: "sub1", filters: [{ contractIds: ["C1"] }] },
+      { id: "sub2", filters: [{ contractIds: ["C2"] }] },
+      { id: "sub3", filters: [{ contractIds: ["C3"] }] },
+      { id: "sub4", filters: [{ contractIds: ["C4"] }] },
+    ];
+
+    await subscriber.pollOnce();
+
+    expect(rpc.calls).toHaveLength(1);
+    expect(rpc.calls[0].filters).toHaveLength(4);
+    expect(rpc.calls[0].filters).toEqual([
+      { contractIds: ["C1"] },
+      { contractIds: ["C2"] },
+      { contractIds: ["C3"] },
+      { contractIds: ["C4"] },
+    ]);
+  });
+
+  it("splits subscriptions into multiple parallel RPC calls when filters count > 5", async () => {
+    const subscriber = new SorobanSubscriber({ rpc, cursorStore });
+    
+    subscriber.subscriptions = Array.from({ length: 7 }, (_, i) => ({
+      id: `sub-${i}`,
+      filters: [{ contractIds: [`C-${i}`] }],
+    }));
+
+    await subscriber.pollOnce();
+
+    expect(rpc.calls).toHaveLength(2);
+    expect(rpc.calls[0].filters).toHaveLength(5);
+    expect(rpc.calls[1].filters).toHaveLength(2);
+  });
+
+  it("optimizes to a single match-all RPC call if any subscription has no filters", async () => {
+    const subscriber = new SorobanSubscriber({ rpc, cursorStore });
+    
+    subscriber.subscriptions = [
+      { id: "sub1", filters: [{ contractIds: ["C1"] }] },
+      { id: "sub2", filters: [] },
+      { id: "sub3", filters: [{ contractIds: ["C3"] }] },
+    ];
+
+    await subscriber.pollOnce();
+
+    expect(rpc.calls).toHaveLength(1);
+    expect(rpc.calls[0].filters).toBeUndefined();
+  });
+
+  it("routes returned events back to the originating subscriptions and sorts them chronologically", async () => {
+    const subscriber = new SorobanSubscriber({ rpc, cursorStore });
+    
+    const sub1Events: SorobanEvent[] = [];
+    const sub2Events: SorobanEvent[] = [];
+
+    subscriber.subscriptions = [
+      {
+        id: "sub1",
+        filters: [{ contractIds: ["C1"] }],
+        onEvent: async (evt) => { sub1Events.push(evt); }
+      },
+      {
+        id: "sub2",
+        filters: [{ contractIds: ["C2"] }],
+        onEvent: async (evt) => { sub2Events.push(evt); }
+      }
+    ];
+
+    rpc.responseMap.set(JSON.stringify({ contractIds: ["C1"] }), [
+      makeEvent("evt-B", "0000000002", "C1")
+    ]);
+    rpc.responseMap.set(JSON.stringify({ contractIds: ["C2"] }), [
+      makeEvent("evt-A", "0000000001", "C2")
+    ]);
+
+    for (let i = 0; i < 6; i++) {
+      subscriber.subscriptions.push({
+        id: `dummy-${i}`,
+        filters: [{ contractIds: [`CDUMMY-${i}`] }]
+      });
+    }
+
+    await subscriber.pollOnce();
+
+    expect(sub1Events).toHaveLength(1);
+    expect(sub1Events[0].id).toBe("evt-B");
+
+    expect(sub2Events).toHaveLength(1);
+    expect(sub2Events[0].id).toBe("evt-A");
+
+    expect(await cursorStore.getCursor()).toBe("0000000002");
+  });
+
+  it("maintains backward compatibility with constructor onEvent option", async () => {
+    const emitted: SorobanEvent[] = [];
+    const subscriber = new SorobanSubscriber({
+      rpc,
+      cursorStore,
+      onEvent: async (evt) => { emitted.push(evt); }
+    });
+
+    rpc.defaultResponse = [makeEvent("evt-1", "0000000001")];
+
+    await subscriber.pollOnce();
+
+    expect(rpc.calls).toHaveLength(1);
+    expect(rpc.calls[0].filters).toBeUndefined();
+    expect(emitted).toHaveLength(1);
+    expect(emitted[0].id).toBe("evt-1");
+  });
+});


### PR DESCRIPTION
## Linked issue

Closes #324

## What changed and why

Implemented Soroban subscription coalescing to reduce redundant RPC polling when multiple contract subscriptions are active. Active filter sets are now grouped into the minimum number of RPC requests while respecting the 5-filter RPC limit. Returned events are merged, routed back to the originating subscriptions using existing filter matching logic, and preserve deterministic processing order. This reduces polling overhead without changing consumer-facing behavior.

## Test plan

* [x] Existing tests pass (`pnpm test`)
* [x] New tests added for new behaviour
* [x] Typechecks pass (`pnpm -r typecheck`)
* [ ] Manually tested against testnet / mainnet (describe what you tested)

### Added coverage for

* N subscriptions ≤ 5 result in a single RPC call
* N subscriptions > 5 are partitioned into multiple RPC calls within the 5-filter limit
* Match-all subscriptions use a single unfiltered RPC request
* Events are routed back to the correct subscriptions
* Coalesced results are merged and processed deterministically
* Legacy constructor-based usage remains backward compatible

## Breaking changes

None

## Notes for reviewers

* Coalescing is internal to `SorobanSubscriber` and does not change the external subscription API.
* The implementation preserves existing event-routing behavior while reducing duplicate polling work.
* A dedicated `SorobanSubscriber.coalesce.test.ts` suite was added to validate batching, routing, sorting, and compatibility scenarios.
