### PR TITLE
Add: S3CursorStore reference adapter

### DIFF
--- a/packages/pulse-core/src/S3CursorStore.ts
+++ b/packages/pulse-core/src/S3CursorStore.ts
@@ -1,0 +1,64 @@
+export type S3Like = {
+  getObject(params: {
+    Bucket: string;
+    Key: string;
+  }): Promise<{ Body: string | Uint8Array }>;
+  putObject(params: {
+    Bucket: string;
+    Key: string;
+    Body: string | Uint8Array;
+  }): Promise<void>;
+};
+
+export class S3CursorStore {
+  private readonly s3: S3Like;
+  private readonly bucket: string;
+  private readonly prefix: string;
+
+  constructor(s3: S3Like, bucket: string, prefix = "cursors/") {
+    this.s3 = s3;
+    this.bucket = bucket;
+    this.prefix = prefix;
+  }
+
+  private keyFor(streamKey: string): string {
+    return `${this.prefix}${streamKey}.json`;
+  }
+
+  async getCursor(streamKey: string): Promise<string | null> {
+    const Key = this.keyFor(streamKey);
+    try {
+      const res = await this.s3.getObject({ Bucket: this.bucket, Key });
+      const body = res.Body;
+      const text =
+        typeof body === "string" ? body : Buffer.from(body).toString();
+      try {
+        const parsed = JSON.parse(text as string);
+        if (parsed && typeof parsed.cursor === "string") return parsed.cursor;
+        return null;
+      } catch (err) {
+        // If the object isn't JSON, treat as null / invalid
+        return null;
+      }
+    } catch (err: any) {
+      // Treat NoSuchKey as missing value
+      if (
+        err &&
+        (err.code === "NoSuchKey" ||
+          err.name === "NoSuchKey" ||
+          err.code === "NoSuchKeyException")
+      ) {
+        return null;
+      }
+      throw err;
+    }
+  }
+
+  async putCursor(streamKey: string, cursor: string): Promise<void> {
+    const Key = this.keyFor(streamKey);
+    const Body = JSON.stringify({ cursor });
+    await this.s3.putObject({ Bucket: this.bucket, Key, Body });
+  }
+}
+
+export default S3CursorStore;

--- a/packages/pulse-core/test/S3CursorStore.test.ts
+++ b/packages/pulse-core/test/S3CursorStore.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from "vitest";
+import { S3CursorStore, S3Like } from "../src/S3CursorStore.js";
+
+function makeMockS3(): { s3: S3Like; _store: Map<string, string> } {
+  const store = new Map<string, string>();
+  const s3: S3Like = {
+    async getObject({ Bucket, Key }) {
+      if (!store.has(Key)) {
+        const e: any = new Error("NoSuchKey");
+        e.code = "NoSuchKey";
+        throw e;
+      }
+      return { Body: store.get(Key)! };
+    },
+    async putObject({ Bucket, Key, Body }) {
+      const text =
+        typeof Body === "string" ? Body : Buffer.from(Body).toString();
+      store.set(Key, text);
+    },
+  };
+  return { s3, _store: store };
+}
+
+describe("S3CursorStore", () => {
+  it("round-trips cursor values", async () => {
+    const { s3 } = makeMockS3();
+    const store = new S3CursorStore(s3, "my-bucket");
+
+    expect(await store.getCursor("stream1")).toBeNull();
+
+    await store.putCursor("stream1", "CURSOR_123");
+
+    const got = await store.getCursor("stream1");
+    expect(got).toBe("CURSOR_123");
+  });
+
+  it("treats NoSuchKey as null", async () => {
+    const { s3 } = makeMockS3();
+    const store = new S3CursorStore(s3, "b");
+
+    // No objects present -> returns null
+    await expect(store.getCursor("missing")).resolves.toBeNull();
+  });
+
+  it("throws for other S3 errors", async () => {
+    const storeMap = new Map<string, string>();
+    const s3: S3Like = {
+      async getObject() {
+        const e: any = new Error("Bad");
+        e.code = "SomeOtherError";
+        throw e;
+      },
+      async putObject() {
+        // noop
+      },
+    };
+
+    const store = new S3CursorStore(s3, "b");
+    await expect(store.getCursor("any")).rejects.toThrow("Bad");
+  });
+});


### PR DESCRIPTION
closes #340

This Pr Introduces S3CursorStore, a CursorStore implementation that persists stream cursors to an S3-compatible bucket. It depends on an S3Like interface (duck-typed, so it works with AWS SDK v2, v3, MinIO, etc.) rather than a concrete SDK. Cursors are stored as { cursor: string } JSON objects under a configurable key prefix (cursors/<streamKey>.json). getCursor() gracefully handles NoSuchKey by returning null (first-run safe), while re-throwing all other S3 errors. putCursor() serialises and writes atomically via putObject. Tests use an in-memory mock S3 and cover round-trips, missing-key → null, and non-NoSuchKey error propagation.