### PR TITLE
docs(abi-registry): well-known token contract specs

### DIFF
--- a/packages/abi-registry/specs/README.md
+++ b/packages/abi-registry/specs/README.md
@@ -1,0 +1,147 @@
+# ABI Registry — Specs
+
+This directory contains Soroban contract ABI specs for the Orbital ABI Registry.
+
+## Directory layout
+
+```
+specs/
+└── well-known/
+    ├── schema.json              # JSON Schema every spec must conform to
+    ├── index.json               # Machine-readable index of all well-known specs
+    ├── sac-interface.json       # Common SAC / SEP-41 interface (reference)
+    ├── native-asset-wrapper.json
+    ├── usdc.json
+    ├── eurc.json
+    └── aqua.json
+```
+
+---
+
+## What are well-known specs?
+
+A **well-known spec** is a pre-seeded ABI spec that ships with the registry and is maintained by the Orbital project. These specs cover the most widely-deployed token contracts on Stellar mainnet so that consumers can decode contract events without having to locate or author the spec themselves.
+
+Well-known specs live under `specs/well-known/` and are versioned alongside the registry package.
+
+---
+
+## Spec format
+
+Every spec is a JSON file that conforms to `specs/well-known/schema.json`. The required top-level fields are:
+
+| Field | Type | Description |
+|---|---|---|
+| `version` | `string` | Spec revision in `MAJOR.MINOR.PATCH` semver format. |
+| `name` | `string` | Human-readable contract name (1–100 characters). |
+| `description` | `string` | Short description of the contract's purpose (1–500 characters). |
+| `contract_id` | `string` | Canonical mainnet Soroban contract address — C-prefixed strkey, 56 characters. |
+| `network` | `"mainnet" \| "testnet" \| "futurenet"` | Stellar network this spec targets. |
+| `source` | `string` | URL or reference identifying where the interface definition was obtained. |
+| `functions` | `array` | List of callable contract functions (at least one entry required). |
+
+Optional fields: `tags` (string array).
+
+Each entry in `functions` must have:
+- `name` — function name as it appears in the contract ABI.
+- `params` — ordered array of `{ name, type }` objects (Soroban XDR type names such as `Address`, `i128`, `u32`, `String`, `bool`).
+- `outputs` — ordered array of `{ type }` objects; empty array for void functions.
+- `doc` — optional human-readable description (on the function or any param/output).
+
+---
+
+## Curation policy
+
+### Criteria for inclusion
+
+A contract qualifies as a well-known spec when it meets **all** of the following:
+
+1. **Mainnet deployment** — the contract is deployed and active on Stellar mainnet with a verifiable C-prefixed contract address.
+2. **Public interface** — the contract interface is publicly documented or derivable via `stellar contract info interface --network mainnet --id <CONTRACT_ID>`.
+3. **Community adoption** — the contract is integrated by at least three independent production applications, or has processed at least 10,000 mainnet transactions.
+4. **Stable interface** — the contract interface is not expected to change without a migration path (i.e., it is not an experimental or alpha deployment).
+
+### Initial well-known specs
+
+| Spec file | Contract ID | Rationale |
+|---|---|---|
+| `sac-interface.json` | *(placeholder — SAC addresses are per-asset)* | Reference interface for all SACs; every Stellar classic asset can be wrapped as a SAC. |
+| `native-asset-wrapper.json` | `CAS3J7GYLGXMF6TDJBBYYSE3HQ6BBSMLNUQ34T6TZMYMW2EVH34XOWMA` | XLM is the native Stellar asset and the most widely used token on the network. |
+| `usdc.json` | `CCW67TSZV3SSS2HXMBQ5JFGCKJNXKZM7UQUWUZPUTHXSTZLEO7SJMI75` | USDC is the dominant USD stablecoin on Stellar, issued by Circle. |
+| `eurc.json` | `CDTKPWPLOURQA2SGTKTUQOWRCBZEORB4BWBOMJ3D3ZTQQSGE5F6JBQLV` | EURC is Circle's MiCA-compliant EUR stablecoin on Stellar, launched 2023-09-26. |
+| `aqua.json` | `CAUIKL3IYGMERDRUN5QQVPKPLZTRNVXV27LFCWQIRNOHSNGB3ZXAEFBX` | AQUA is the governance and liquidity incentive token of the Aquarius protocol, held by 120K+ wallets. |
+
+> **SAC contract IDs** are derived deterministically from the classic asset. To verify or derive an address:
+> ```
+> stellar contract id asset --asset CODE:ISSUER --network mainnet
+> stellar contract id asset --asset native --network mainnet
+> ```
+
+---
+
+## Adding a new well-known spec
+
+1. **Check eligibility** — confirm the contract meets all four criteria above.
+2. **Derive the contract ID** — use the Stellar CLI or SDK to obtain the canonical C-prefixed address.
+3. **Author the spec** — create `specs/well-known/<token-symbol-lowercase>.json` following the schema. Run `pnpm --filter @orbital/abi-registry validate` to confirm it passes before opening a PR.
+4. **Update the index** — add an entry to `specs/well-known/index.json` with `name`, `contract_id`, `file`, `description`, and `tags`.
+5. **Open a pull request** — include:
+   - The new spec file.
+   - The updated `index.json`.
+   - Evidence of mainnet deployment (explorer link or CLI output).
+   - Evidence of community adoption (links to integrations or on-chain transaction count).
+6. **Review** — a maintainer will verify the contract ID, check the interface against the on-chain WASM, and merge once the spec is confirmed correct.
+
+---
+
+## Updating an existing well-known spec
+
+If a contract is upgraded or its interface changes:
+
+1. Bump the `version` field in the spec file following semver (patch for doc-only changes, minor for new functions, major for breaking changes).
+2. Update the `functions` array to reflect the new interface.
+3. Add a note in the PR description explaining what changed and linking to the upgrade transaction or announcement.
+4. If the contract ID changes (new deployment), update `contract_id` and the `index.json` entry, and add a comment in the PR explaining the migration.
+
+---
+
+## Deprecating or removing a well-known spec
+
+A well-known spec is deprecated when:
+- The contract is no longer actively used (fewer than 100 transactions in the past 90 days on mainnet).
+- The issuer has publicly announced end-of-life for the contract.
+- A successor contract has been deployed and the original is frozen or drained.
+
+Deprecation process:
+1. Open a PR adding a `"deprecated": true` field to the spec and a `"deprecated_reason"` string explaining why.
+2. The spec remains in the registry for one release cycle (minimum 30 days) before removal, to give consumers time to migrate.
+3. Removal is a breaking change and requires a major version bump of the registry package.
+
+---
+
+## Validation workflow
+
+All specs are validated against `specs/well-known/schema.json` using the `validate` script.
+
+**Run validation locally:**
+
+```bash
+# From the repo root
+pnpm --filter @orbital/abi-registry validate
+
+# Or from the package directory
+cd packages/abi-registry
+node validate.js
+```
+
+**What the validator checks:**
+- The file parses as valid JSON.
+- All required fields are present (`version`, `name`, `description`, `contract_id`, `network`, `source`, `functions`).
+- Field types and constraints match the schema (e.g. `contract_id` matches the C-prefixed strkey pattern, `version` is valid semver, `functions` is non-empty).
+- No extra fields are present (`additionalProperties: false`).
+
+**Exit codes:**
+- `0` — all specs pass.
+- `1` — one or more specs fail; errors are printed to stderr with the file path and the failing field.
+
+CI runs `pnpm --filter @orbital/abi-registry validate` on every pull request that touches `packages/abi-registry/`.

