### PR TITLE
3.42 — Suspense integration for first-event ready

### DIFF
--- a/apps/web/content/api/pulse-notify.md
+++ b/apps/web/content/api/pulse-notify.md
@@ -68,6 +68,54 @@ type EventState<T extends NormalizedEvent = NormalizedEvent> = {
 };
 ```
 
+## useStellarEventSuspense
+
+A [React Suspense](https://react.dev/reference/react/Suspense)-compatible hook. It throws a Promise until the first matching event arrives, so the nearest `<Suspense>` boundary renders its `fallback` until the component is ready to display real data.
+
+```tsx
+"use client";
+import { Suspense } from "react";
+import { useStellarEventSuspense } from "@orbital/pulse-notify";
+
+// The component never receives null — it is suspended until data arrives.
+function LiveBalance({ address }: { address: string }) {
+  const event = useStellarEventSuspense(
+    "https://events.example.com",
+    address,
+    { event: "payment.received" },
+  );
+  return <p>+{event.amount} {event.asset} from {event.from.slice(0, 8)}…</p>;
+}
+
+export default function Page() {
+  return (
+    <Suspense fallback={<p>Waiting for first event…</p>}>
+      <LiveBalance address="GABC..." />
+    </Suspense>
+  );
+}
+```
+
+Also accepts a single config object — same shape as `useStellarEvent`.
+
+### Return value
+
+Returns `T` (never `null`). The component is suspended until the first event arrives, so the return value is always a fully-populated event object.
+
+### Shared connection
+
+Uses the same connection pool as `useStellarEvent` — multiple hook instances with the same `(serverUrl, address)` arguments share one `EventSource`. The connection is released when the last instance unmounts.
+
+### Trade-offs
+
+| Consideration | Detail |
+|---|---|
+| **Invisible until ready** | The component renders nothing (fallback shows instead) until the first event arrives. For addresses that rarely receive events this can mean a long — or permanent — fallback. |
+| **No loading skeleton inside** | You cannot render partial UI inside the suspended component. Put loading UI in the `fallback` prop of `<Suspense>` instead. |
+| **Prefer `useStellarEvent` when…** | You want to show a "no events yet" state, a loading indicator inside the component, or you need `connected` / `error` status. |
+| **Client-only** | `EventSource` is not available in Node.js. Mark consuming components with `"use client"` in Next.js App Router. |
+| **Error boundaries** | Pair with an `<ErrorBoundary>` to handle connection failures gracefully — the hook does not surface errors through its return value. |
+
 ## useStellarPayment
 
 Convenience hook — only updates on `payment.received` events. Equivalent to `useStellarEvent(serverUrl, address, { event: "payment.received" })`.

--- a/packages/pulse-notify/src/useStellarEventSuspense.ts
+++ b/packages/pulse-notify/src/useStellarEventSuspense.ts
@@ -1,111 +1,71 @@
 import { useEffect, useRef } from "react";
 import type { NormalizedEvent } from "@orbital/pulse-core";
+import { acquireEventConnection } from "./connectionPool.js";
 import type { UseEventConfig } from "./index.js";
 
 // ---------------------------------------------------------------------------
-// Suspense-compatible cache
+// Suspense resource cache
 //
 // React Suspense works by catching a thrown Promise (a "thenable"). When the
 // promise resolves, React re-renders the suspended subtree. We keep one cache
-// entry per (serverUrl + address + eventKey) tuple so that:
+// entry per (serverUrl + address + eventKey + token) tuple so that:
 //
-//   1. The first render throws the pending promise → Suspense shows fallback.
-//   2. When the first event arrives the promise resolves → React re-renders.
-//   3. Subsequent renders return the cached event synchronously.
-//   4. The cache entry is removed when the last subscriber unmounts.
+//   1. First render → entry is "pending" → hook throws the promise →
+//      Suspense shows the fallback.
+//   2. First matching event arrives → promise resolves → React re-renders.
+//   3. Subsequent renders → entry is "ready" → hook returns the event
+//      synchronously (never null).
+//   4. Last consumer unmounts → connection is released via the pool.
+//
+// The pool's own ref-counting (acquireEventConnection / unsubscribe) handles
+// the underlying EventSource lifetime. The Suspense cache only tracks the
+// promise/event state and its own subscriber count.
 // ---------------------------------------------------------------------------
 
-type CacheStatus =
+type ResourceStatus<T extends NormalizedEvent> =
   | { status: "pending"; promise: Promise<void>; resolve: () => void }
-  | { status: "ready"; event: NormalizedEvent };
+  | { status: "ready"; event: T };
 
-type CacheEntry = {
-  data: CacheStatus;
-  /** Number of hook instances currently subscribed to this cache key. */
+type ResourceEntry<T extends NormalizedEvent> = {
+  status: ResourceStatus<T>;
+  /** Number of hook instances currently using this resource. */
   refCount: number;
-  /** The EventSource opened for this cache key. */
-  source: EventSource;
-  /** Latest event stored so re-renders after the first one are synchronous. */
-  latestEvent: NormalizedEvent | null;
 };
 
-const cache = new Map<string, CacheEntry>();
+// Keyed by the same tuple used by the connection pool.
+const resourceCache = new Map<string, ResourceEntry<NormalizedEvent>>();
 
-function buildCacheKey(
+function buildResourceKey(
   serverUrl: string,
   address: string,
   eventKey: string,
   token: string | undefined
 ): string {
-  return `${serverUrl}|${address}|${eventKey}|${token ?? ""}`;
+  return JSON.stringify([serverUrl, address, eventKey, token ?? ""]);
 }
 
-function openEntry(
+function getOrCreateResource<T extends NormalizedEvent>(
   serverUrl: string,
   address: string,
   eventType: string | string[],
   token: string | undefined,
-  cacheKey: string
-): CacheEntry {
-  const base = `${serverUrl}/events/${address}`;
-  const url = token ? `${base}?token=${encodeURIComponent(token)}` : base;
-
-  const source = new EventSource(url);
+  resourceKey: string
+): ResourceEntry<T> {
+  const existing = resourceCache.get(resourceKey);
+  if (existing) return existing as ResourceEntry<T>;
 
   let resolve!: () => void;
   const promise = new Promise<void>((res) => {
     resolve = res;
   });
 
-  const entry: CacheEntry = {
-    data: { status: "pending", promise, resolve },
+  const entry: ResourceEntry<NormalizedEvent> = {
+    status: { status: "pending", promise, resolve },
     refCount: 0,
-    source,
-    latestEvent: null,
   };
 
-  source.onmessage = (e) => {
-    try {
-      const incoming: NormalizedEvent = JSON.parse(e.data);
-
-      const allowed =
-        eventType === "*" ||
-        (Array.isArray(eventType)
-          ? eventType.includes(incoming.type)
-          : incoming.type === eventType);
-
-      if (!allowed) return;
-
-      entry.latestEvent = incoming;
-
-      if (entry.data.status === "pending") {
-        const { resolve: res } = entry.data;
-        entry.data = { status: "ready", event: incoming };
-        res();
-      } else {
-        // Already resolved — just update the stored event so the next render
-        // picks up the latest value synchronously.
-        entry.data = { status: "ready", event: incoming };
-      }
-    } catch {
-      // Malformed message — ignore; the component stays suspended or keeps
-      // the last good event.
-    }
-  };
-
-  cache.set(cacheKey, entry);
-  return entry;
-}
-
-function releaseEntry(cacheKey: string): void {
-  const entry = cache.get(cacheKey);
-  if (!entry) return;
-
-  entry.refCount -= 1;
-  if (entry.refCount <= 0) {
-    entry.source.close();
-    cache.delete(cacheKey);
-  }
+  resourceCache.set(resourceKey, entry);
+  return entry as ResourceEntry<T>;
 }
 
 // ---------------------------------------------------------------------------
@@ -113,19 +73,19 @@ function releaseEntry(cacheKey: string): void {
 // ---------------------------------------------------------------------------
 
 /**
- * A Suspense-compatible hook that throws a Promise until the first matching
- * event arrives for the given Stellar address.
- *
- * **Usage**
+ * A [React Suspense](https://react.dev/reference/react/Suspense)-compatible
+ * hook that throws a Promise until the first matching event arrives for the
+ * given Stellar address.
  *
  * Wrap the consuming component in a `<Suspense>` boundary:
  *
  * ```tsx
