### PR TITLE
feat(pulse-core): add subscribeContract(config) overload with RPC fil…

### DIFF
--- a/packages/pulse-core/src/EventEngine.ts
+++ b/packages/pulse-core/src/EventEngine.ts
@@ -18,8 +18,10 @@ import type {
   ClaimableClaimedEvent,
   ClaimableCreatedEvent,
   ContractEmittedEvent,
+  ContractFilter,
   ContractInvokedEvent,
   ContractSubscribeOptions,
+  ContractSubscriptionConfig,
   ContractSubscriptionFilter,
   CoreConfig,
   DataEvent,
@@ -90,10 +92,24 @@ const STELLAR_MAX_TRUSTLINE_LIMIT = "922337203685.4775807";
 
 const noop: Logger = { info: () => { }, warn: () => { }, error: () => { } };
 
+/**
+ * Produces a stable, order-independent string key for a ContractFilter array.
+ * Used to deduplicate subscribeContract(config) calls.
+ */
+function stableFilterKey(filters: ContractFilter[]): string {
+  const normalized = filters.map((f) => ({
+    type: f.type,
+    contractIds: f.contractIds ? [...f.contractIds].sort() : undefined,
+    topics: f.topics,
+  }));
+  return JSON.stringify(normalized);
+}
+
 export class EventEngine {
   private server: Horizon.Server;
   private registry: Map<string, Watcher> = new Map();
   private contractRegistry: Map<string, { watcher: Watcher; filters: ContractSubscriptionFilter[] }> = new Map();
+  private contractConfigRegistry: Map<string, Watcher> = new Map();
   private subscriptionNames: Map<string, string> = new Map();
   private stopStream: HorizonStreamStopper | null = null;
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
@@ -312,7 +328,48 @@ export class EventEngine {
    * @param id - A caller-chosen identifier for this subscription (used to unsubscribe).
    * @param options - Optional filters; omitting filters matches all contract events.
    */
-  subscribeContract(id: string, options?: ContractSubscribeOptions): Watcher {
+  subscribeContract(id: string, options?: ContractSubscribeOptions): Watcher;
+  /**
+   * Subscribes to Soroban contract events using an RPC-shaped filter config.
+   * Deduplicates by a stable key over the filter shape — repeated calls with
+   * semantically equal configs return the same Watcher instance.
+   * Throws synchronously when filters.length > 5 or any filter's contractIds.length > 5.
+   * @param config - Filter configuration mirroring the RPC getEvents filter shape.
+   */
+  subscribeContract(config: ContractSubscriptionConfig): Watcher;
+  subscribeContract(
+    idOrConfig: string | ContractSubscriptionConfig,
+    options?: ContractSubscribeOptions
+  ): Watcher {
+    // New config-object overload
+    if (typeof idOrConfig === "object") {
+      const config = idOrConfig;
+      if (config.filters.length > 5) {
+        throw new Error(
+          `ContractSubscriptionConfig.filters must have ≤ 5 entries, got ${config.filters.length}`
+        );
+      }
+      for (let i = 0; i < config.filters.length; i++) {
+        const f = config.filters[i]!;
+        if (f.contractIds !== undefined && f.contractIds.length > 5) {
+          throw new Error(
+            `ContractSubscriptionConfig.filters[${i}].contractIds must have ≤ 5 entries, got ${f.contractIds.length}`
+          );
+        }
+      }
+
+      const key = stableFilterKey(config.filters);
+      const existing = this.contractConfigRegistry.get(key);
+      if (existing) return existing;
+
+      const watcher = new Watcher(key);
+      watcher.addStopHandler(() => this.contractConfigRegistry.delete(key));
+      this.contractConfigRegistry.set(key, watcher);
+      return watcher;
+    }
+
+    // Legacy string-id overload
+    const id = idOrConfig;
     const existing = this.contractRegistry.get(id);
     if (existing) {
       if (options?.filter) {

--- a/packages/pulse-core/src/index.ts
+++ b/packages/pulse-core/src/index.ts
@@ -559,3 +559,17 @@ export type ContractSubscribeOptions = {
  * function handlePayment(e: events.PaymentEvent) { ... }
  */
 export * as events from "./events.js";
+
+// ---------------------------------------------------------------------------
+// Phase 1 — new RPC-shaped contract subscription API
+// ---------------------------------------------------------------------------
+
+export type ContractFilter = {
+  type?: "system" | "contract" | "diagnostic";
+  contractIds?: string[];
+  topics?: string[][];
+};
+
+export type ContractSubscriptionConfig = {
+  filters: ContractFilter[];
+};

--- a/packages/pulse-core/test/EventEngine.subscribeContract.test.ts
+++ b/packages/pulse-core/test/EventEngine.subscribeContract.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { EventEngine } from "../src/EventEngine.js";
-import type { ContractEmittedEvent, ContractInvokedEvent } from "../src/index.js";
+import type { ContractEmittedEvent, ContractInvokedEvent, ContractSubscriptionConfig } from "../src/index.js";
 
 function buildEngine(log?: any): {
   engine: EventEngine;
@@ -194,5 +194,124 @@ describe("EventEngine.awaitContractSubscriptionActive", () => {
     engine.notifyContractPolled("C4", ["whatever"]);
 
     await expect(p).resolves.toBeUndefined();
+  });
+});
+
+function makeEngine(): EventEngine {
+  return new EventEngine({ network: "testnet" });
+}
+
+describe("engine.subscribeContract(config)", () => {
+  it("returns a Watcher for a valid config", () => {
+    const engine = makeEngine();
+    const watcher = engine.subscribeContract({
+      filters: [{ contractIds: ["CA1234"] }],
+    });
+    expect(watcher).toBeDefined();
+    expect(typeof watcher.on).toBe("function");
+  });
+
+  it("returns the same Watcher instance for semantically equal configs", () => {
+    const engine = makeEngine();
+    const config: ContractSubscriptionConfig = {
+      filters: [{ contractIds: ["CA1234"] }],
+    };
+    const w1 = engine.subscribeContract(config);
+    const w2 = engine.subscribeContract({ filters: [{ contractIds: ["CA1234"] }] });
+    expect(w1).toBe(w2);
+  });
+
+  it("deduplicates regardless of contractIds order", () => {
+    const engine = makeEngine();
+    const w1 = engine.subscribeContract({ filters: [{ contractIds: ["CA", "CB"] }] });
+    const w2 = engine.subscribeContract({ filters: [{ contractIds: ["CB", "CA"] }] });
+    expect(w1).toBe(w2);
+  });
+
+  it("returns different Watchers for different filter shapes", () => {
+    const engine = makeEngine();
+    const w1 = engine.subscribeContract({ filters: [{ contractIds: ["CA"] }] });
+    const w2 = engine.subscribeContract({ filters: [{ contractIds: ["CB"] }] });
+    expect(w1).not.toBe(w2);
+  });
+
+  it("accepts an empty filters array", () => {
+    const engine = makeEngine();
+    expect(() => engine.subscribeContract({ filters: [] })).not.toThrow();
+  });
+
+  it("accepts exactly 5 filters", () => {
+    const engine = makeEngine();
+    const filters = Array.from({ length: 5 }, (_, i) => ({ contractIds: [`C${i}`] }));
+    expect(() => engine.subscribeContract({ filters })).not.toThrow();
+  });
+
+  it("throws synchronously when filters.length > 5", () => {
+    const engine = makeEngine();
+    const filters = Array.from({ length: 6 }, (_, i) => ({ contractIds: [`C${i}`] }));
+    expect(() => engine.subscribeContract({ filters })).toThrow(
+      /filters.*≤ 5/i
+    );
+  });
+
+  it("throws synchronously when a filter's contractIds.length > 5", () => {
+    const engine = makeEngine();
+    const contractIds = ["C1", "C2", "C3", "C4", "C5", "C6"];
+    expect(() =>
+      engine.subscribeContract({ filters: [{ contractIds }] })
+    ).toThrow(/contractIds.*≤ 5/i);
+  });
+
+  it("accepts a filter with exactly 5 contractIds", () => {
+    const engine = makeEngine();
+    const contractIds = ["C1", "C2", "C3", "C4", "C5"];
+    expect(() =>
+      engine.subscribeContract({ filters: [{ contractIds }] })
+    ).not.toThrow();
+  });
+
+  it("accepts all optional ContractFilter fields", () => {
+    const engine = makeEngine();
+    expect(() =>
+      engine.subscribeContract({
+        filters: [
+          {
+            type: "contract",
+            contractIds: ["CA1234"],
+            topics: [["transfer"], ["GABC"]],
+          },
+        ],
+      })
+    ).not.toThrow();
+  });
+
+  it("accepts type 'system'", () => {
+    const engine = makeEngine();
+    expect(() =>
+      engine.subscribeContract({ filters: [{ type: "system" }] })
+    ).not.toThrow();
+  });
+
+  it("accepts type 'diagnostic'", () => {
+    const engine = makeEngine();
+    expect(() =>
+      engine.subscribeContract({ filters: [{ type: "diagnostic" }] })
+    ).not.toThrow();
+  });
+
+  it("does not interfere with the legacy string-id subscribeContract", () => {
+    const engine = makeEngine();
+    const legacyWatcher = engine.subscribeContract("my-sub");
+    const configWatcher = engine.subscribeContract({ filters: [{ contractIds: ["CA"] }] });
+    expect(legacyWatcher).not.toBe(configWatcher);
+  });
+
+  it("stop() removes the watcher so a new call creates a fresh instance", () => {
+    const engine = makeEngine();
+    const config: ContractSubscriptionConfig = { filters: [{ contractIds: ["CA"] }] };
+    const w1 = engine.subscribeContract(config);
+    w1.stop();
+    const w2 = engine.subscribeContract(config);
+    expect(w1).not.toBe(w2);
   });
 });


### PR DESCRIPTION
Title: feat(pulse-core): add subscribeContract(config) overload with RPC filter shape
  
  Body:
  
  ## Summary
  
  Adds `engine.subscribeContract(config: ContractSubscriptionConfig)` as a new overload
  alongside the existing string-id API, completing the M1 Soroban event subscription
  milestone (150 pts).
  
  ## Changes
  
  **`packages/pulse-core/src/index.ts`**
  - `ContractFilter` — `{ type?: 'system'|'contract'|'diagnostic', contractIds?: string[],
  topics?: string[][] }`
  - `ContractSubscriptionConfig` — `{ filters: ContractFilter[] }`
  
  **`packages/pulse-core/src/EventEngine.ts`**
  - `contractConfigRegistry` — separate `Map<string, Watcher>` for config-based subscriptions
  - `stableFilterKey()` — sorts `contractIds` within each filter then JSON-serialises for
  order-independent dedup
  - `subscribeContract(config)` overload — validates at construction, deduplicates by stable key,
  returns existing watcher on repeated equal calls
  
  **`packages/pulse-core/test/EventEngine.subscribeContract.test.ts`** (new, 14 tests)
  
  ## Done criteria
  
  - [x] `engine.subscribeContract({ filters: [{ contractIds: ['CA…'] }] })` returns a Watcher
  - [x] Calling twice with semantically equal filters returns the same instance
  - [x] Throws synchronously when `filters.length > 5`
  - [x] Throws synchronously when any `filter.contractIds.length > 5`
  
  ## Testing
  
  pnpm --filter @orbital/pulse-core exec vitest run test/EventEngine.subscribeContract.test.ts
  
  closes #289 
  