--- a/packages/abi-registry/specs/well-known/aqua.json
+++ b/packages/abi-registry/specs/well-known/aqua.json
@@ -1,0 +1,168 @@
+{
+  "version": "1.0.0",
+  "name": "Aquarius (AQUA)",
+  "description": "Governance and liquidity incentive token of the Aquarius protocol on Stellar mainnet, deployed as a Stellar Asset Contract (SAC). AQUA is used for voting on market rewards, liquidity provision incentives, and protocol governance. Implements the full SEP-41 token interface.",
+  "contract_id": "CAUIKL3IYGMERDRUN5QQVPKPLZTRNVXV27LFCWQIRNOHSNGB3ZXAEFBX",
+  "network": "mainnet",
+  "source": "https://docs.aqua.network/developers/code-examples/prerequisites-and-basics",
+  "tags": ["sep41", "sac", "governance", "defi", "aquarius"],
+  "functions": [
+    {
+      "name": "transfer",
+      "doc": "Transfer `amount` AQUA from `from` to `to`. Requires authorization from `from`.",
+      "params": [
+        { "name": "from",   "type": "Address", "doc": "Source account or contract address." },
+        { "name": "to",     "type": "Address", "doc": "Destination account or contract address." },
+        { "name": "amount", "type": "i128",    "doc": "Amount in AQUA base units (7 decimal places; 1 AQUA = 10,000,000)." }
+      ],
+      "outputs": []
+    },
+    {
+      "name": "transfer_from",
+      "doc": "Transfer `amount` AQUA from `from` to `to` using a pre-approved allowance. Requires authorization from `spender`.",
+      "params": [
+        { "name": "spender", "type": "Address", "doc": "Address that was granted the allowance." },
+        { "name": "from",    "type": "Address", "doc": "Source account whose allowance is consumed." },
+        { "name": "to",      "type": "Address", "doc": "Destination account or contract address." },
+        { "name": "amount",  "type": "i128",    "doc": "Amount in AQUA base units." }
+      ],
+      "outputs": []
+    },
+    {
+      "name": "approve",
+      "doc": "Approve `spender` to transfer up to `amount` AQUA from the caller's balance.",
+      "params": [
+        { "name": "from",              "type": "Address", "doc": "Token owner granting the allowance." },
+        { "name": "spender",           "type": "Address", "doc": "Address being granted the allowance." },
+        { "name": "amount",            "type": "i128",    "doc": "Maximum transferable amount in AQUA base units." },
+        { "name": "expiration_ledger", "type": "u32",     "doc": "Ledger sequence number at which the allowance expires." }
+      ],
+      "outputs": []
+    },
+    {
+      "name": "allowance",
+      "doc": "Return the remaining allowance that `spender` may transfer from `from`.",
+      "params": [
+        { "name": "from",    "type": "Address", "doc": "Token owner." },
+        { "name": "spender", "type": "Address", "doc": "Approved spender." }
+      ],
+      "outputs": [
+        { "type": "i128", "doc": "Remaining allowance in AQUA base units." }
+      ]
+    },
+    {
+      "name": "balance",
+      "doc": "Return the AQUA balance of `id`.",
+      "params": [
+        { "name": "id", "type": "Address", "doc": "Account or contract address to query." }
+      ],
+      "outputs": [
+        { "type": "i128", "doc": "Balance in AQUA base units." }
+      ]
+    },
+    {
+      "name": "decimals",
+      "doc": "Return the number of decimal places. Always 7 for Stellar-native AQUA.",
+      "params": [],
+      "outputs": [
+        { "type": "u32", "doc": "Always 7." }
+      ]
+    },
+    {
+      "name": "name",
+      "doc": "Return the token name.",
+      "params": [],
+      "outputs": [
+        { "type": "String", "doc": "Always 'Aquarius'." }
+      ]
+    },
+    {
+      "name": "symbol",
+      "doc": "Return the token symbol.",
+      "params": [],
+      "outputs": [
+        { "type": "String", "doc": "Always 'AQUA'." }
+      ]
+    },
+    {
+      "name": "total_supply",
+      "doc": "Return the total AQUA supply currently in circulation on Stellar.",
+      "params": [],
+      "outputs": [
+        { "type": "i128", "doc": "Total supply in AQUA base units." }
+      ]
+    },
+    {
+      "name": "mint",
+      "doc": "Mint `amount` AQUA to `to`. Requires admin (Aquarius issuer) authorization.",
+      "params": [
+        { "name": "to",     "type": "Address", "doc": "Recipient of the newly minted AQUA." },
+        { "name": "amount", "type": "i128",    "doc": "Amount to mint in AQUA base units." }
+      ],
+      "outputs": []
+    },
+    {
+      "name": "burn",
+      "doc": "Burn `amount` AQUA from `from`. Requires authorization from `from`.",
+      "params": [
+        { "name": "from",   "type": "Address", "doc": "Account whose AQUA is burned." },
+        { "name": "amount", "type": "i128",    "doc": "Amount to burn in AQUA base units." }
+      ],
+      "outputs": []
+    },
+    {
+      "name": "burn_from",
+      "doc": "Burn `amount` AQUA from `from` using a pre-approved allowance.",
+      "params": [
+        { "name": "spender", "type": "Address", "doc": "Address consuming the allowance." },
+        { "name": "from",    "type": "Address", "doc": "Account whose AQUA is burned." },
+        { "name": "amount",  "type": "i128",    "doc": "Amount to burn in AQUA base units." }
+      ],
+      "outputs": []
+    },
+    {
+      "name": "clawback",
+      "doc": "Clawback `amount` AQUA from `from`. Only callable by the admin on assets with clawback enabled.",
+      "params": [
+        { "name": "from",   "type": "Address", "doc": "Account from which AQUA is clawed back." },
+        { "name": "amount", "type": "i128",    "doc": "Amount to clawback in AQUA base units." }
+      ],
+      "outputs": []
+    },
+    {
+      "name": "set_authorized",
+      "doc": "Set the authorization flag for `id`. Requires admin authorization.",
+      "params": [
+        { "name": "id",        "type": "Address", "doc": "Account whose authorization flag is being set." },
+        { "name": "authorize", "type": "bool",    "doc": "True to authorize, false to deauthorize." }
+      ],
+      "outputs": []
+    },
+    {
+      "name": "authorized",
+      "doc": "Return whether `id` is authorized to hold and transfer AQUA.",
+      "params": [
+        { "name": "id", "type": "Address", "doc": "Account to query." }
+      ],
+      "outputs": [
+        { "type": "bool", "doc": "True if authorized." }
+      ]
+    },
+    {
+      "name": "set_admin",
+      "doc": "Transfer admin rights to `new_admin`. Requires current admin authorization.",
+      "params": [
+        { "name": "new_admin", "type": "Address", "doc": "Address that will become the new admin." }
+      ],
+      "outputs": []
+    },
+    {
+      "name": "admin",
+      "doc": "Return the current admin address.",
+      "params": [],
+      "outputs": [
+        { "type": "Address", "doc": "Current admin address (Aquarius issuer account)." }
+      ]
+    }
+  ]
+}

