### PR TITLE
 3.45 — Server-side fallback: render last-known event during SSR

### DIFF
--- a/packages/pulse-notify/src/index.ts
+++ b/packages/pulse-notify/src/index.ts
@@ -127,6 +127,24 @@ export function useStellarEvent<T extends NormalizedEvent = NormalizedEvent>(
 
 type PaymentEvent = Extract<NormalizedEvent, { type: "payment.received" }>;
 
+/**
+ * Converts a Stellar decimal amount string (e.g. "12.3456789") to stroops
+ * (1 XLM = 10,000,000 stroops) as a bigint.
+ *
+ * Uses integer arithmetic only — no parseFloat, no floating-point rounding.
+ * Returns null if the string is not a valid non-negative decimal number.
+ */
+function amountToStroop(amount: string): bigint | null {
+  if (!/^\d+(\.\d+)?$/.test(amount)) return null;
+  const [whole, frac = ""] = amount.split(".");
+  const fracPadded = frac.slice(0, 7).padEnd(7, "0");
+  try {
+    return BigInt(whole) * 10_000_000n + BigInt(fracPadded);
+  } catch {
+    return null;
+  }
+}
+
 export function useStellarPayment(
   serverUrl: string,
   address: string,
@@ -139,9 +157,7 @@ export function useStellarPayment(
     withCredentials: options?.withCredentials,
   });
   const amountStroop: bigint | null =
-    base.event?.amount != null
-      ? BigInt(Math.round(parseFloat(base.event.amount) * 10_000_000))
-      : null;
+    base.event?.amount != null ? amountToStroop(base.event.amount) : null;
   return { ...base, amountStroop };
 }
 


### PR DESCRIPTION
Closes #427  3.45 — Server-side fallback: render last-known event during SSR
…arithmetic

The remote implementation used BigInt(Math.round(parseFloat(amount) * 10_000_000)) which reintroduces floating-point precision loss for amounts like 0.0000001.

Replace with amountToStroop() that splits on the decimal point and pads the fractional part to exactly 7 digits before combining with BigInt safe for all amounts representable on the Stellar network.

## Linked issue

Closes #

## What changed and why

<!-- One paragraph. What does this PR do, and why is the change needed? -->

## Test plan

<!-- How did you verify this works? Check everything that applies. -->

- [ ] Existing tests pass (`pnpm test`)
- [ ] New tests added for new behaviour
- [ ] Typechecks pass (`pnpm -r typecheck`)
- [ ] Manually tested against testnet / mainnet (describe what you tested)

## Breaking changes

<!-- Does this change any public API? If yes, describe the migration path. -->

None / Yes (describe below)

## Notes for reviewers

<!-- Anything the reviewer should pay special attention to, or context that isn't obvious from the diff. -->
