### PR TITLE
docs(pulse-core): document webhook.failed and webhook.dropped watcher…

### DIFF
--- a/packages/pulse-core/README.md
+++ b/packages/pulse-core/README.md
@@ -92,6 +92,12 @@ Normalized asset strings follow one rule across every event payload:
 | `engine.reconnected` | `WatcherNotification` | Reconnect succeeded |
 | `engine.rate_limited` | `WatcherNotification` | The engine was rate limited and will retry after the delay |
 | `engine.stopped` | `WatcherNotification` | `engine.stop()` was called; emitted before watchers are torn down |
+| `webhook.failed` | `NormalizedEvent` | All delivery attempts to a webhook URL have failed (emitted by `pulse-webhooks`) |
+| `webhook.dropped` | `NormalizedEvent` | A pending webhook retry is dropped because the concurrency cap is reached (emitted by `pulse-webhooks`) |
+
+> [!NOTE]
+> Webhook events (`webhook.failed` and `webhook.dropped`) are emitted on the `Watcher` by the [`@orbital/pulse-webhooks`](../pulse-webhooks/README.md) package when attached. For these events, the `NormalizedEvent`'s `raw` field is populated with specialized metadata objects (`WebhookFailureRaw` and `WebhookDroppedRaw`, respectively). See the [Failure events section of `@orbital/pulse-webhooks`](../pulse-webhooks/README.md#failure-events) for detailed documentation and payload schemas.
+
 
 ### `NormalizedEvent` shape
 


### PR DESCRIPTION
## Linked issue

Closes #311

## What changed and why

Updated the Watcher events table in `packages/pulse-core/README.md` to document the `webhook.failed` and `webhook.dropped` events emitted by `pulse-webhooks`. Added the corresponding payload types and included a cross-reference to the relevant section of the pulse-webhooks documentation. This ensures that consumers reading only the pulse-core README can discover and understand all watcher events without needing to separately inspect pulse-webhooks.

## Test plan

* [ ] Existing tests pass (`pnpm test`)
* [ ] New tests added for new behaviour
* [ ] Typechecks pass (`pnpm -r typecheck`)
* [x] Manually verified README updates, event names, payload types, and documentation links

## Breaking changes

None

## Notes for reviewers

This is a documentation-only change. The update brings the pulse-core Watcher events table in sync with the events already emitted and documented in pulse-webhooks. No runtime behavior or public API was modified.