--- a/packages/abi-registry/specs/well-known/eurc.json
+++ b/packages/abi-registry/specs/well-known/eurc.json
@@ -1,0 +1,168 @@
+{
+  "version": "1.0.0",
+  "name": "Euro Coin (EURC)",
+  "description": "Circle's EUR-backed stablecoin on Stellar mainnet, deployed as a Stellar Asset Contract (SAC). Implements the full SEP-41 token interface. Always redeemable 1:1 for euros under a full-reserve model. MiCA-compliant.",
+  "contract_id": "CDTKPWPLOURQA2SGTKTUQOWRCBZEORB4BWBOMJ3D3ZTQQSGE5F6JBQLV",
+  "network": "mainnet",
+  "source": "https://developers.circle.com/stablecoins/eurc-contract-addresses",
+  "tags": ["sep41", "sac", "stablecoin", "eur", "circle", "mica"],
+  "functions": [
+    {
+      "name": "transfer",
+      "doc": "Transfer `amount` EURC from `from` to `to`. Requires authorization from `from`.",
+      "params": [
+        { "name": "from",   "type": "Address", "doc": "Source account or contract address." },
+        { "name": "to",     "type": "Address", "doc": "Destination account or contract address." },
+        { "name": "amount", "type": "i128",    "doc": "Amount in EURC base units (7 decimal places; 1 EURC = 10,000,000)." }
+      ],
+      "outputs": []
+    },
+    {
+      "name": "transfer_from",
+      "doc": "Transfer `amount` EURC from `from` to `to` using a pre-approved allowance. Requires authorization from `spender`.",
+      "params": [
+        { "name": "spender", "type": "Address", "doc": "Address that was granted the allowance." },
+        { "name": "from",    "type": "Address", "doc": "Source account whose allowance is consumed." },
+        { "name": "to",      "type": "Address", "doc": "Destination account or contract address." },
+        { "name": "amount",  "type": "i128",    "doc": "Amount in EURC base units." }
+      ],
+      "outputs": []
+    },
+    {
+      "name": "approve",
+      "doc": "Approve `spender` to transfer up to `amount` EURC from the caller's balance.",
+      "params": [
+        { "name": "from",              "type": "Address", "doc": "Token owner granting the allowance." },
+        { "name": "spender",           "type": "Address", "doc": "Address being granted the allowance." },
+        { "name": "amount",            "type": "i128",    "doc": "Maximum transferable amount in EURC base units." },
+        { "name": "expiration_ledger", "type": "u32",     "doc": "Ledger sequence number at which the allowance expires." }
+      ],
+      "outputs": []
+    },
+    {
+      "name": "allowance",
+      "doc": "Return the remaining allowance that `spender` may transfer from `from`.",
+      "params": [
+        { "name": "from",    "type": "Address", "doc": "Token owner." },
+        { "name": "spender", "type": "Address", "doc": "Approved spender." }
+      ],
+      "outputs": [
+        { "type": "i128", "doc": "Remaining allowance in EURC base units." }
+      ]
+    },
+    {
+      "name": "balance",
+      "doc": "Return the EURC balance of `id`.",
+      "params": [
+        { "name": "id", "type": "Address", "doc": "Account or contract address to query." }
+      ],
+      "outputs": [
+        { "type": "i128", "doc": "Balance in EURC base units." }
+      ]
+    },
+    {
+      "name": "decimals",
+      "doc": "Return the number of decimal places. Always 7 for Stellar-native EURC.",
+      "params": [],
+      "outputs": [
+        { "type": "u32", "doc": "Always 7." }
+      ]
+    },
+    {
+      "name": "name",
+      "doc": "Return the token name.",
+      "params": [],
+      "outputs": [
+        { "type": "String", "doc": "Always 'Euro Coin'." }
+      ]
+    },
+    {
+      "name": "symbol",
+      "doc": "Return the token symbol.",
+      "params": [],
+      "outputs": [
+        { "type": "String", "doc": "Always 'EURC'." }
+      ]
+    },
+    {
+      "name": "total_supply",
+      "doc": "Return the total EURC supply currently in circulation on Stellar.",
+      "params": [],
+      "outputs": [
+        { "type": "i128", "doc": "Total supply in EURC base units." }
+      ]
+    },
+    {
+      "name": "mint",
+      "doc": "Mint `amount` EURC to `to`. Requires admin (Circle issuer) authorization.",
+      "params": [
+        { "name": "to",     "type": "Address", "doc": "Recipient of the newly minted EURC." },
+        { "name": "amount", "type": "i128",    "doc": "Amount to mint in EURC base units." }
+      ],
+      "outputs": []
+    },
+    {
+      "name": "burn",
+      "doc": "Burn `amount` EURC from `from`. Requires authorization from `from`.",
+      "params": [
+        { "name": "from",   "type": "Address", "doc": "Account whose EURC is burned." },
+        { "name": "amount", "type": "i128",    "doc": "Amount to burn in EURC base units." }
+      ],
+      "outputs": []
+    },
+    {
+      "name": "burn_from",
+      "doc": "Burn `amount` EURC from `from` using a pre-approved allowance.",
+      "params": [
+        { "name": "spender", "type": "Address", "doc": "Address consuming the allowance." },
+        { "name": "from",    "type": "Address", "doc": "Account whose EURC is burned." },
+        { "name": "amount",  "type": "i128",    "doc": "Amount to burn in EURC base units." }
+      ],
+      "outputs": []
+    },
+    {
+      "name": "clawback",
+      "doc": "Clawback `amount` EURC from `from`. Only callable by the admin on assets with clawback enabled.",
+      "params": [
+        { "name": "from",   "type": "Address", "doc": "Account from which EURC is clawed back." },
+        { "name": "amount", "type": "i128",    "doc": "Amount to clawback in EURC base units." }
+      ],
+      "outputs": []
+    },
+    {
+      "name": "set_authorized",
+      "doc": "Set the authorization flag for `id`. Requires admin authorization.",
+      "params": [
+        { "name": "id",        "type": "Address", "doc": "Account whose authorization flag is being set." },
+        { "name": "authorize", "type": "bool",    "doc": "True to authorize, false to deauthorize." }
+      ],
+      "outputs": []
+    },
+    {
+      "name": "authorized",
+      "doc": "Return whether `id` is authorized to hold and transfer EURC.",
+      "params": [
+        { "name": "id", "type": "Address", "doc": "Account to query." }
+      ],
+      "outputs": [
+        { "type": "bool", "doc": "True if authorized." }
+      ]
+    },
+    {
+      "name": "set_admin",
+      "doc": "Transfer admin rights to `new_admin`. Requires current admin authorization.",
+      "params": [
+        { "name": "new_admin", "type": "Address", "doc": "Address that will become the new admin." }
+      ],
+      "outputs": []
+    },
+    {
+      "name": "admin",
+      "doc": "Return the current admin address.",
+      "params": [],
+      "outputs": [
+        { "type": "Address", "doc": "Current admin address (Circle issuer account)." }
+      ]
+    }
+  ]
+}

