### PR TITLE
feat(abi-registry): M2 — ContractSpec types, JSON schema, and well-known specs

### DIFF
--- a/packages/abi-registry/schema/spec.schema.json
+++ b/packages/abi-registry/schema/spec.schema.json
@@ -1,0 +1,245 @@
+{
+  "title": "OrbitalContractSpec",
+  "description": "JSON Schema for a complete Orbital ABI Registry contract spec (packages/abi-registry/src/spec.ts).",
+  "type": "object",
+  "required": ["version", "contractId", "name", "functions", "events"],
+  "additionalProperties": false,
+  "properties": {
+    "version": {
+      "type": "string",
+      "description": "Spec format version in MAJOR.MINOR.PATCH semver.",
+      "pattern": "^\\d+\\.\\d+\\.\\d+$"
+    },
+    "contractId": {
+      "type": "string",
+      "description": "Canonical mainnet Soroban contract address (C-prefixed strkey, 56 characters).",
+      "pattern": "^C[A-Z2-7]{55}$"
+    },
+    "name": {
+      "type": "string",
+      "description": "Human-readable contract name.",
+      "minLength": 1,
+      "maxLength": 100
+    },
+    "description": {
+      "type": "string",
+      "description": "Short description of the contract's purpose.",
+      "maxLength": 500
+    },
+    "source": {
+      "type": "string",
+      "description": "URL or reference identifying where the interface definition was obtained.",
+      "minLength": 1,
+      "maxLength": 2048
+    },
+    "functions": {
+      "type": "array",
+      "description": "All callable functions exposed by the contract.",
+      "items": { "$ref": "#/$defs/FunctionSpec" }
+    },
+    "events": {
+      "type": "array",
+      "description": "All events the contract may emit.",
+      "items": { "$ref": "#/$defs/EventSpec" }
+    },
+    "types": {
+      "type": "array",
+      "description": "User-defined types (structs, enums) referenced by functions or events.",
+      "items": { "$ref": "#/$defs/TypeSpec" }
+    }
+  },
+  "$defs": {
+    "TypeSpec": {
+      "description": "A fully-resolved Soroban type — primitive, composite, or user-defined.",
+      "oneOf": [
+        {
+          "description": "Primitive type.",
+          "type": "object",
+          "required": ["type"],
+          "additionalProperties": false,
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "bool", "u32", "i32", "u64", "i64",
+                "u128", "i128", "u256", "i256",
+                "bytes", "bytes_n", "string", "symbol",
+                "address", "void"
+              ]
+            },
+            "len": {
+              "type": "integer",
+              "minimum": 1,
+              "description": "Fixed byte length — only valid when type is 'bytes_n'."
+            }
+          }
+        },
+        {
+          "description": "Option<T> — nullable wrapper.",
+          "type": "object",
+          "required": ["type", "inner"],
+          "additionalProperties": false,
+          "properties": {
+            "type": { "type": "string", "const": "option" },
+            "inner": { "$ref": "#/$defs/TypeSpec" }
+          }
+        },
+        {
+          "description": "Vec<T> — homogeneous list.",
+          "type": "object",
+          "required": ["type", "item"],
+          "additionalProperties": false,
+          "properties": {
+            "type": { "type": "string", "const": "vec" },
+            "item": { "$ref": "#/$defs/TypeSpec" }
+          }
+        },
+        {
+          "description": "Map<K, V> — key-value collection.",
+          "type": "object",
+          "required": ["type", "key", "value"],
+          "additionalProperties": false,
+          "properties": {
+            "type":  { "type": "string", "const": "map" },
+            "key":   { "$ref": "#/$defs/TypeSpec" },
+            "value": { "$ref": "#/$defs/TypeSpec" }
+          }
+        },
+        {
+          "description": "Tuple — fixed-length heterogeneous list.",
+          "type": "object",
+          "required": ["type", "fields"],
+          "additionalProperties": false,
+          "properties": {
+            "type":   { "type": "string", "const": "tuple" },
+            "fields": {
+              "type": "array",
+              "items": { "$ref": "#/$defs/TypeSpec" },
+              "minItems": 1
+            }
+          }
+        },
+        {
+          "description": "Named struct with typed fields.",
+          "type": "object",
+          "required": ["type", "name", "fields"],
+          "additionalProperties": false,
+          "properties": {
+            "type":   { "type": "string", "const": "struct" },
+            "name":   { "type": "string", "minLength": 1 },
+            "fields": {
+              "type": "array",
+              "items": { "$ref": "#/$defs/StructField" },
+              "minItems": 1
+            }
+          }
+        },
+        {
+          "description": "Named enum with integer-discriminated variants.",
+          "type": "object",
+          "required": ["type", "name", "variants"],
+          "additionalProperties": false,
+          "properties": {
+            "type":     { "type": "string", "const": "enum" },
+            "name":     { "type": "string", "minLength": 1 },
+            "variants": {
+              "type": "array",
+              "items": { "$ref": "#/$defs/EnumVariant" },
+              "minItems": 1
+            }
+          }
+        },
+        {
+          "description": "Result<Ok, Err> — success/failure wrapper.",
+          "type": "object",
+          "required": ["type", "ok", "err"],
+          "additionalProperties": false,
+          "properties": {
+            "type": { "type": "string", "const": "result" },
+            "ok":   { "$ref": "#/$defs/TypeSpec" },
+            "err":  { "$ref": "#/$defs/TypeSpec" }
+          }
+        },
+        {
+          "description": "Reference to a user-defined type by name.",
+          "type": "object",
+          "required": ["type", "name"],
+          "additionalProperties": false,
+          "properties": {
+            "type": { "type": "string", "const": "custom" },
+            "name": { "type": "string", "minLength": 1 }
+          }
+        }
+      ]
+    },
+    "StructField": {
+      "type": "object",
+      "required": ["name", "type"],
+      "additionalProperties": false,
+      "properties": {
+        "name": { "type": "string", "minLength": 1 },
+        "type": { "$ref": "#/$defs/TypeSpec" },
+        "doc":  { "type": "string" }
+      }
+    },
+    "EnumVariant": {
+      "type": "object",
+      "required": ["name", "discriminant"],
+      "additionalProperties": false,
+      "properties": {
+        "name":          { "type": "string", "minLength": 1 },
+        "discriminant":  { "type": "integer", "minimum": 0 },
+        "value":         { "$ref": "#/$defs/TypeSpec" },
+        "doc":           { "type": "string" }
+      }
+    },
+    "ParameterSpec": {
+      "type": "object",
+      "required": ["name", "type"],
+      "additionalProperties": false,
+      "properties": {
+        "name": { "type": "string", "minLength": 1 },
+        "type": { "$ref": "#/$defs/TypeSpec" },
+        "doc":  { "type": "string" }
+      }
+    },
+    "FunctionSpec": {
+      "type": "object",
+      "required": ["name", "params", "returns"],
+      "additionalProperties": false,
+      "properties": {
+        "name":    { "type": "string", "minLength": 1 },
+        "params":  {
+          "type": "array",
+          "items": { "$ref": "#/$defs/ParameterSpec" }
+        },
+        "returns": { "$ref": "#/$defs/TypeSpec" },
+        "doc":     { "type": "string" }
+      }
+    },
+    "TopicSpec": {
+      "type": "object",
+      "required": ["index", "type"],
+      "additionalProperties": false,
+      "properties": {
+        "index": { "type": "integer", "minimum": 0 },
+        "type":  { "$ref": "#/$defs/TypeSpec" },
+        "doc":   { "type": "string" }
+      }
+    },
+    "EventSpec": {
+      "type": "object",
+      "required": ["name", "topics", "data"],
+      "additionalProperties": false,
+      "properties": {
+        "name":   { "type": "string", "minLength": 1 },
+        "topics": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/TopicSpec" }
+        },
+        "data":   { "$ref": "#/$defs/TypeSpec" },
+        "doc":    { "type": "string" }
+      }
+    }
+  }
+}

