### PR TITLE
fix(ci): add missing pulse-notify size script so bundle-size job passes

### DIFF
--- a/packages/pulse-notify/package.json
+++ b/packages/pulse-notify/package.json
@@ -22,7 +22,8 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "test": "vitest run",
-    "test:coverage": "vitest run --coverage"
+    "test:coverage": "vitest run --coverage",
+    "size": "size-limit"
   },
   "dependencies": {
     "@orbital/pulse-core": "workspace:*"


### PR DESCRIPTION
The `bundle-size` CI job runs `pnpm --filter @orbital/pulse-notify size`, but pulse-notify had no `size` script — so the job failed the moment the (now-repaired) `ci.yml` workflow started actually running. The `.size-limit.json` config and `@size-limit/preset-small-lib` dep were already in place; adding `"size": "size-limit"` makes it pass. Verified locally: **2.71 kB gzipped, under the 5 kB limit**.