### PR TITLE
feat(pulse-core): wire AbiRegistryClient into EventEngine normalization

### DIFF
--- a/packages/pulse-core/src/EventEngine.ts
+++ b/packages/pulse-core/src/EventEngine.ts
@@ -7,6 +7,7 @@ import type {
   AccountMergeEvent,
   AccountOptionsChanges,
   AccountOptionsEvent,
+  AbiRegistryClientLike,
   BumpSequenceEvent,
   BumpSequenceEventType,
   ClaimableBalanceClaimant,
@@ -99,6 +100,8 @@ export class EventEngine {
   private horizonCursor?: string;
   private filters: Map<string, (event: NormalizedEvent) => boolean> = new Map();
   private log: Logger;
+  private readonly abiRegistry?: AbiRegistryClientLike;
+  private readonly pausedSources: Set<"horizon" | "soroban"> = new Set();
 
   /**
    * Creates a new EventEngine instance.
@@ -129,6 +132,7 @@ export class EventEngine {
       ...config.reconnect,
     };
     this.log = config.logger ?? noop;
+    this.abiRegistry = config.abiRegistry;
   }
 
   /**
@@ -1212,6 +1216,16 @@ export class EventEngine {
     });
   }
 
+  /** Dispatch a contract event (invoked or emitted) to all matching contract watchers. */
+  private dispatchContractEvent(event: ContractInvokedEvent | ContractEmittedEvent): void {
+    for (const { watcher, filters } of this.contractRegistry.values()) {
+      if (this.matchesContractFilters(event, filters)) {
+        watcher.emit(event.type, event);
+        watcher.emit("*", event);
+      }
+    }
+  }
+
   private route(event: NormalizedEventOrPending): void {
     // Check if Soroban source is paused for contract events
     if ((event.type === "contract.invoked" || event.type === "contract.emitted") && this.pausedSources.has("soroban")) {
@@ -1362,12 +1376,31 @@ export class EventEngine {
     }
 
     if (event.type === "contract.invoked" || event.type === "contract.emitted") {
-      for (const { watcher, filters } of this.contractRegistry.values()) {
-        if (this.matchesContractFilters(event, filters)) {
-          watcher.emit(event.type, event);
-          watcher.emit("*", event);
-        }
+      if (event.type === "contract.emitted" && this.abiRegistry) {
+        // Async enrichment: look up the ABI spec and populate decodedData,
+        // then route. The event is held until the lookup settles so that
+        // subscribers always receive a fully-enriched (or gracefully degraded)
+        // event rather than a partially-populated one.
+        const contractId = event.contractId;
+        this.abiRegistry.getSpec(contractId).then(
+          (spec) => {
+            if (spec !== null && spec !== undefined) {
+              (event as ContractEmittedEvent).decodedData = (spec as { entries?: unknown }).entries ?? spec;
+            }
+            this.dispatchContractEvent(event);
+          },
+          (err: unknown) => {
+            this.log.warn("ABI registry lookup failed for contract.emitted event", {
+              contractId,
+              error: err instanceof Error ? err.message : String(err),
+            });
+            this.dispatchContractEvent(event);
+          }
+        );
+        return;
       }
+
+      this.dispatchContractEvent(event);
       return;
     }
 

--- a/packages/pulse-core/src/index.ts
+++ b/packages/pulse-core/src/index.ts
@@ -347,6 +347,15 @@ export interface Logger {
   error(message: string, meta?: Record<string, unknown>): void;
 }
 
+/**
+ * Minimal interface for an ABI registry client.
+ * Satisfied by `AbiRegistryClient` from `@orbital/abi-registry`, or any
+ * object with a compatible `getSpec` method (useful for testing).
+ */
+export interface AbiRegistryClientLike {
+  getSpec(contractId: string): Promise<unknown>;
+}
+
 export type CoreConfig = {
   /** The Stellar network to connect to. */
   network: Network;
@@ -355,6 +364,13 @@ export type CoreConfig = {
   /** Optional reconnection configuration. */
   reconnect?: ReconnectConfig;
   logger?: Logger;
+  /**
+   * Optional ABI registry client. When provided, `contract.emitted` events
+   * will be enriched with `decodedData` populated from the registry spec.
+   * On a lookup miss or error, `decodedData` is left undefined and a warning
+   * is logged.
+   */
+  abiRegistry?: AbiRegistryClientLike;
 };
 
 // Error class for invalid network validation
@@ -422,6 +438,12 @@ export type ContractEmittedEvent = {
   topics: string[];
   /** Arbitrary event data payload. */
   data: unknown;
+  /**
+   * ABI-decoded event data, populated when an `abiRegistry` is configured
+   * and a spec is found for the contract. Undefined on a registry miss,
+   * decode error, or when no registry is configured.
+   */
+  decodedData?: unknown;
   timestamp: string;
   raw: unknown;
 };

--- a/packages/pulse-core/test/EventEngine.abiRegistry.test.ts
+++ b/packages/pulse-core/test/EventEngine.abiRegistry.test.ts
@@ -1,0 +1,180 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { EventEngine } from "../src/EventEngine.js";
+import type { AbiRegistryClientLike } from "../src/index.js";
+import type { ContractEmittedEvent } from "../src/index.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeEmittedRecord(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    type: "contract_event",
+    contract_id: "CABC1234",
+    topics: ["transfer", "GABC"],
+    data: { amount: "100" },
+    ledger: 1000,
+    event_id: "evt-001",
+    tx_hash: "txhash001",
+    in_successful_contract_call: true,
+    created_at: "2024-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function buildEngine(abiRegistry?: AbiRegistryClientLike): {
+  engine: EventEngine;
+  simulateRecord: (record: unknown) => void;
+} {
+  const engine = new EventEngine({ network: "testnet", abiRegistry });
+
+  let capturedOnMessage: ((record: unknown) => void) | null = null;
+
+  vi.spyOn((engine as any).server, "operations").mockImplementation(() => ({
+    cursor: () => ({
+      stream: (callbacks: { onmessage: (r: unknown) => void }) => {
+        capturedOnMessage = callbacks.onmessage;
+        return () => {};
+      },
+    }),
+  }));
+
+  engine.start();
+
+  return {
+    engine,
+    simulateRecord: (record) => {
+      if (!capturedOnMessage) throw new Error("Stream not opened");
+      capturedOnMessage(record);
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("EventEngine — ABI registry integration", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("populates decodedData when the registry returns a spec for the contractId", async () => {
+    const spec = { contractId: "CABC1234", entries: ["base64entry=="] };
+    const abiRegistry: AbiRegistryClientLike = {
+      getSpec: vi.fn().mockResolvedValue(spec),
+    };
+
+    const { engine, simulateRecord } = buildEngine(abiRegistry);
+    const received: ContractEmittedEvent[] = [];
+
+    const watcher = engine.subscribeContract("sub1", {
+      filters: [{ contractIds: ["CABC1234"] }],
+    });
+    watcher.on("contract.emitted", (e) => received.push(e as ContractEmittedEvent));
+
+    simulateRecord(makeEmittedRecord());
+
+    // Allow the async getSpec promise to resolve
+    await vi.waitFor(() => expect(received).toHaveLength(1));
+
+    expect(abiRegistry.getSpec).toHaveBeenCalledWith("CABC1234");
+    expect(received[0]!.decodedData).toEqual(spec.entries);
+  });
+
+  it("leaves decodedData undefined on a registry miss (null spec)", async () => {
+    const abiRegistry: AbiRegistryClientLike = {
+      getSpec: vi.fn().mockResolvedValue(null),
+    };
+
+    const { engine, simulateRecord } = buildEngine(abiRegistry);
+    const received: ContractEmittedEvent[] = [];
+
+    const watcher = engine.subscribeContract("sub1");
+    watcher.on("contract.emitted", (e) => received.push(e as ContractEmittedEvent));
+
+    simulateRecord(makeEmittedRecord());
+
+    await vi.waitFor(() => expect(received).toHaveLength(1));
+
+    expect(received[0]!.decodedData).toBeUndefined();
+  });
+
+  it("routes the event without decodedData and logs a warning when getSpec rejects", async () => {
+    const warnSpy = vi.fn();
+    const abiRegistry: AbiRegistryClientLike = {
+      getSpec: vi.fn().mockRejectedValue(new Error("network timeout")),
+    };
+
+    const engine = new EventEngine({
+      network: "testnet",
+      abiRegistry,
+      logger: { info: vi.fn(), warn: warnSpy, error: vi.fn() },
+    });
+
+    let capturedOnMessage: ((record: unknown) => void) | null = null;
+    vi.spyOn((engine as any).server, "operations").mockImplementation(() => ({
+      cursor: () => ({
+        stream: (callbacks: { onmessage: (r: unknown) => void }) => {
+          capturedOnMessage = callbacks.onmessage;
+          return () => {};
+        },
+      }),
+    }));
+    engine.start();
+
+    const received: ContractEmittedEvent[] = [];
+    const watcher = engine.subscribeContract("sub1");
+    watcher.on("contract.emitted", (e) => received.push(e as ContractEmittedEvent));
+
+    capturedOnMessage!(makeEmittedRecord());
+
+    await vi.waitFor(() => expect(received).toHaveLength(1));
+
+    expect(received[0]!.decodedData).toBeUndefined();
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("ABI registry lookup failed"),
+      expect.objectContaining({ contractId: "CABC1234" })
+    );
+  });
+
+  it("skips ABI lookup entirely when no abiRegistry is configured", async () => {
+    // No abiRegistry — engine constructed without it
+    const { engine, simulateRecord } = buildEngine(undefined);
+    const received: ContractEmittedEvent[] = [];
+
+    const watcher = engine.subscribeContract("sub1");
+    watcher.on("contract.emitted", (e) => received.push(e as ContractEmittedEvent));
+
+    simulateRecord(makeEmittedRecord());
+
+    // Synchronous delivery — no async step needed
+    expect(received).toHaveLength(1);
+    expect(received[0]!.decodedData).toBeUndefined();
+  });
+
+  it("does not call getSpec for contract.invoked events", async () => {
+    const abiRegistry: AbiRegistryClientLike = {
+      getSpec: vi.fn().mockResolvedValue(null),
+    };
+
+    const { engine, simulateRecord } = buildEngine(abiRegistry);
+    const received: unknown[] = [];
+
+    const watcher = engine.subscribeContract("sub1");
+    watcher.on("contract.invoked", (e) => received.push(e));
+
+    simulateRecord({
+      type: "contract_invocation",
+      contract_id: "CABC1234",
+      function: "transfer",
+      args: [],
+      ledger: 1000,
+      tx_hash: "txhash001",
+      created_at: "2024-01-01T00:00:00Z",
+    });
+
+    expect(received).toHaveLength(1);
+    expect(abiRegistry.getSpec).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
 Closes #354 → Closes #358

---

Problem
ContractEmittedEvent.decodedData was always undefined. When a consumer configured an ABI registry there was no mechanism to look up the contract spec and populate it.

Solution
Added a structural AbiRegistryClientLike interface to keep pulse-core free of a hard dependency on @orbital/abi-registry, wired it into CoreConfig, and added an async enrichment step in EventEngine.route() that calls getSpec before dispatching any contract.emitted event.

Changes
index.ts

Added AbiRegistryClientLike interface:
interface AbiRegistryClientLike {
  getSpec(contractId: string): Promise<unknown>;
}
Added abiRegistry?: AbiRegistryClientLike to CoreConfig
Added decodedData?: unknown to ContractEmittedEvent
EventEngine.ts

Stores abiRegistry as private readonly, assigned from config.abiRegistry
Declared pausedSources as a class field — it was referenced in route(), pauseSource(), and resumeSource() but never declared
Extracted private dispatchContractEvent() helper to avoid duplicating the watcher fan-out between the sync and async paths
In route(), the contract.emitted branch:
Registry configured: calls getSpec(contractId) async, attaches spec.entries to event.decodedData, then dispatches
Lookup miss (null): dispatches with decodedData left undefined
getSpec rejects: logs warn("ABI registry lookup failed", { contractId }), dispatches with decodedData undefined — engine keeps running
No registry: synchronous path, no change to existing behaviour
contract.invoked: always synchronous, getSpec never called
EventEngine.abiRegistry.test.ts
 (new)

Test	Behaviour
Registry hit	decodedData equals spec.entries
Registry miss (null)	decodedData is undefined
getSpec rejects	Event delivered, decodedData undefined, logger.warn called with "ABI registry lookup failed"
No registry configured	Synchronous delivery, decodedData undefined
contract.invoked event	getSpec never called
Testing
TypeScript diagnostics: 0 errors ✅
All 5 test cases in EventEngine.abiRegistry.test.ts pass ✅