--- a/packages/abi-registry/specs/well-known/index.json
+++ b/packages/abi-registry/specs/well-known/index.json
@@ -1,0 +1,39 @@
+{
+  "specs": [
+    {
+      "name": "Stellar Asset Contract (SAC) Interface",
+      "contract_id": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+      "file": "sac-interface.json",
+      "description": "Common interface implemented by every Stellar Asset Contract (SAC). SACs are the standard Soroban wrappers for Stellar classic assets and implement the full SEP-41 token interface plus SAC-specific admin operations.",
+      "tags": ["sep41", "sac", "interface"]
+    },
+    {
+      "name": "Native Asset Wrapper (XLM SAC)",
+      "contract_id": "CAS3J7GYLGXMF6TDJBBYYSE3HQ6BBSMLNUQ34T6TZMYMW2EVH34XOWMA",
+      "file": "native-asset-wrapper.json",
+      "description": "Stellar Asset Contract wrapping the native XLM asset. Exposes XLM as a SEP-41-compatible Soroban token.",
+      "tags": ["sep41", "sac", "native", "xlm"]
+    },
+    {
+      "name": "USD Coin (USDC)",
+      "contract_id": "CCW67TSZV3SSS2HXMBQ5JFGCKJNXKZM7UQUWUZPUTHXSTZLEO7SJMI75",
+      "file": "usdc.json",
+      "description": "Circle's USD-backed stablecoin on Stellar mainnet, deployed as a Stellar Asset Contract (SAC).",
+      "tags": ["sep41", "sac", "stablecoin", "usd", "circle"]
+    },
+    {
+      "name": "Euro Coin (EURC)",
+      "contract_id": "CDTKPWPLOURQA2SGTKTUQOWRCBZEORB4BWBOMJ3D3ZTQQSGE5F6JBQLV",
+      "file": "eurc.json",
+      "description": "Circle's EUR-backed stablecoin on Stellar mainnet, deployed as a Stellar Asset Contract (SAC). MiCA-compliant.",
+      "tags": ["sep41", "sac", "stablecoin", "eur", "circle", "mica"]
+    },
+    {
+      "name": "Aquarius (AQUA)",
+      "contract_id": "CAUIKL3IYGMERDRUN5QQVPKPLZTRNVXV27LFCWQIRNOHSNGB3ZXAEFBX",
+      "file": "aqua.json",
+      "description": "Governance and liquidity incentive token of the Aquarius protocol on Stellar mainnet.",
+      "tags": ["sep41", "sac", "governance", "defi", "aquarius"]
+    }
+  ]
+}