+ * "use client";
  * import { Suspense } from "react";
  * import { useStellarEventSuspense } from "@orbital/pulse-notify";
  *
  * function LiveBalance({ address }: { address: string }) {
- *   // Throws until the first event — never returns null.
+ *   // Never returns null — component is suspended until data arrives.
  *   const event = useStellarEventSuspense(
  *     "https://events.example.com",
  *     address,
@@ -143,23 +103,26 @@ function releaseEntry(cacheKey: string): void {
  * }
  * ```
  *
+ * Also accepts a single config object — same shape as `useStellarEvent`.
+ *
  * **Trade-offs**
  *
  * - The component is invisible until the first event arrives. For addresses
- *   that rarely receive events this can mean a long (or permanent) fallback.
- *   Prefer {@link useStellarEvent} when you want to render a loading skeleton
- *   or a "no events yet" state instead.
- * - Each unique (serverUrl, address, eventKey) tuple opens one `EventSource`
- *   connection. Multiple hook instances with the same arguments share a single
- *   connection via an internal cache.
- * - The hook is client-only — `EventSource` is not available in Node.js.
- *   Mark consuming components with `"use client"` in Next.js App Router.
+ *   that rarely receive events this can mean a long — or permanent — fallback.
+ *   Prefer `useStellarEvent` when you want to render a loading skeleton or a
+ *   "no events yet" state instead.
+ * - You cannot render partial UI inside the suspended component; put loading
+ *   UI in the `fallback` prop of `<Suspense>`.
+ * - Pair with an `<ErrorBoundary>` to handle connection failures gracefully.
+ * - Client-only: `EventSource` is not available in Node.js. Mark consuming
+ *   components with `"use client"` in Next.js App Router.
+ * - Multiple hook instances with the same arguments share one `EventSource`
+ *   connection via the connection pool.
  *
  * @param serverUrl - Base URL of your Orbital-powered backend.
  * @param address   - Stellar address to watch.
  * @param options   - Optional event type filter and API token.
- * @returns The most recent matching {@link NormalizedEvent}. Never `null` —
- *          the component is suspended until the first event arrives.
+ * @returns The most recent matching event. Never `null`.
  */
 export function useStellarEventSuspense<
   T extends NormalizedEvent = NormalizedEvent,
@@ -169,9 +132,7 @@ export function useStellarEventSuspense<
   options?: Pick<UseEventConfig, "event" | "token">
 ): T;
 
-/**
- * Overload that accepts a single config object.
- */
+/** Overload that accepts a single config object. */
 export function useStellarEventSuspense<
   T extends NormalizedEvent = NormalizedEvent,
 >(config: UseEventConfig): T;
@@ -195,54 +156,104 @@ export function useStellarEventSuspense<
   const token =
     typeof configOrUrl === "string" ? options?.token : configOrUrl.token;
 
-  // Stable string key for the dep array and cache lookup.
+  // Stable string key — same strategy as useStellarEvent.
   const eventKey = Array.isArray(eventType)
     ? [...eventType].sort().join(",")
     : eventType;
 
-  const cacheKey = buildCacheKey(serverUrl, addr, eventKey, token);
+  const resourceKey = buildResourceKey(serverUrl, addr, eventKey, token);
 
-  // We need a ref to track the cache key used during the current render so
-  // the cleanup effect can release the correct entry even if the key changes.
-  const cacheKeyRef = useRef<string>(cacheKey);
+  // Acquire or create the resource entry synchronously during render so the
+  // thrown promise is available on the very first render pass.
+  const entry = getOrCreateResource<T>(
+    serverUrl,
+    addr,
+    eventType,
+    token,
+    resourceKey
+  );
 
-  // Acquire / create the cache entry synchronously during render so the
-  // thrown promise is available on the very first render.
-  let entry = cache.get(cacheKey);
-  if (!entry) {
-    entry = openEntry(serverUrl, addr, eventType, token, cacheKey);
-  }
+  // Track the resource key this instance is currently subscribed to so the
+  // effect cleanup can release the right entry even if args change mid-life.
+  const resourceKeyRef = useRef<string | null>(null);
 
-  // Track whether this render is the first time this hook instance has seen
-  // this particular cache key so we only increment refCount once per mount.
-  const mountedKeyRef = useRef<string | null>(null);
-  if (mountedKeyRef.current !== cacheKey) {
+  // Increment refCount once per (instance × resourceKey). We do this during
+  // render (not inside useEffect) so the count is correct before the first
+  // paint — important when StrictMode double-invokes render.
+  if (resourceKeyRef.current !== resourceKey) {
     entry.refCount += 1;
-    mountedKeyRef.current = cacheKey;
+    resourceKeyRef.current = resourceKey;
   }
 
   useEffect(() => {
-    const currentKey = cacheKey;
-    cacheKeyRef.current = currentKey;
+    const currentKey = resourceKey;
+    const currentEntry = resourceCache.get(currentKey) as
+      | ResourceEntry<T>
+      | undefined;
 
-    // If the key changed between renders (serverUrl / address / eventKey
-    // changed), the old entry was already released by the previous effect
-    // cleanup. The new entry's refCount was incremented during render above.
+    if (!currentEntry) return;
+
+    // Subscribe to the shared connection pool. The pool manages the actual
+    // EventSource lifetime; we only need to update the resource status here.
+    const connection = acquireEventConnection(
+      { serverUrl, address: addr, token },
+      {
+        onOpen: () => {
+          // Connection open — nothing to do for Suspense state.
+        },
+        onEvent: (incoming) => {
+          const allowed =
+            eventType === "*" ||
+            (Array.isArray(eventType)
+              ? eventType.includes(incoming.type)
+              : incoming.type === eventType);
+
+          if (!allowed) return;
+
+          if (currentEntry.status.status === "pending") {
+            const { resolve } = currentEntry.status;
+            currentEntry.status = { status: "ready", event: incoming as T };
+            resolve();
+          } else {
+            // Already resolved — update the stored event for subsequent renders.
+            currentEntry.status = { status: "ready", event: incoming as T };
+          }
+        },
+        onParseError: () => {
+          // Malformed message — stay suspended or keep the last good event.
+        },
+        onError: () => {
+          // Connection error — stay suspended; browser will reconnect.
+        },
+      }
+    );
+
+    // If the connection was already open when we subscribed (e.g. shared pool
+    // entry), there's nothing extra to do — we wait for the next event.
 
     return () => {
-      releaseEntry(currentKey);
-      // Reset so a future remount with the same key increments refCount again.
-      mountedKeyRef.current = null;
+      connection.unsubscribe();
+
+      // Release this instance's hold on the resource entry.
+      const entryToRelease = resourceCache.get(currentKey);
+      if (entryToRelease) {
+        entryToRelease.refCount -= 1;
+        if (entryToRelease.refCount <= 0) {
+          resourceCache.delete(currentKey);
+        }
+      }
+      resourceKeyRef.current = null;
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [cacheKey]);
+  }, [resourceKey]);
 
   // --- Suspense protocol ---
-  // If the entry is still pending, throw the promise. React will catch it,
-  // show the nearest Suspense fallback, and re-render when it resolves.
-  if (entry.data.status === "pending") {
-    throw entry.data.promise;
+  // Throw the pending promise so React shows the nearest Suspense fallback.
+  // When the promise resolves React re-renders and we fall through to the
+  // return below.
+  if (entry.status.status === "pending") {
+    throw entry.status.promise;
   }
 
-  return entry.data.event as T;
+  return entry.status.event as T;
 }


### PR DESCRIPTION
Closes #424  3.42 — Suspense integration for first-event ready
Adds a Suspense-compatible hook that throws a Promise until the first matching event arrives, allowing React Suspense boundaries to render a fallback until the component has real data.

- New: packages/pulse-notify/src/useStellarEventSuspense.ts
  - Throws a pending Promise on first render; resolves on first event
  - Built on acquireEventConnection  shares the pool with useStellarEvent
  - Module-level resource cache keyed on (serverUrl|address|eventKey|token)
  - Returns T (never null); component is suspended until first event
  - Supports both positional-args and single config-object call signatures
  - Cleans up pool subscription and cache entry on unmount

- Updated: packages/pulse-notify/src/index.ts
  - Re-exports useStellarEventSuspense

- Updated: apps/web/content/api/pulse-notify.md
  - Documents useStellarEventSuspense with usage example and trade-offs table

## Linked issue

Closes #

## What changed and why

<!-- One paragraph. What does this PR do, and why is the change needed? -->

## Test plan

<!-- How did you verify this works? Check everything that applies. -->

- [ ] Existing tests pass (`pnpm test`)
- [ ] New tests added for new behaviour
- [ ] Typechecks pass (`pnpm -r typecheck`)
- [ ] Manually tested against testnet / mainnet (describe what you tested)

## Breaking changes

<!-- Does this change any public API? If yes, describe the migration path. -->

None / Yes (describe below)

## Notes for reviewers

<!-- Anything the reviewer should pay special attention to, or context that isn't obvious from the diff. -->
