### PR TITLE
Refactor/add engine cursor expired

### DIFF
--- a/apps/web/content/api/pulse-core.md
+++ b/apps/web/content/api/pulse-core.md
@@ -116,6 +116,11 @@ In addition to event payloads, watchers receive lifecycle notifications:
 | `engine.reconnected` | Reconnect succeeded |
 | `engine.rate_limited` | Horizon returned HTTP 429; engine will retry after the delay |
 | `engine.stopped` | `engine.stop()` was called |
+| `engine.cursor_expired` | The stream cursor has expired or is no longer valid, requiring a reset |
+
+For `engine.cursor_expired` notifications, the payload includes extra fields:
+- `lostCursor?: string` — The value of the expired or lost cursor.
+- `source?: "horizon" | "soroban"` — The subscription engine source where the expiry occurred.
 
 ## NormalizedEvent shape
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -243,6 +243,11 @@ Every watcher receives lifecycle notifications alongside operation events:
 | `engine.reconnected` | Reconnect succeeded on attempt `N` |
 | `engine.rate_limited` | 429 received; reconnect deferred by `delayMs` |
 | `engine.stopped` | `engine.stop()` was called explicitly |
+| `engine.cursor_expired` | Stream cursor expired (Horizon or Soroban) |
+
+For `engine.cursor_expired` notifications, the payload includes:
+- `lostCursor?: string` — The value of the expired or lost cursor.
+- `source?: "horizon" | "soroban"` — The subscription engine source where the expiry occurred.
 
 Consumers can subscribe to these via `watcher.on("engine.reconnecting", …)`
 to surface UI banners or write structured logs.

--- a/packages/pulse-core/README.md
+++ b/packages/pulse-core/README.md
@@ -92,11 +92,17 @@ Normalized asset strings follow one rule across every event payload:
 | `engine.reconnected` | `WatcherNotification` | Reconnect succeeded |
 | `engine.rate_limited` | `WatcherNotification` | The engine was rate limited and will retry after the delay |
 | `engine.stopped` | `WatcherNotification` | `engine.stop()` was called; emitted before watchers are torn down |
+| `engine.cursor_expired` | `WatcherNotification` | The ingestion stream cursor has expired or is no longer valid, requiring a reset |
 | `webhook.failed` | `NormalizedEvent` | All delivery attempts to a webhook URL have failed (emitted by `pulse-webhooks`) |
 | `webhook.dropped` | `NormalizedEvent` | A pending webhook retry is dropped because the concurrency cap is reached (emitted by `pulse-webhooks`) |
 
 > [!NOTE]
 > Webhook events (`webhook.failed` and `webhook.dropped`) are emitted on the `Watcher` by the [`@orbital/pulse-webhooks`](../pulse-webhooks/README.md) package when attached. For these events, the `NormalizedEvent`'s `raw` field is populated with specialized metadata objects (`WebhookFailureRaw` and `WebhookDroppedRaw`, respectively). See the [Failure events section of `@orbital/pulse-webhooks`](../pulse-webhooks/README.md#failure-events) for detailed documentation and payload schemas.
+
+> [!NOTE]
+> For `engine.cursor_expired` notifications, the `WatcherNotification` payload includes additional fields:
+> - `lostCursor`: `string` — The value of the cursor that expired.
+> - `source`: `"horizon" | "soroban"` — The subscription engine source where the expiry occurred.
 
 
 ### `NormalizedEvent` shape

--- a/packages/pulse-core/src/index.ts
+++ b/packages/pulse-core/src/index.ts
@@ -95,7 +95,8 @@ export type WatcherNotificationType =
   | "engine.reconnected"
   | "engine.rate_limited"
   | "engine.stopped"
-  | "engine.cursor_store_unhealthy";
+  | "engine.cursor_store_unhealthy"
+  | "engine.cursor_expired";
 
 export type OfferEventType =
   | "offer.created"
@@ -368,6 +369,10 @@ export type WatcherNotification = {
   delayMs?: number;
   /** ISO 8601 timestamp of when this notification was emitted. */
   emittedAt: string;
+  /** The cursor value that was expired or lost, if applicable. */
+  lostCursor?: string;
+  /** The source engine that encountered the expired cursor. */
+  source?: "horizon" | "soroban";
 };
 
 /**


### PR DESCRIPTION
## Linked issue

Closes #310 

## What changed and why

Updated the public lifecycle notification surface to include `engine.cursor_expired`. Added `'engine.cursor_expired'` to the `WatcherNotificationType` union and extended `WatcherNotification` with the optional `lostCursor` and `source` fields to reflect the notification payload. Also updated the Watcher events table in `packages/pulse-core/README.md` so the documentation accurately reflects the exported notification types. This ensures consumers can discover and type against the full set of supported watcher lifecycle events.

## Test plan

* [ ] Existing tests pass (`pnpm test`)
* [ ] New tests added for new behaviour
* [x] Typechecks pass (`pnpm -r typecheck`)
* [ ] Manually tested against testnet / mainnet (describe what you tested)

## Breaking changes

None

## Notes for reviewers

This change refines the public type surface and documentation to align with the existing `engine.cursor_expired` notification introduced previously. No runtime behavior was modified; the update is limited to exported types and README documentation.