--- a/packages/abi-registry/specs/well-known/native-asset-wrapper.json
+++ b/packages/abi-registry/specs/well-known/native-asset-wrapper.json
@@ -1,0 +1,106 @@
+{
+  "version": "1.0.0",
+  "name": "Native Asset Wrapper (XLM SAC)",
+  "description": "Stellar Asset Contract wrapping the native XLM asset. Exposes XLM as a SEP-41-compatible Soroban token. Mint, burn, clawback, and authorization operations are not available on the native asset.",
+  "contract_id": "CAS3J7GYLGXMF6TDJBBYYSE3HQ6BBSMLNUQ34T6TZMYMW2EVH34XOWMA",
+  "network": "mainnet",
+  "source": "https://developers.stellar.org/docs/build/guides/tokens/stellar-asset-contract",
+  "tags": ["sep41", "sac", "native", "xlm"],
+  "functions": [
+    {
+      "name": "transfer",
+      "doc": "Transfer `amount` stroops of XLM from `from` to `to`. Requires authorization from `from`.",
+      "params": [
+        { "name": "from",   "type": "Address", "doc": "Source account or contract address." },
+        { "name": "to",     "type": "Address", "doc": "Destination account or contract address." },
+        { "name": "amount", "type": "i128",    "doc": "Amount in stroops (1 XLM = 10,000,000 stroops)." }
+      ],
+      "outputs": []
+    },
+    {
+      "name": "transfer_from",
+      "doc": "Transfer `amount` stroops from `from` to `to` using a pre-approved allowance.",
+      "params": [
+        { "name": "spender", "type": "Address", "doc": "Address that was granted the allowance." },
+        { "name": "from",    "type": "Address", "doc": "Source account whose allowance is consumed." },
+        { "name": "to",      "type": "Address", "doc": "Destination account or contract address." },
+        { "name": "amount",  "type": "i128",    "doc": "Amount in stroops." }
+      ],
+      "outputs": []
+    },
+    {
+      "name": "approve",
+      "doc": "Approve `spender` to transfer up to `amount` stroops from the caller's balance.",
+      "params": [
+        { "name": "from",              "type": "Address", "doc": "Token owner granting the allowance." },
+        { "name": "spender",           "type": "Address", "doc": "Address being granted the allowance." },
+        { "name": "amount",            "type": "i128",    "doc": "Maximum transferable amount in stroops." },
+        { "name": "expiration_ledger", "type": "u32",     "doc": "Ledger sequence number at which the allowance expires." }
+      ],
+      "outputs": []
+    },
+    {
+      "name": "allowance",
+      "doc": "Return the remaining allowance that `spender` may transfer from `from`.",
+      "params": [
+        { "name": "from",    "type": "Address", "doc": "Token owner." },
+        { "name": "spender", "type": "Address", "doc": "Approved spender." }
+      ],
+      "outputs": [
+        { "type": "i128", "doc": "Remaining allowance in stroops." }
+      ]
+    },
+    {
+      "name": "balance",
+      "doc": "Return the XLM balance of `id` in stroops.",
+      "params": [
+        { "name": "id", "type": "Address", "doc": "Account or contract address to query." }
+      ],
+      "outputs": [
+        { "type": "i128", "doc": "Balance in stroops." }
+      ]
+    },
+    {
+      "name": "decimals",
+      "doc": "Return the number of decimal places. Always 7 for XLM (1 XLM = 10^7 stroops).",
+      "params": [],
+      "outputs": [
+        { "type": "u32", "doc": "Always 7." }
+      ]
+    },
+    {
+      "name": "name",
+      "doc": "Return the token name.",
+      "params": [],
+      "outputs": [
+        { "type": "String", "doc": "Always 'native'." }
+      ]
+    },
+    {
+      "name": "symbol",
+      "doc": "Return the token symbol.",
+      "params": [],
+      "outputs": [
+        { "type": "String", "doc": "Always 'XLM'." }
+      ]
+    },
+    {
+      "name": "authorized",
+      "doc": "Return whether `id` is authorized. Always true for the native asset.",
+      "params": [
+        { "name": "id", "type": "Address", "doc": "Account to query." }
+      ],
+      "outputs": [
+        { "type": "bool", "doc": "Always true for the native asset." }
+      ]
+    },
+    {
+      "name": "admin",
+      "doc": "Return the current admin address.",
+      "params": [],
+      "outputs": [
+        { "type": "Address", "doc": "Current admin address." }
+      ]
+    }
+  ]
+}

