### PR TITLE
feat(pulse-core): add CursorStore interface and MemoryCursorStore ada…

### DIFF
--- a/packages/pulse-core/src/CursorStore.ts
+++ b/packages/pulse-core/src/CursorStore.ts
@@ -1,0 +1,15 @@
+/**
+ * Pluggable durable store interface for the Horizon stream cursor.
+ */
+export interface CursorStore {
+  /**
+   * Retrieves the stored cursor for a given stream key.
+   * Returns null if no cursor has been stored yet.
+   */
+  get(streamKey: string): Promise<string | null>;
+
+  /**
+   * Stores or updates the cursor for a given stream key.
+   */
+  set(streamKey: string, cursor: string): Promise<void>;
+}

--- a/packages/pulse-core/src/MemoryCursorStore.ts
+++ b/packages/pulse-core/src/MemoryCursorStore.ts
@@ -1,0 +1,13 @@
+import { CursorStore } from "./CursorStore";
+
+export class MemoryCursorStore implements CursorStore {
+  private store = new Map<string, string>();
+
+  async get(streamKey: string) {
+    return this.store.get(streamKey);
+  }
+
+  async set(streamKey: string, cursor: string) {
+    this.store.set(streamKey, cursor);
+  }
+}

--- a/packages/pulse-core/src/index.ts
+++ b/packages/pulse-core/src/index.ts
@@ -2,6 +2,8 @@ export { EventEngine } from "./EventEngine.js";
 export { Watcher } from "./Watcher.js";
 export { EngineAlreadyStartedError } from "./errors.js";
 export { StrKey } from "@stellar/stellar-sdk";
+export { CursorStore } from "./CursorStore.js";
+export { MemoryCursorStore } from "./MemoryCursorStore.js";
 
 /** The Stellar network to connect to. */
 export type Network = "mainnet" | "testnet";
@@ -14,7 +16,9 @@ export type PaymentEventType =
 /** Event type for account options changes. */
 export type AccountOptionsEventType = "account.options_changed";
 export type LiquidityPoolEventType = "lp.deposited" | "lp.withdrawn";
-export type TrustAuthEventType = "trustline.authorized" | "trustline.deauthorized";
+export type TrustAuthEventType =
+  | "trustline.authorized"
+  | "trustline.deauthorized";
 /** Event type for account creation. */
 export type AccountEventType = "account.created";
 export type ClaimableCreatedEventType = "claimable.created";
@@ -33,7 +37,10 @@ export type WatcherNotificationType =
   | "engine.rate_limited"
   | "engine.stopped";
 
-export type OfferEventType = "offer.created" | "offer.updated" | "offer.deleted";
+export type OfferEventType =
+  | "offer.created"
+  | "offer.updated"
+  | "offer.deleted";
 export type BumpSequenceEventType = "account.bump_sequence";
 export type DataEventType = "data.set" | "data.cleared";
 

--- a/packages/pulse-core/test/MemoryCursorStore.test.ts
+++ b/packages/pulse-core/test/MemoryCursorStore.test.ts
@@ -1,0 +1,13 @@
+import { MemoryCursorStore } from "../src/MemoryCursorStore";
+
+describe("MemoryCursorStore", () => {
+  it("should store and retrieve cursor", async () => {
+    const store = new MemoryCursorStore();
+
+    await store.set("stream-1", "cursor-123");
+
+    const result = await store.get("stream-1");
+
+    expect(result).toBe("cursor-123");
+  });
+});


### PR DESCRIPTION
#closes #295 
## Summary
Adds a pluggable `CursorStore` interface for durable Horizon stream cursor persistence, along with an in-memory `MemoryCursorStore` adapter implementation.

## Changes
- **packages/pulse-core/src/CursorStore.ts**: New `CursorStore` interface with `get()` and `set()` methods for cursor persistence
- **packages/pulse-core/src/MemoryCursorStore.ts**: In-memory implementation using a Map for cursor storage
- **packages/pulse-core/test/MemoryCursorStore.test.ts**: Basic test for MemoryCursorStore
- **packages/pulse-core/src/index.ts**: Exports `CursorStore` and `MemoryCursorStore`

## Issue
Resolves #295

## Testing
- Added basic test for MemoryCursorStore to verify cursor storage and retrieval

#closes 