### PR TITLE
docs: document abi registry package

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 **Stellar's biggest developer-experience gap isn't a missing API — it's that Horizon's firehose still requires every team to build their own event delivery.**
 
-Orbital ships that delivery layer once, openly: a typed event engine that normalizes Horizon output into application-shaped events, HMAC-signed webhook delivery with retry and edge-runtime verification, and React hooks for live data in the browser. Three MIT-licensed packages, designed to be composed.
+Orbital ships that delivery layer once, openly: a typed event engine that normalizes Horizon output into application-shaped events, HMAC-signed webhook delivery with retry and edge-runtime verification, a shared ABI registry for Soroban schemas, and React hooks for live data in the browser. Four MIT-licensed packages, designed to be composed.
 
 ---
 
@@ -52,6 +52,7 @@ The longer-form thesis, the multi-year vision, and the SCF grant case live in [`
 | [`@orbital/pulse-core`](./packages/pulse-core) | EventEngine — Horizon subscription, normalization, reconnection, rate-limit handling | ✅ Phase 0 |
 | [`@orbital/pulse-webhooks`](./packages/pulse-webhooks) | HMAC-signed webhook delivery + verification (Node + edge runtimes) | ✅ Phase 0 |
 | [`@orbital/pulse-notify`](./packages/pulse-notify) | React hooks — `useStellarEvent`, `useStellarPayment`, `useStellarActivity` | ✅ Phase 0 |
+| [`@orbital/abi-registry`](./packages/abi-registry) | Canonical Soroban ABI client, schema helpers, and registry publisher interface | ✅ Phase 1 |
 
 > The full classic-operation taxonomy is shipped (payments, account create/merge/options/bump-sequence, trustlines + auth, offers, claimables, liquidity pools, manage-data). Soroban contract events are Phase 1 (Q2–Q3 2026) — see [`ROADMAP.md`](ROADMAP.md).
 
@@ -185,6 +186,7 @@ The reference composition — a Next.js route handler that subscribes to an addr
 | [`packages/pulse-core/README.md`](packages/pulse-core/README.md) | EventEngine API, event taxonomy, configuration |
 | [`packages/pulse-webhooks/README.md`](packages/pulse-webhooks/README.md) | Delivery contract, verification, SSRF safety |
 | [`packages/pulse-notify/README.md`](packages/pulse-notify/README.md) | React hooks, type narrowing, authentication |
+| [`packages/abi-registry/README.md`](packages/abi-registry/README.md) | ABI Registry client, publisher interface, and shared schema helpers |
 | [`apps/web/README.md`](apps/web/README.md) | Marketing site + sandboxed demo API routes |
 
 ---

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -90,12 +90,26 @@ together inside a single Next.js route handler — about 50 lines of glue.
 | **`WebhookDelivery`** | Attaches to a `Watcher`, signs each event, POSTs it with retry + timeout + concurrent-retry cap. Emits `webhook.failed` / `webhook.dropped` on terminal failure. | `packages/pulse-webhooks/src/index.ts` | ✅ |
 | **`verifyWebhook`** | Node-side HMAC verifier using `crypto.timingSafeEqual`. | `packages/pulse-webhooks/src/index.ts` | ✅ |
 | **`verifyWebhookEdge`** | Edge-runtime HMAC verifier using Web Crypto API + constant-time XOR. | `packages/pulse-webhooks/src/edge.ts` | ✅ |
+| **`@orbital/abi-registry`** | Shared Soroban ABI package that exports the canonical registry client, publisher interface, and scval conversion helpers. | `packages/abi-registry/src/index.ts` | ✅ |
 | **`useStellarEvent<T>`** | React hook that opens an `EventSource`, parses incoming SSE messages, optionally filters by event type, and re-renders on each event. Stable dep-array via sorted `eventKey`. | `packages/pulse-notify/src/index.ts` | ✅ |
 | **`useStellarPayment` / `useStellarActivity`** | Convenience wrappers over `useStellarEvent`. | `packages/pulse-notify/src/index.ts` | ✅ |
 | **Reference composition** | A Next.js Node-runtime route handler that subscribes to an address and streams events as SSE; plus a `webhook-sample` route that returns an HMAC-signed payload for the demo. | `apps/web/app/api/events/[address]/route.ts`, `apps/web/app/api/webhook-sample/route.ts` | ✅ |
 | **Soroban subscriber** | Subscribes to Stellar RPC for contract events, decodes via the ABI Registry, normalizes into the same `NormalizedEvent` union. | `packages/pulse-core` (planned) | 🛠️ Phase 1 |
 | **Cursor persistence** | Pluggable durable store for the Horizon cursor so a process restart resumes from where it left off. | `packages/pulse-core` (planned) | 🛠️ Phase 1 |
 | **Replay adapters** | Pluggable durable queues (Redis / Postgres / S3) for in-flight webhook retries. | `packages/pulse-webhooks` (planned) | 🛠️ Phase 1 |
+
+---
+
+## 2.1 ABI Registry (`@orbital/abi-registry`)
+
+`@orbital/abi-registry` is the shared contract-interface package for Orbital.
+
+- It holds the canonical ABI client surface for Soroban event decoding and publishing.
+- It keeps ABI-related helpers in one place instead of duplicating schema logic in `pulse-core` or application code.
+- It exposes the registry-facing building blocks the rest of the repo consumes: `AbiRegistryClient`, `RegistryPublisher`, `LocalFilePublisher`, `scvalToJs`, and `jsToScval`.
+- It is the MIT package surface. The hosted registry service described in `docs/open-source-policy.md` is a separate product boundary.
+
+The package-level reference lives in [`packages/abi-registry/README.md`](../packages/abi-registry/README.md).
 
 ---
 
@@ -371,8 +385,8 @@ API:
   (`contract.invoked`, `contract.emitted`) join the `NormalizedEvent` union;
   existing consumers ignore them unless they subscribe.
 - **ABI Registry client.** Decodes Soroban event topics + data into typed,
-  human-readable JSON. Lives as a separate package (`@orbital/abi-registry`
-  TBD) so the registry data layer is independently versioned.
+  human-readable JSON. Lives in the separate `@orbital/abi-registry`
+  package so the registry data layer is independently versioned.
 - **Cursor persistence.** A pluggable `CursorStore` interface stored on
   `EventEngine` config. Implementations: in-memory (default, current
   behavior), local file, Redis, Postgres, S3. On reconnect, the engine

--- a/docs/open-source-policy.md
+++ b/docs/open-source-policy.md
@@ -60,6 +60,15 @@ Everything below is in `packages/` or `apps/` today, or will be added to one of 
 - Replay-queue **interface** + the in-memory reference adapter
 - Starter boilerplates (`orbital-next-starter`, `orbital-express-starter`, `orbital-anchor-starter`)
 
+### ABI Registry
+
+`@orbital/abi-registry` is the MIT package surface for Soroban ABI client code, schema helpers, and publishing interfaces.
+
+- Technical map: [`docs/ARCHITECTURE.md`](./ARCHITECTURE.md)
+- Package README: [`packages/abi-registry/README.md`](../packages/abi-registry/README.md)
+
+The hosted verification / publishing service remains a separate Cloud product. The schema, client, and decoder helpers in this repository stay open.
+
 ### Phase 2 (2027)
 
 - `@orbital/hooks` — `useAccount`, `useBalance`, `useTransaction`, `useOrderBook`

--- a/packages/abi-registry/README.md
+++ b/packages/abi-registry/README.md
@@ -1,0 +1,77 @@
+# @orbital/abi-registry
+
+**Shared Soroban ABI registry for Orbital.** This package holds the canonical client surface for ABI-aware code, along with schema helpers and publisher abstractions that keep Soroban integration logic consistent across the repo.
+
+```bash
+pnpm add @orbital/abi-registry
+```
+
+## What it does
+
+`abi-registry` is the package you use when you need to read, decode, publish, or reuse Soroban contract interface metadata without duplicating schema logic in application code.
+
+It is the shared boundary between:
+
+- ABI consumers in `pulse-core`
+- any future Soroban event subscriber or decoder
+- tooling that publishes or snapshots registry data
+
+If you are looking for the hosted verification / publishing service, that is a separate Cloud product. This package is the open-source schema and client surface.
+
+## Quickstart
+
+```ts
+import {
+  AbiRegistryClient,
+  LocalFilePublisher,
+  RegistryPublisher,
+  jsToScval,
+  scvalToJs,
+} from "@orbital/abi-registry";
+
+const client = new AbiRegistryClient({
+  baseUrl: "https://abi.example.com",
+});
+
+const spec = await client.getSpec("CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF");
+const specs = await client.getSpecs([
+  "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
+]);
+
+const encoded = jsToScval({ hello: "world" });
+const decoded = scvalToJs(encoded);
+
+const publisher: RegistryPublisher = new LocalFilePublisher();
+
+await publisher.publish({
+  contractId: "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
+  entries: [],
+});
+```
+
+## API
+
+### `AbiRegistryClient`
+
+Creates a cached client that fetches contract ABI specs from the configured registry endpoint. Use `getSpec(contractId)` for a single contract or `getSpecs(contractIds)` for batched lookups.
+
+### `RegistryPublisher`
+
+An interface for publishing registry snapshots or derived ABI artifacts.
+
+### `LocalFilePublisher`
+
+Reference publisher that writes registry output to the local filesystem. Useful for testing, debugging, and snapshots.
+
+### `jsToScval(value)` / `scvalToJs(value)`
+
+Helpers for converting between JavaScript values and Soroban `ScVal` payloads.
+
+## Related documents
+
+- [`docs/ARCHITECTURE.md`](../../docs/ARCHITECTURE.md) - where the registry sits in the system map
+- [`docs/open-source-policy.md`](../../docs/open-source-policy.md) - the public/private boundary for the registry service
+
+## License
+
+MIT


### PR DESCRIPTION
## Linked issue

Closes #367
Added @orbital/abi-registry to the architecture map and documented its role as the shared ABI client surface
Added the ABI Registry cross-link block to the open-source policy【/Users/USER/Desktop/wave/orbital_stellar/docs/open-source-policy.md†L57-L70】
Added the @orbital/abi-registry row to the root packages table and docs index
Created packages/abi-registry/README.md with the package surface, examples, and doc links