--- a/packages/abi-registry/specs/well-known/sac-interface.json
+++ b/packages/abi-registry/specs/well-known/sac-interface.json
@@ -1,0 +1,168 @@
+{
+  "version": "1.0.0",
+  "name": "Stellar Asset Contract (SAC) Interface",
+  "description": "Common interface implemented by every Stellar Asset Contract (SAC). SACs are the standard Soroban wrappers for Stellar classic assets and implement the full SEP-41 token interface plus SAC-specific admin operations.",
+  "contract_id": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+  "network": "mainnet",
+  "source": "https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0041.md",
+  "tags": ["sep41", "sac", "interface"],
+  "functions": [
+    {
+      "name": "transfer",
+      "doc": "Transfer `amount` tokens from `from` to `to`. Requires authorization from `from`.",
+      "params": [
+        { "name": "from",   "type": "Address", "doc": "Source account or contract address." },
+        { "name": "to",     "type": "Address", "doc": "Destination account or contract address." },
+        { "name": "amount", "type": "i128",    "doc": "Amount to transfer (scaled by token decimals)." }
+      ],
+      "outputs": []
+    },
+    {
+      "name": "transfer_from",
+      "doc": "Transfer `amount` tokens from `from` to `to` using a pre-approved allowance. Requires authorization from `spender`.",
+      "params": [
+        { "name": "spender", "type": "Address", "doc": "Address that was granted the allowance." },
+        { "name": "from",    "type": "Address", "doc": "Source account whose allowance is consumed." },
+        { "name": "to",      "type": "Address", "doc": "Destination account or contract address." },
+        { "name": "amount",  "type": "i128",    "doc": "Amount to transfer." }
+      ],
+      "outputs": []
+    },
+    {
+      "name": "approve",
+      "doc": "Approve `spender` to transfer up to `amount` tokens from the caller's balance. The approval expires at `expiration_ledger`.",
+      "params": [
+        { "name": "from",              "type": "Address", "doc": "Token owner granting the allowance." },
+        { "name": "spender",           "type": "Address", "doc": "Address being granted the allowance." },
+        { "name": "amount",            "type": "i128",    "doc": "Maximum transferable amount." },
+        { "name": "expiration_ledger", "type": "u32",     "doc": "Ledger sequence number at which the allowance expires." }
+      ],
+      "outputs": []
+    },
+    {
+      "name": "allowance",
+      "doc": "Return the remaining allowance that `spender` may transfer from `from`.",
+      "params": [
+        { "name": "from",    "type": "Address", "doc": "Token owner." },
+        { "name": "spender", "type": "Address", "doc": "Approved spender." }
+      ],
+      "outputs": [
+        { "type": "i128", "doc": "Remaining allowance amount." }
+      ]
+    },
+    {
+      "name": "balance",
+      "doc": "Return the token balance of `id`.",
+      "params": [
+        { "name": "id", "type": "Address", "doc": "Account or contract address to query." }
+      ],
+      "outputs": [
+        { "type": "i128", "doc": "Token balance scaled by decimals." }
+      ]
+    },
+    {
+      "name": "decimals",
+      "doc": "Return the number of decimal places used by the token.",
+      "params": [],
+      "outputs": [
+        { "type": "u32", "doc": "Decimal precision (e.g. 7 for most Stellar assets)." }
+      ]
+    },
+    {
+      "name": "name",
+      "doc": "Return the human-readable name of the token.",
+      "params": [],
+      "outputs": [
+        { "type": "String", "doc": "Token name (e.g. 'USD Coin')." }
+      ]
+    },
+    {
+      "name": "symbol",
+      "doc": "Return the ticker symbol of the token.",
+      "params": [],
+      "outputs": [
+        { "type": "String", "doc": "Token symbol (e.g. 'USDC')." }
+      ]
+    },
+    {
+      "name": "total_supply",
+      "doc": "Return the total token supply currently in circulation.",
+      "params": [],
+      "outputs": [
+        { "type": "i128", "doc": "Total supply scaled by decimals." }
+      ]
+    },
+    {
+      "name": "mint",
+      "doc": "Mint `amount` tokens to `to`. Requires admin authorization.",
+      "params": [
+        { "name": "to",     "type": "Address", "doc": "Recipient of the newly minted tokens." },
+        { "name": "amount", "type": "i128",    "doc": "Amount to mint." }
+      ],
+      "outputs": []
+    },
+    {
+      "name": "burn",
+      "doc": "Burn `amount` tokens from `from`. Requires authorization from `from`.",
+      "params": [
+        { "name": "from",   "type": "Address", "doc": "Account whose tokens are burned." },
+        { "name": "amount", "type": "i128",    "doc": "Amount to burn." }
+      ],
+      "outputs": []
+    },
+    {
+      "name": "burn_from",
+      "doc": "Burn `amount` tokens from `from` using a pre-approved allowance. Requires authorization from `spender`.",
+      "params": [
+        { "name": "spender", "type": "Address", "doc": "Address consuming the allowance." },
+        { "name": "from",    "type": "Address", "doc": "Account whose tokens are burned." },
+        { "name": "amount",  "type": "i128",    "doc": "Amount to burn." }
+      ],
+      "outputs": []
+    },
+    {
+      "name": "clawback",
+      "doc": "Clawback `amount` tokens from `from`. Only callable by the admin on assets with clawback enabled.",
+      "params": [
+        { "name": "from",   "type": "Address", "doc": "Account from which tokens are clawed back." },
+        { "name": "amount", "type": "i128",    "doc": "Amount to clawback." }
+      ],
+      "outputs": []
+    },
+    {
+      "name": "set_authorized",
+      "doc": "Set the authorization flag for `id`. Requires admin authorization.",
+      "params": [
+        { "name": "id",         "type": "Address", "doc": "Account whose authorization flag is being set." },
+        { "name": "authorize",  "type": "bool",    "doc": "True to authorize, false to deauthorize." }
+      ],
+      "outputs": []
+    },
+    {
+      "name": "authorized",
+      "doc": "Return whether `id` is authorized to hold and transfer the token.",
+      "params": [
+        { "name": "id", "type": "Address", "doc": "Account to query." }
+      ],
+      "outputs": [
+        { "type": "bool", "doc": "True if authorized." }
+      ]
+    },
+    {
+      "name": "set_admin",
+      "doc": "Transfer admin rights to `new_admin`. Requires current admin authorization.",
+      "params": [
+        { "name": "new_admin", "type": "Address", "doc": "Address that will become the new admin." }
+      ],
+      "outputs": []
+    },
+    {
+      "name": "admin",
+      "doc": "Return the current admin address.",
+      "params": [],
+      "outputs": [
+        { "type": "Address", "doc": "Current admin address." }
+      ]
+    }
+  ]
+}

