### PR TITLE
Add: a decoded: Uint8Array | null sibling to DataEvent.value

### DIFF
--- a/packages/pulse-core/src/EventEngine.ts
+++ b/packages/pulse-core/src/EventEngine.ts
@@ -613,11 +613,21 @@ export class EventEngine {
     const value = r.data_value == null ? null : String(r.data_value);
     const type: DataEventType = value !== null ? "data.set" : "data.cleared";
 
+    let decoded: Uint8Array | null = null;
+    if (value !== null) {
+      try {
+        decoded = Buffer.from(value, "base64");
+      } catch (err) {
+        decoded = null;
+      }
+    }
+
     return {
       type,
       source: r.source_account,
       name: r.data_name,
       value,
+      decoded,
       timestamp: typeof r.created_at === "string" ? r.created_at : "",
       raw,
     };

--- a/packages/pulse-core/src/index.ts
+++ b/packages/pulse-core/src/index.ts
@@ -20,7 +20,9 @@ export type PaymentEventType =
 /** Event type for account options changes. */
 export type AccountOptionsEventType = "account.options_changed";
 export type LiquidityPoolEventType = "lp.deposited" | "lp.withdrawn";
-export type TrustAuthEventType = "trustline.authorized" | "trustline.deauthorized";
+export type TrustAuthEventType =
+  | "trustline.authorized"
+  | "trustline.deauthorized";
 /** Event type for account creation. */
 export type AccountEventType = "account.created";
 export type ClaimableCreatedEventType = "claimable.created";
@@ -39,7 +41,10 @@ export type WatcherNotificationType =
   | "engine.rate_limited"
   | "engine.stopped";
 
-export type OfferEventType = "offer.created" | "offer.updated" | "offer.deleted";
+export type OfferEventType =
+  | "offer.created"
+  | "offer.updated"
+  | "offer.deleted";
 export type BumpSequenceEventType = "account.bump_sequence";
 export type DataEventType = "data.set" | "data.cleared";
 
@@ -160,7 +165,10 @@ export type DataEvent = {
   type: DataEventType;
   source: string;
   name: string;
+  /** The raw base64-encoded value returned by Horizon, or null when cleared. */
   value: string | null;
+  /** The decoded bytes of `value` as a Uint8Array, or null when `value` is null or invalid base64. */
+  decoded: Uint8Array | null;
   timestamp: string;
   raw: unknown;
 };


### PR DESCRIPTION
closes #332

DataEvent.value already exposed the raw Horizon base64 string for manage-data operations, but consumers had to decode it themselves every time. This PR adds a decoded field alongside value populated at normalisation time by Buffer.from(value, "base64"), falling back to null if the value is absent or the base64 is malformed. The DataEvent type in index.ts is updated with JSDoc comments distinguishing the two fields. No breaking changes  value is untouched.