--- a/packages/abi-registry/src/AbiRegistryClient.ts
+++ b/packages/abi-registry/src/AbiRegistryClient.ts
@@ -1,11 +1,11 @@
 import { LruCache } from "./LruCache.js";
-import type { AbiRegistryClientConfig, ContractSpec } from "./types.js";
+import type { AbiRegistryClientConfig, RawContractEntry } from "./types.js";
 
 const DEFAULT_MAX_CACHE_SIZE = 512;
 
 export class AbiRegistryClient {
   private readonly baseUrl: string;
-  private readonly cache: LruCache<string, ContractSpec | null>;
+  private readonly cache: LruCache<string, RawContractEntry | null>;
 
   constructor(config: AbiRegistryClientConfig) {
     this.baseUrl = config.baseUrl.replace(/\/$/, "");
@@ -13,7 +13,7 @@ export class AbiRegistryClient {
   }
 
   /** Fetch a single contract spec (cached). */
-  async getSpec(contractId: string): Promise<ContractSpec | null> {
+  async getSpec(contractId: string): Promise<RawContractEntry | null> {
     const results = await this.getSpecs([contractId]);
     return results[contractId] ?? null;
   }
@@ -26,8 +26,8 @@ export class AbiRegistryClient {
    */
   async getSpecs(
     contractIds: string[]
-  ): Promise<Record<string, ContractSpec | null>> {
-    const result: Record<string, ContractSpec | null> = {};
+  ): Promise<Record<string, RawContractEntry | null>> {
+    const result: Record<string, RawContractEntry | null> = {};
     const uncached: string[] = [];
 
     for (const id of contractIds) {
@@ -56,7 +56,7 @@ export class AbiRegistryClient {
    */
   private async fetchBatch(
     contractIds: string[]
-  ): Promise<Record<string, ContractSpec | null>> {
+  ): Promise<Record<string, RawContractEntry | null>> {
     const response = await fetch(`${this.baseUrl}/specs`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
@@ -69,6 +69,6 @@ export class AbiRegistryClient {
       );
     }
 
-    return response.json() as Promise<Record<string, ContractSpec | null>>;
+    return response.json() as Promise<Record<string, RawContractEntry | null>>;
   }
 }

--- a/packages/abi-registry/src/index.ts
+++ b/packages/abi-registry/src/index.ts
@@ -2,7 +2,7 @@ export { AbiRegistryClient } from "./AbiRegistryClient.js";
 
 export type {
   AbiRegistryClientConfig,
-  ContractSpec,
+  RawContractEntry,
 } from "./types.js";
 
 export type {
@@ -11,3 +11,15 @@ export type {
 } from "./RegistryPublisher.js";
 
 export { LocalFilePublisher } from "./RegistryPublisher.js";
+
+export type {
+  PrimitiveSorobanType,
+  TypeSpec,
+  StructField,
+  EnumVariant,
+  ParameterSpec,
+  FunctionSpec,
+  TopicSpec,
+  EventSpec,
+  ContractSpec,
+} from "./spec.js";

--- a/packages/abi-registry/src/spec.ts
+++ b/packages/abi-registry/src/spec.ts
@@ -1,0 +1,162 @@
+/**
+ * spec.ts — Rich typed shape for Soroban contract ABI specs.
+ *
+ * Covers every primitive and composite Soroban XDR type, plus the full
+ * function and event surface of a contract. Designed to be serialisable
+ * to/from JSON and validatable against schema/spec.schema.json.
+ */
+
+// ---------------------------------------------------------------------------
+// Primitive Soroban XDR types
+// ---------------------------------------------------------------------------
+
+/**
+ * All primitive Soroban value types as string literals.
+ * Matches the type names used in the Stellar SDK's ScVal / XDR layer.
+ */
+export type PrimitiveSorobanType =
+  | "bool"
+  | "u32"
+  | "i32"
+  | "u64"
+  | "i64"
+  | "u128"
+  | "i128"
+  | "u256"
+  | "i256"
+  | "bytes"
+  | "bytes_n"   // fixed-length byte array; length carried in TypeSpec.len
+  | "string"
+  | "symbol"
+  | "address"
+  | "void";
+
+// ---------------------------------------------------------------------------
+// Composite / container types
+// ---------------------------------------------------------------------------
+
+/**
+ * A fully-resolved Soroban type, including composite and user-defined forms.
+ *
+ * @example Primitive:   { type: "i128" }
+ * @example Option:      { type: "option", inner: { type: "address" } }
+ * @example Vec:         { type: "vec",    item:  { type: "u64" } }
+ * @example Map:         { type: "map",    key:   { type: "string" }, value: { type: "i128" } }
+ * @example Tuple:       { type: "tuple",  fields: [{ type: "address" }, { type: "u32" }] }
+ * @example Struct:      { type: "struct", name: "Transfer", fields: [{ name: "from", type: { type: "address" } }] }
+ * @example Enum:        { type: "enum",   name: "Status",   variants: [{ name: "Active", discriminant: 0 }] }
+ * @example Result:      { type: "result", ok: { type: "u32" }, err: { type: "string" } }
+ * @example Custom:      { type: "custom", name: "MyType" }
+ */
+export type TypeSpec =
+  | { type: PrimitiveSorobanType; len?: number }
+  | { type: "option"; inner: TypeSpec }
+  | { type: "vec";    item:  TypeSpec }
+  | { type: "map";    key:   TypeSpec; value: TypeSpec }
+  | { type: "tuple";  fields: TypeSpec[] }
+  | { type: "struct"; name: string; fields: StructField[] }
+  | { type: "enum";   name: string; variants: EnumVariant[] }
+  | { type: "result"; ok: TypeSpec; err: TypeSpec }
+  | { type: "custom"; name: string };
+
+/** A named field inside a struct type. */
+export type StructField = {
+  name: string;
+  type: TypeSpec;
+  doc?: string;
+};
+
+/** A variant inside an enum type. */
+export type EnumVariant = {
+  name: string;
+  /** Integer discriminant value (0-based by default). */
+  discriminant: number;
+  /** Optional associated value type for tuple-style enum variants. */
+  value?: TypeSpec;
+  doc?: string;
+};
+
+// ---------------------------------------------------------------------------
+// Function spec
+// ---------------------------------------------------------------------------
+
+/** A single input parameter of a contract function. */
+export type ParameterSpec = {
+  name: string;
+  type: TypeSpec;
+  doc?: string;
+};
+
+/**
+ * Full description of one callable function on a Soroban contract.
+ */
+export type FunctionSpec = {
+  /** Function name as it appears in the contract WASM. */
+  name: string;
+  /** Ordered list of input parameters. */
+  params: ParameterSpec[];
+  /**
+   * Return type of the function.
+   * Use `{ type: "void" }` for functions that return nothing.
+   */
+  returns: TypeSpec;
+  doc?: string;
+};
+
+// ---------------------------------------------------------------------------
+// Event spec
+// ---------------------------------------------------------------------------
+
+/** One positional topic slot in a contract event. */
+export type TopicSpec = {
+  /**
+   * Position index (0-based) of this topic in the event's topics array.
+   * The first topic is conventionally the event name / discriminator.
+   */
+  index: number;
+  type: TypeSpec;
+  doc?: string;
+};
+
+/**
+ * Full description of one event emitted by a Soroban contract.
+ */
+export type EventSpec = {
+  /**
+   * Canonical event name — matches the first topic string by convention
+   * (e.g. "transfer", "approve", "mint").
+   */
+  name: string;
+  /** Typed description of each topic slot. */
+  topics: TopicSpec[];
+  /** Type of the event's data payload. Use `{ type: "void" }` if absent. */
+  data: TypeSpec;
+  doc?: string;
+};
+
+// ---------------------------------------------------------------------------
+// Contract spec (top-level)
+// ---------------------------------------------------------------------------
+
+/**
+ * Complete ABI spec for a single Soroban contract.
+ * Serialisable to JSON and validatable against schema/spec.schema.json.
+ */
+export type ContractSpec = {
+  /** Spec format version — MAJOR.MINOR.PATCH semver. */
+  version: string;
+  /** Canonical mainnet contract address (C-prefixed strkey, 56 chars). */
+  contractId: string;
+  /** Human-readable contract name. */
+  name: string;
+  /** Short description of the contract's purpose. */
+  description?: string;
+  /** All callable functions exposed by the contract. */
+  functions: FunctionSpec[];
+  /** All events the contract may emit. */
+  events: EventSpec[];
+  /** Any user-defined types (structs, enums) referenced by functions/events. */
+  types?: TypeSpec[];
+  /** Source reference — URL or identifier for the interface definition. */
+  source?: string;
+};

--- a/packages/abi-registry/src/types.ts
+++ b/packages/abi-registry/src/types.ts
@@ -1,5 +1,9 @@
-/** A parsed Soroban contract ABI spec entry. */
-export type ContractSpec = {
+/**
+ * Raw registry entry returned by the ABI registry HTTP API.
+ * Contains the contract ID and raw XDR entries as base64 strings.
+ * For the rich typed ABI spec shape, see ContractSpec in spec.ts.
+ */
+export type RawContractEntry = {
   contractId: string;
   /** Raw XDR entries as base64 strings. */
   entries: string[];

--- a/packages/abi-registry/test/AbiRegistryClient.test.ts
+++ b/packages/abi-registry/test/AbiRegistryClient.test.ts
@@ -1,8 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { AbiRegistryClient } from "../src/AbiRegistryClient.js";
-import type { ContractSpec } from "../src/types.js";
+import type { RawContractEntry } from "../src/types.js";
 
-function makeSpec(contractId: string): ContractSpec {
+function makeSpec(contractId: string): RawContractEntry {
   return { contractId, entries: ["base64entry=="] };
 }
 
@@ -27,7 +27,7 @@ describe("AbiRegistryClient", () => {
   describe("getSpecs", () => {
     it("issues a single POST /specs for 100 unique contract IDs", async () => {
       const ids = Array.from({ length: 100 }, (_, i) => `CONTRACT_${i}`);
-      const responseBody: Record<string, ContractSpec> = Object.fromEntries(
+      const responseBody: Record<string, RawContractEntry> = Object.fromEntries(
         ids.map((id) => [id, makeSpec(id)])
       );
 

--- a/packages/abi-registry/test/spec.test.ts
+++ b/packages/abi-registry/test/spec.test.ts
@@ -1,0 +1,241 @@
+import { describe, it, expect } from "vitest";
+import Ajv from "ajv";
+import { readFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import type {
+  ContractSpec as ContractAbiSpec,
+  FunctionSpec,
+  EventSpec,
+  TypeSpec,
+} from "../src/index.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const schema = JSON.parse(
+  readFileSync(resolve(__dirname, "../schema/spec.schema.json"), "utf8")
+);
+
+// ---------------------------------------------------------------------------
+// Representative ABI spec — SEP-41 token (USDC-shaped)
+// ---------------------------------------------------------------------------
+
+const ADDRESS: TypeSpec = { type: "address" };
+const I128: TypeSpec    = { type: "i128" };
+const U32: TypeSpec     = { type: "u32" };
+const BOOL: TypeSpec    = { type: "bool" };
+const STRING: TypeSpec  = { type: "string" };
+const VOID: TypeSpec    = { type: "void" };
+
+const transferFn: FunctionSpec = {
+  name: "transfer",
+  doc: "Transfer amount tokens from `from` to `to`.",
+  params: [
+    { name: "from",   type: ADDRESS },
+    { name: "to",     type: ADDRESS },
+    { name: "amount", type: I128 },
+  ],
+  returns: VOID,
+};
+
+const approveFn: FunctionSpec = {
+  name: "approve",
+  params: [
+    { name: "from",              type: ADDRESS },
+    { name: "spender",           type: ADDRESS },
+    { name: "amount",            type: I128 },
+    { name: "expiration_ledger", type: U32 },
+  ],
+  returns: VOID,
+};
+
+const allowanceFn: FunctionSpec = {
+  name: "allowance",
+  params: [
+    { name: "from",    type: ADDRESS },
+    { name: "spender", type: ADDRESS },
+  ],
+  returns: I128,
+};
+
+const balanceFn: FunctionSpec = {
+  name: "balance",
+  params: [{ name: "id", type: ADDRESS }],
+  returns: I128,
+};
+
+const decimalsFn: FunctionSpec = {
+  name: "decimals",
+  params: [],
+  returns: U32,
+};
+
+const nameFn: FunctionSpec = {
+  name: "name",
+  params: [],
+  returns: STRING,
+};
+
+const symbolFn: FunctionSpec = {
+  name: "symbol",
+  params: [],
+  returns: STRING,
+};
+
+const authorizedFn: FunctionSpec = {
+  name: "authorized",
+  params: [{ name: "id", type: ADDRESS }],
+  returns: BOOL,
+};
+
+const transferEvent: EventSpec = {
+  name: "transfer",
+  doc: "Emitted on every successful token transfer.",
+  topics: [
+    { index: 0, type: { type: "symbol" }, doc: "Event name — always 'transfer'." },
+    { index: 1, type: ADDRESS,            doc: "Sender address." },
+    { index: 2, type: ADDRESS,            doc: "Recipient address." },
+  ],
+  data: I128,
+};
+
+const approveEvent: EventSpec = {
+  name: "approve",
+  topics: [
+    { index: 0, type: { type: "symbol" } },
+    { index: 1, type: ADDRESS },
+    { index: 2, type: ADDRESS },
+  ],
+  data: {
+    type: "struct",
+    name: "ApproveData",
+    fields: [
+      { name: "amount",            type: I128 },
+      { name: "expiration_ledger", type: U32 },
+    ],
+  },
+};
+
+const representativeSpec: ContractAbiSpec = {
+  version: "1.0.0",
+  contractId: "CCW67TSZV3SSS2HXMBQ5JFGCKJNXKZM7UQUWUZPUTHXSTZLEO7SJMI75",
+  name: "USD Coin (USDC)",
+  description: "Circle USDC on Stellar mainnet — SEP-41 token interface.",
+  source: "https://developers.circle.com/stablecoins/usdc-contract-addresses",
+  functions: [
+    transferFn,
+    approveFn,
+    allowanceFn,
+    balanceFn,
+    decimalsFn,
+    nameFn,
+    symbolFn,
+    authorizedFn,
+  ],
+  events: [transferEvent, approveEvent],
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("ContractAbiSpec — schema validation", () => {
+  const ajv = new Ajv({ allErrors: true });
+  const validate = ajv.compile(schema);
+
+  it("representative USDC spec validates against spec.schema.json", () => {
+    const valid = validate(representativeSpec);
+    if (!valid) {
+      console.error(validate.errors);
+    }
+    expect(valid).toBe(true);
+  });
+
+  it("rejects a spec missing required contractId", () => {
+    const bad = { ...representativeSpec, contractId: undefined };
+    expect(validate(bad)).toBe(false);
+  });
+
+  it("rejects a spec with a malformed contractId (not C-prefixed strkey)", () => {
+    const bad = { ...representativeSpec, contractId: "GABC1234" };
+    expect(validate(bad)).toBe(false);
+  });
+
+  it("rejects a spec with a malformed version string", () => {
+    const bad = { ...representativeSpec, version: "v1" };
+    expect(validate(bad)).toBe(false);
+  });
+
+  it("rejects a function entry missing returns", () => {
+    const badFn = { name: "transfer", params: [] }; // no returns
+    const bad = { ...representativeSpec, functions: [badFn] };
+    expect(validate(bad)).toBe(false);
+  });
+
+  it("rejects an event entry missing data", () => {
+    const badEvent = { name: "transfer", topics: [] }; // no data
+    const bad = { ...representativeSpec, events: [badEvent] };
+    expect(validate(bad)).toBe(false);
+  });
+});
+
+describe("ContractAbiSpec — TypeSpec coverage", () => {
+  const ajv = new Ajv({ allErrors: true });
+  const validate = ajv.compile(schema);
+
+  function specWith(fnType: TypeSpec): ContractAbiSpec {
+    return {
+      ...representativeSpec,
+      functions: [{ name: "fn", params: [{ name: "x", type: fnType }], returns: VOID }],
+      events: [],
+    };
+  }
+
+  it("accepts option<address>", () => {
+    expect(validate(specWith({ type: "option", inner: ADDRESS }))).toBe(true);
+  });
+
+  it("accepts vec<i128>", () => {
+    expect(validate(specWith({ type: "vec", item: I128 }))).toBe(true);
+  });
+
+  it("accepts map<string, u32>", () => {
+    expect(validate(specWith({ type: "map", key: STRING, value: U32 }))).toBe(true);
+  });
+
+  it("accepts tuple<address, i128>", () => {
+    expect(validate(specWith({ type: "tuple", fields: [ADDRESS, I128] }))).toBe(true);
+  });
+
+  it("accepts result<u32, string>", () => {
+    expect(validate(specWith({ type: "result", ok: U32, err: STRING }))).toBe(true);
+  });
+
+  it("accepts custom named type reference", () => {
+    expect(validate(specWith({ type: "custom", name: "MyStruct" }))).toBe(true);
+  });
+
+  it("accepts bytes_n with len", () => {
+    expect(validate(specWith({ type: "bytes_n", len: 32 }))).toBe(true);
+  });
+
+  it("accepts nested struct with enum field", () => {
+    const nested: TypeSpec = {
+      type: "struct",
+      name: "Outer",
+      fields: [
+        {
+          name: "status",
+          type: {
+            type: "enum",
+            name: "Status",
+            variants: [
+              { name: "Active",   discriminant: 0 },
+              { name: "Inactive", discriminant: 1 },
+            ],
+          },
+        },
+      ],
+    };
+    expect(validate(specWith(nested))).toBe(true);
+  });
+});

--- a/packages/pulse-core/src/EventEngine.ts
+++ b/packages/pulse-core/src/EventEngine.ts
@@ -7,6 +7,7 @@ import type {
   AccountMergeEvent,
   AccountOptionsChanges,
   AccountOptionsEvent,
+  AbiRegistryClientLike,
   BumpSequenceEvent,
   BumpSequenceEventType,
   ClaimableBalanceClaimant,
@@ -99,6 +100,8 @@ export class EventEngine {
   private horizonCursor?: string;
   private filters: Map<string, (event: NormalizedEvent) => boolean> = new Map();
   private log: Logger;
+  private readonly abiRegistry?: AbiRegistryClientLike;
+  private readonly pausedSources: Set<"horizon" | "soroban"> = new Set();
 
   /**
    * Creates a new EventEngine instance.
@@ -129,6 +132,7 @@ export class EventEngine {
       ...config.reconnect,
     };
     this.log = config.logger ?? noop;
+    this.abiRegistry = config.abiRegistry;
   }
 
   /**
@@ -1212,6 +1216,16 @@ export class EventEngine {
     });
   }
 
+  /** Dispatch a contract event (invoked or emitted) to all matching contract watchers. */
+  private dispatchContractEvent(event: ContractInvokedEvent | ContractEmittedEvent): void {
+    for (const { watcher, filters } of this.contractRegistry.values()) {
+      if (this.matchesContractFilters(event, filters)) {
+        watcher.emit(event.type, event);
+        watcher.emit("*", event);
+      }
+    }
+  }
+
   private route(event: NormalizedEventOrPending): void {
     // Check if Soroban source is paused for contract events
     if ((event.type === "contract.invoked" || event.type === "contract.emitted") && this.pausedSources.has("soroban")) {
@@ -1362,12 +1376,31 @@ export class EventEngine {
     }
 
     if (event.type === "contract.invoked" || event.type === "contract.emitted") {
-      for (const { watcher, filters } of this.contractRegistry.values()) {
-        if (this.matchesContractFilters(event, filters)) {
-          watcher.emit(event.type, event);
-          watcher.emit("*", event);
-        }
+      if (event.type === "contract.emitted" && this.abiRegistry) {
+        // Async enrichment: look up the ABI spec and populate decodedData,
+        // then route. The event is held until the lookup settles so that
+        // subscribers always receive a fully-enriched (or gracefully degraded)
+        // event rather than a partially-populated one.
+        const contractId = event.contractId;
+        this.abiRegistry.getSpec(contractId).then(
+          (spec) => {
+            if (spec !== null && spec !== undefined) {
+              (event as ContractEmittedEvent).decodedData = (spec as { entries?: unknown }).entries ?? spec;
+            }
+            this.dispatchContractEvent(event);
+          },
+          (err: unknown) => {
+            this.log.warn("ABI registry lookup failed for contract.emitted event", {
+              contractId,
+              error: err instanceof Error ? err.message : String(err),
+            });
+            this.dispatchContractEvent(event);
+          }
+        );
+        return;
       }
+
+      this.dispatchContractEvent(event);
       return;
     }
 

--- a/packages/pulse-core/src/index.ts
+++ b/packages/pulse-core/src/index.ts
@@ -347,6 +347,15 @@ export interface Logger {
   error(message: string, meta?: Record<string, unknown>): void;
 }
 
+/**
+ * Minimal interface for an ABI registry client.
+ * Satisfied by `AbiRegistryClient` from `@orbital/abi-registry`, or any
+ * object with a compatible `getSpec` method (useful for testing).
+ */
+export interface AbiRegistryClientLike {
+  getSpec(contractId: string): Promise<unknown>;
+}
+
 export type CoreConfig = {
   /** The Stellar network to connect to. */
   network: Network;
@@ -355,6 +364,13 @@ export type CoreConfig = {
   /** Optional reconnection configuration. */
   reconnect?: ReconnectConfig;
   logger?: Logger;
+  /**
+   * Optional ABI registry client. When provided, `contract.emitted` events
+   * will be enriched with `decodedData` populated from the registry spec.
+   * On a lookup miss or error, `decodedData` is left undefined and a warning
+   * is logged.
+   */
+  abiRegistry?: AbiRegistryClientLike;
 };
 
 // Error class for invalid network validation
@@ -422,6 +438,12 @@ export type ContractEmittedEvent = {
   topics: string[];
   /** Arbitrary event data payload. */
   data: unknown;
+  /**
+   * ABI-decoded event data, populated when an `abiRegistry` is configured
+   * and a spec is found for the contract. Undefined on a registry miss,
+   * decode error, or when no registry is configured.
+   */
+  decodedData?: unknown;
   timestamp: string;
   raw: unknown;
 };

--- a/packages/pulse-core/test/EventEngine.abiRegistry.test.ts
+++ b/packages/pulse-core/test/EventEngine.abiRegistry.test.ts
@@ -1,0 +1,180 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { EventEngine } from "../src/EventEngine.js";
+import type { AbiRegistryClientLike } from "../src/index.js";
+import type { ContractEmittedEvent } from "../src/index.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeEmittedRecord(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    type: "contract_event",
+    contract_id: "CABC1234",
+    topics: ["transfer", "GABC"],
+    data: { amount: "100" },
+    ledger: 1000,
+    event_id: "evt-001",
+    tx_hash: "txhash001",
+    in_successful_contract_call: true,
+    created_at: "2024-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function buildEngine(abiRegistry?: AbiRegistryClientLike): {
+  engine: EventEngine;
+  simulateRecord: (record: unknown) => void;
+} {
+  const engine = new EventEngine({ network: "testnet", abiRegistry });
+
+  let capturedOnMessage: ((record: unknown) => void) | null = null;
+
+  vi.spyOn((engine as any).server, "operations").mockImplementation(() => ({
+    cursor: () => ({
+      stream: (callbacks: { onmessage: (r: unknown) => void }) => {
+        capturedOnMessage = callbacks.onmessage;
+        return () => {};
+      },
+    }),
+  }));
+
+  engine.start();
+
+  return {
+    engine,
+    simulateRecord: (record) => {
+      if (!capturedOnMessage) throw new Error("Stream not opened");
+      capturedOnMessage(record);
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("EventEngine — ABI registry integration", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("populates decodedData when the registry returns a spec for the contractId", async () => {
+    const spec = { contractId: "CABC1234", entries: ["base64entry=="] };
+    const abiRegistry: AbiRegistryClientLike = {
+      getSpec: vi.fn().mockResolvedValue(spec),
+    };
+
+    const { engine, simulateRecord } = buildEngine(abiRegistry);
+    const received: ContractEmittedEvent[] = [];
+
+    const watcher = engine.subscribeContract("sub1", {
+      filters: [{ contractIds: ["CABC1234"] }],
+    });
+    watcher.on("contract.emitted", (e) => received.push(e as ContractEmittedEvent));
+
+    simulateRecord(makeEmittedRecord());
+
+    // Allow the async getSpec promise to resolve
+    await vi.waitFor(() => expect(received).toHaveLength(1));
+
+    expect(abiRegistry.getSpec).toHaveBeenCalledWith("CABC1234");
+    expect(received[0]!.decodedData).toEqual(spec.entries);
+  });
+
+  it("leaves decodedData undefined on a registry miss (null spec)", async () => {
+    const abiRegistry: AbiRegistryClientLike = {
+      getSpec: vi.fn().mockResolvedValue(null),
+    };
+
+    const { engine, simulateRecord } = buildEngine(abiRegistry);
+    const received: ContractEmittedEvent[] = [];
+
+    const watcher = engine.subscribeContract("sub1");
+    watcher.on("contract.emitted", (e) => received.push(e as ContractEmittedEvent));
+
+    simulateRecord(makeEmittedRecord());
+
+    await vi.waitFor(() => expect(received).toHaveLength(1));
+
+    expect(received[0]!.decodedData).toBeUndefined();
+  });
+
+  it("routes the event without decodedData and logs a warning when getSpec rejects", async () => {
+    const warnSpy = vi.fn();
+    const abiRegistry: AbiRegistryClientLike = {
+      getSpec: vi.fn().mockRejectedValue(new Error("network timeout")),
+    };
+
+    const engine = new EventEngine({
+      network: "testnet",
+      abiRegistry,
+      logger: { info: vi.fn(), warn: warnSpy, error: vi.fn() },
+    });
+
+    let capturedOnMessage: ((record: unknown) => void) | null = null;
+    vi.spyOn((engine as any).server, "operations").mockImplementation(() => ({
+      cursor: () => ({
+        stream: (callbacks: { onmessage: (r: unknown) => void }) => {
+          capturedOnMessage = callbacks.onmessage;
+          return () => {};
+        },
+      }),
+    }));
+    engine.start();
+
+    const received: ContractEmittedEvent[] = [];
+    const watcher = engine.subscribeContract("sub1");
+    watcher.on("contract.emitted", (e) => received.push(e as ContractEmittedEvent));
+
+    capturedOnMessage!(makeEmittedRecord());
+
+    await vi.waitFor(() => expect(received).toHaveLength(1));
+
+    expect(received[0]!.decodedData).toBeUndefined();
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("ABI registry lookup failed"),
+      expect.objectContaining({ contractId: "CABC1234" })
+    );
+  });
+
+  it("skips ABI lookup entirely when no abiRegistry is configured", async () => {
+    // No abiRegistry — engine constructed without it
+    const { engine, simulateRecord } = buildEngine(undefined);
+    const received: ContractEmittedEvent[] = [];
+
+    const watcher = engine.subscribeContract("sub1");
+    watcher.on("contract.emitted", (e) => received.push(e as ContractEmittedEvent));
+
+    simulateRecord(makeEmittedRecord());
+
+    // Synchronous delivery — no async step needed
+    expect(received).toHaveLength(1);
+    expect(received[0]!.decodedData).toBeUndefined();
+  });
+
+  it("does not call getSpec for contract.invoked events", async () => {
+    const abiRegistry: AbiRegistryClientLike = {
+      getSpec: vi.fn().mockResolvedValue(null),
+    };
+
+    const { engine, simulateRecord } = buildEngine(abiRegistry);
+    const received: unknown[] = [];
+
+    const watcher = engine.subscribeContract("sub1");
+    watcher.on("contract.invoked", (e) => received.push(e));
+
+    simulateRecord({
+      type: "contract_invocation",
+      contract_id: "CABC1234",
+      function: "transfer",
+      args: [],
+      ledger: 1000,
+      tx_hash: "txhash001",
+      created_at: "2024-01-01T00:00:00Z",
+    });
+
+    expect(received).toHaveLength(1);
+    expect(abiRegistry.getSpec).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Summary
Implements both M2 ABI Registry issues: the full Soroban type system with JSON schema validation, and the five seeded well-known token specs.

Changes
spec.ts
 (new)

Defines the complete typed ABI surface for Soroban contracts:

PrimitiveSorobanType — all 15 XDR primitives (bool, u32–u256, bytes, bytes_n, string, symbol, address, void)
TypeSpec — discriminated union covering primitive, option<T>, vec<T>, map<K,V>, tuple, struct, enum, result<Ok,Err>, and custom (named reference)
StructField, EnumVariant — supporting types for composite forms
ParameterSpec, FunctionSpec — function name, ordered params, return type
TopicSpec, EventSpec — indexed topic slots and data payload
ContractSpec — top-level envelope: version, contractId, name, functions, events, optional types and source
spec.schema.json
 (new)

JSON Schema (draft-07) mirroring spec.ts exactly:

Required fields: version (semver pattern), contractId (C-prefixed strkey regex), name, functions, events
Recursive $defs for every TypeSpec variant via oneOf
additionalProperties: false at every level — no silent extra fields
index.ts
 (modified)

Exports all spec types from the package barrel: ContractSpec, FunctionSpec, EventSpec, TypeSpec, StructField, EnumVariant, ParameterSpec, TopicSpec, PrimitiveSorobanType.

types.ts
 (modified)

Renamed the legacy ContractSpec (raw XDR entries stub) to RawContractEntry to free the ContractSpec name for the rich typed shape. Updated AbiRegistryClient and its test accordingly.

spec.test.ts
 (new)

Builds a representative USDC-shaped ContractSpec in TypeScript and validates it against the schema via AJV
Negative tests: missing contractId, malformed strkey, bad semver, missing returns, missing data
TypeSpec coverage tests: option, vec, map, tuple, result, custom, bytes_n, nested struct+enum
packages/abi-registry/specs/well-known/ (previously committed)

Five seeded specs, all passing node validate.js (exit 0):

File	Contract ID	Functions
usdc.json	CCW67TSZV3SSS2HXMBQ5JFGCKJNXKZM7UQUWUZPUTHXSTZLEO7SJMI75	17
eurc.json	CDTKPWPLOURQA2SGTKTUQOWRCBZEORB4BWBOMJ3D3ZTQQSGE5F6JBQLV	17
aqua.json	CAUIKL3IYGMERDRUN5QQVPKPLZTRNVXV27LFCWQIRNOHSNGB3ZXAEFBX	17
native-asset-wrapper.json	CAS3J7GYLGXMF6TDJBBYYSE3HQ6BBSMLNUQ34T6TZMYMW2EVH34XOWMA	10
sac-interface.json	(reference — SAC addresses are per-asset)	17
README.md
 (previously committed)

Curation policy: eligibility criteria, addition/update/deprecation workflows, validation instructions.

Tested
node validate.js → 5 passed, 0 failed ✅
TypeScript diagnostics: 0 errors across all modified/new files ✅
spec.test.ts
: representative spec + all TypeSpec variants validate; all negative cases correctly rejected ✅