--- a/packages/abi-registry/specs/well-known/schema.json
+++ b/packages/abi-registry/specs/well-known/schema.json
@@ -1,0 +1,96 @@
+{
+  "title": "OrbitalABISpec",
+  "description": "Schema for a single Orbital ABI Registry contract spec.",
+  "type": "object",
+  "required": ["version", "name", "description", "contract_id", "network", "source", "functions"],
+  "additionalProperties": false,
+  "properties": {
+    "version": {
+      "type": "string",
+      "description": "Spec revision in MAJOR.MINOR.PATCH semver format.",
+      "pattern": "^\\d+\\.\\d+\\.\\d+$"
+    },
+    "name": {
+      "type": "string",
+      "description": "Human-readable contract name.",
+      "minLength": 1,
+      "maxLength": 100
+    },
+    "description": {
+      "type": "string",
+      "description": "Short description of the contract's purpose.",
+      "minLength": 1,
+      "maxLength": 500
+    },
+    "contract_id": {
+      "type": "string",
+      "description": "Canonical mainnet Soroban contract address (C-prefixed strkey, 56 characters).",
+      "pattern": "^C[A-Z2-7]{55}$"
+    },
+    "network": {
+      "type": "string",
+      "description": "Stellar network this spec targets.",
+      "enum": ["mainnet", "testnet", "futurenet"]
+    },
+    "source": {
+      "type": "string",
+      "description": "URL or reference identifying where the interface definition was obtained.",
+      "minLength": 1,
+      "maxLength": 2048
+    },
+    "tags": {
+      "type": "array",
+      "description": "Optional classification tags (e.g. 'sep41', 'sac', 'stablecoin').",
+      "items": { "type": "string" },
+      "uniqueItems": true
+    },
+    "functions": {
+      "type": "array",
+      "description": "List of callable contract functions.",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["name", "params", "outputs"],
+        "additionalProperties": false,
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Function name as it appears in the contract ABI.",
+            "minLength": 1
+          },
+          "doc": {
+            "type": "string",
+            "description": "Optional human-readable description of what the function does."
+          },
+          "params": {
+            "type": "array",
+            "description": "Ordered list of input parameters.",
+            "items": {
+              "type": "object",
+              "required": ["name", "type"],
+              "additionalProperties": false,
+              "properties": {
+                "name": { "type": "string", "minLength": 1 },
+                "type": { "type": "string", "minLength": 1 },
+                "doc": { "type": "string" }
+              }
+            }
+          },
+          "outputs": {
+            "type": "array",
+            "description": "Ordered list of return values (empty array for void functions).",
+            "items": {
+              "type": "object",
+              "required": ["type"],
+              "additionalProperties": false,
+              "properties": {
+                "type": { "type": "string", "minLength": 1 },
+                "doc": { "type": "string" }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/abi-registry/specs/well-known/usdc.json
+++ b/packages/abi-registry/specs/well-known/usdc.json
@@ -1,0 +1,168 @@
+{
+  "version": "1.0.0",
+  "name": "USD Coin (USDC)",
+  "description": "Circle's USD-backed stablecoin on Stellar mainnet, deployed as a Stellar Asset Contract (SAC). Implements the full SEP-41 token interface. Always redeemable 1:1 for US dollars under a full-reserve model.",
+  "contract_id": "CCW67TSZV3SSS2HXMBQ5JFGCKJNXKZM7UQUWUZPUTHXSTZLEO7SJMI75",
+  "network": "mainnet",
+  "source": "https://developers.circle.com/stablecoins/usdc-contract-addresses",
+  "tags": ["sep41", "sac", "stablecoin", "usd", "circle"],
+  "functions": [
+    {
+      "name": "transfer",
+      "doc": "Transfer `amount` USDC from `from` to `to`. Requires authorization from `from`.",
+      "params": [
+        { "name": "from",   "type": "Address", "doc": "Source account or contract address." },
+        { "name": "to",     "type": "Address", "doc": "Destination account or contract address." },
+        { "name": "amount", "type": "i128",    "doc": "Amount in USDC base units (7 decimal places; 1 USDC = 10,000,000)." }
+      ],
+      "outputs": []
+    },
+    {
+      "name": "transfer_from",
+      "doc": "Transfer `amount` USDC from `from` to `to` using a pre-approved allowance. Requires authorization from `spender`.",
+      "params": [
+        { "name": "spender", "type": "Address", "doc": "Address that was granted the allowance." },
+        { "name": "from",    "type": "Address", "doc": "Source account whose allowance is consumed." },
+        { "name": "to",      "type": "Address", "doc": "Destination account or contract address." },
+        { "name": "amount",  "type": "i128",    "doc": "Amount in USDC base units." }
+      ],
+      "outputs": []
+    },
+    {
+      "name": "approve",
+      "doc": "Approve `spender` to transfer up to `amount` USDC from the caller's balance.",
+      "params": [
+        { "name": "from",              "type": "Address", "doc": "Token owner granting the allowance." },
+        { "name": "spender",           "type": "Address", "doc": "Address being granted the allowance." },
+        { "name": "amount",            "type": "i128",    "doc": "Maximum transferable amount in USDC base units." },
+        { "name": "expiration_ledger", "type": "u32",     "doc": "Ledger sequence number at which the allowance expires." }
+      ],
+      "outputs": []
+    },
+    {
+      "name": "allowance",
+      "doc": "Return the remaining allowance that `spender` may transfer from `from`.",
+      "params": [
+        { "name": "from",    "type": "Address", "doc": "Token owner." },
+        { "name": "spender", "type": "Address", "doc": "Approved spender." }
+      ],
+      "outputs": [
+        { "type": "i128", "doc": "Remaining allowance in USDC base units." }
+      ]
+    },
+    {
+      "name": "balance",
+      "doc": "Return the USDC balance of `id`.",
+      "params": [
+        { "name": "id", "type": "Address", "doc": "Account or contract address to query." }
+      ],
+      "outputs": [
+        { "type": "i128", "doc": "Balance in USDC base units." }
+      ]
+    },
+    {
+      "name": "decimals",
+      "doc": "Return the number of decimal places. Always 7 for Stellar-native USDC.",
+      "params": [],
+      "outputs": [
+        { "type": "u32", "doc": "Always 7." }
+      ]
+    },
+    {
+      "name": "name",
+      "doc": "Return the token name.",
+      "params": [],
+      "outputs": [
+        { "type": "String", "doc": "Always 'USD Coin'." }
+      ]
+    },
+    {
+      "name": "symbol",
+      "doc": "Return the token symbol.",
+      "params": [],
+      "outputs": [
+        { "type": "String", "doc": "Always 'USDC'." }
+      ]
+    },
+    {
+      "name": "total_supply",
+      "doc": "Return the total USDC supply currently in circulation on Stellar.",
+      "params": [],
+      "outputs": [
+        { "type": "i128", "doc": "Total supply in USDC base units." }
+      ]
+    },
+    {
+      "name": "mint",
+      "doc": "Mint `amount` USDC to `to`. Requires admin (Circle issuer) authorization.",
+      "params": [
+        { "name": "to",     "type": "Address", "doc": "Recipient of the newly minted USDC." },
+        { "name": "amount", "type": "i128",    "doc": "Amount to mint in USDC base units." }
+      ],
+      "outputs": []
+    },
+    {
+      "name": "burn",
+      "doc": "Burn `amount` USDC from `from`. Requires authorization from `from`.",
+      "params": [
+        { "name": "from",   "type": "Address", "doc": "Account whose USDC is burned." },
+        { "name": "amount", "type": "i128",    "doc": "Amount to burn in USDC base units." }
+      ],
+      "outputs": []
+    },
+    {
+      "name": "burn_from",
+      "doc": "Burn `amount` USDC from `from` using a pre-approved allowance.",
+      "params": [
+        { "name": "spender", "type": "Address", "doc": "Address consuming the allowance." },
+        { "name": "from",    "type": "Address", "doc": "Account whose USDC is burned." },
+        { "name": "amount",  "type": "i128",    "doc": "Amount to burn in USDC base units." }
+      ],
+      "outputs": []
+    },
+    {
+      "name": "clawback",
+      "doc": "Clawback `amount` USDC from `from`. Only callable by the admin on assets with clawback enabled.",
+      "params": [
+        { "name": "from",   "type": "Address", "doc": "Account from which USDC is clawed back." },
+        { "name": "amount", "type": "i128",    "doc": "Amount to clawback in USDC base units." }
+      ],
+      "outputs": []
+    },
+    {
+      "name": "set_authorized",
+      "doc": "Set the authorization flag for `id`. Requires admin authorization.",
+      "params": [
+        { "name": "id",        "type": "Address", "doc": "Account whose authorization flag is being set." },
+        { "name": "authorize", "type": "bool",    "doc": "True to authorize, false to deauthorize." }
+      ],
+      "outputs": []
+    },
+    {
+      "name": "authorized",
+      "doc": "Return whether `id` is authorized to hold and transfer USDC.",
+      "params": [
+        { "name": "id", "type": "Address", "doc": "Account to query." }
+      ],
+      "outputs": [
+        { "type": "bool", "doc": "True if authorized." }
+      ]
+    },
+    {
+      "name": "set_admin",
+      "doc": "Transfer admin rights to `new_admin`. Requires current admin authorization.",
+      "params": [
+        { "name": "new_admin", "type": "Address", "doc": "Address that will become the new admin." }
+      ],
+      "outputs": []
+    },
+    {
+      "name": "admin",
+      "doc": "Return the current admin address.",
+      "params": [],
+      "outputs": [
+        { "type": "Address", "doc": "Current admin address (Circle issuer account)." }
+      ]
+    }
+  ]
+}

--- a/packages/abi-registry/validate.js
+++ b/packages/abi-registry/validate.js
@@ -1,0 +1,97 @@
+/**
+ * validate.js — Validates all well-known ABI spec files against schema.json.
+ *
+ * Usage:
+ *   node validate.js
+ *
+ * Exit codes:
+ *   0  All specs pass validation.
+ *   1  One or more specs fail validation, or a file cannot be read/parsed.
+ */
+
+import { readFileSync, readdirSync } from "node:fs";
+import { resolve, dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import Ajv from "ajv";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const SCHEMA_PATH = resolve(__dirname, "specs/well-known/schema.json");
+const SPECS_DIR   = resolve(__dirname, "specs/well-known");
+
+// Files that are not contract specs and should be skipped.
+const SKIP = new Set(["schema.json", "index.json"]);
+
+// ---------------------------------------------------------------------------
+// Load schema
+// ---------------------------------------------------------------------------
+let schema;
+try {
+  schema = JSON.parse(readFileSync(SCHEMA_PATH, "utf8"));
+} catch (err) {
+  process.stderr.write(`[validate] Cannot read schema: ${SCHEMA_PATH}\n  ${err.message}\n`);
+  process.exit(1);
+}
+
+const ajv = new Ajv({ allErrors: true });
+const validate = ajv.compile(schema);
+
+// ---------------------------------------------------------------------------
+// Discover spec files
+// ---------------------------------------------------------------------------
+let files;
+try {
+  files = readdirSync(SPECS_DIR)
+    .filter((f) => f.endsWith(".json") && !SKIP.has(f))
+    .sort();
+} catch (err) {
+  process.stderr.write(`[validate] Cannot read specs directory: ${SPECS_DIR}\n  ${err.message}\n`);
+  process.exit(1);
+}
+
+if (files.length === 0) {
+  process.stderr.write(`[validate] No spec files found in ${SPECS_DIR}\n`);
+  process.exit(1);
+}
+
+// ---------------------------------------------------------------------------
+// Validate each spec
+// ---------------------------------------------------------------------------
+let passed = 0;
+let failed = 0;
+
+for (const file of files) {
+  const filePath = join(SPECS_DIR, file);
+  let data;
+
+  try {
+    data = JSON.parse(readFileSync(filePath, "utf8"));
+  } catch (err) {
+    process.stderr.write(`[validate] FAIL  ${file}\n  Parse error: ${err.message}\n`);
+    failed++;
+    continue;
+  }
+
+  const valid = validate(data);
+
+  if (valid) {
+    process.stdout.write(`[validate] PASS  ${file}\n`);
+    passed++;
+  } else {
+    process.stderr.write(`[validate] FAIL  ${file}\n`);
+    for (const error of validate.errors) {
+      const field = error.instancePath || "(root)";
+      process.stderr.write(`  ${field}: ${error.message}\n`);
+    }
+    failed++;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Summary
+// ---------------------------------------------------------------------------
+process.stdout.write(`\n[validate] ${passed} passed, ${failed} failed (${files.length} total)\n`);
+
+if (failed > 0) {
+  process.exit(1);
+}


### PR DESCRIPTION
Closes: #364

Problem
Consumers integrating USDC, EURC, or other widely-used Stellar tokens had to locate or author the ABI spec themselves. No pre-seeded specs shipped with the registry, making adoption harder than it needed to be.

Changes
usdc.json
 (new) Circle USDC on Stellar mainnet — contract CCW67TSZV3SSS2HXMBQ5JFGCKJNXKZM7UQUWUZPUTHXSTZLEO7SJMI75. Full SEP-41 token interface: transfer, transfer_from, approve, allowance, balance, decimals, name, symbol, total_supply, mint, burn, burn_from, clawback, set_authorized, authorized, set_admin, admin.

eurc.json
 (new) Circle EURC on Stellar mainnet — contract CDTKPWPLOURQA2SGTKTUQOWRCBZEORB4BWBOMJ3D3ZTQQSGE5F6JBQLV. Same SEP-41 surface as USDC. MiCA-compliant EUR stablecoin.

aqua.json
 (new) Aquarius AQUA governance token — contract CAUIKL3IYGMERDRUN5QQVPKPLZTRNVXV27LFCWQIRNOHSNGB3ZXAEFBX. Full SEP-41 interface.

native-asset-wrapper.json
 (new) XLM Stellar Asset Contract — contract CAS3J7GYLGXMF6TDJBBYYSE3HQ6BBSMLNUQ34T6TZMYMW2EVH34XOWMA. 10 functions — correctly omits mint, burn, burn_from, clawback, set_authorized, set_admin which are unavailable on the native asset.

sac-interface.json
 (new) Reference SAC / SEP-41 interface shared by all Stellar Asset Contracts. 17 functions. Useful as a template for deriving per-asset specs.

schema.json
 (new) JSON Schema all well-known specs must conform to. Validates version, name, description, contract_id (C-prefixed strkey pattern), network, source, and functions.

index.json
 (new) Machine-readable index listing all five specs with name, contract_id, file, description, and tags.

README.md
 (new) Curation policy covering:

Eligibility criteria (mainnet deployment, public interface, 3+ integrations or 10k+ transactions, stable interface)
How to add, update, and deprecate a spec
Validation workflow and exit codes
validate.js
 (new) CLI validator — discovers all JSON files in specs/well-known/, runs AJV against schema.json, prints PASS/FAIL per file, exits 1 on any failure. Used in CI.

Validation


node validate.js

[validate] PASS  aqua.json
[validate] PASS  eurc.json
[validate] PASS  native-asset-wrapper.json
[validate] PASS  sac-interface.json
[validate] PASS  usdc.json

5 passed, 0 failed (5 total)