### PR TITLE
chore: rename npm scope @orbital -> @orbital-stellar

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,7 +7,7 @@ assignees: ''
 ---
 
 **Package / area**
-Which package or app is affected? (e.g. `@orbital/pulse-core`, `@orbital/pulse-webhooks`, `@orbital/pulse-notify`, `apps/web`)
+Which package or app is affected? (e.g. `@orbital-stellar/pulse-core`, `@orbital-stellar/pulse-webhooks`, `@orbital-stellar/pulse-notify`, `apps/web`)
 
 **Describe the bug**
 A clear description of what is wrong and what you expected to happen instead.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -23,7 +23,7 @@ Describe the API or behaviour change you have in mind. If you have a specific in
 What workarounds have you tried? Why don't they work for you?
 
 **Package / area affected**
-Which part of the codebase would this touch? (e.g. `@orbital/pulse-core`, `@orbital/pulse-notify`)
+Which part of the codebase would this touch? (e.g. `@orbital-stellar/pulse-core`, `@orbital-stellar/pulse-notify`)
 
 **Additional context**
 Links, prior art in similar projects, Stellar SEPs, etc.

--- a/.kiro/specs/coalesce-cursor-store/design.md
+++ b/.kiro/specs/coalesce-cursor-store/design.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-`coalesceCursorStore` is a write-coalescing decorator for any `CursorStore` implementation in `@orbital/pulse-core`. High-throughput Stellar event engines call `set` after every processed event; stores like Postgres and S3 charge per write, making per-event persistence expensive. The wrapper buffers all writes in an in-memory `Map` (the PendingBuffer) and drains it to the underlying store on a configurable `setInterval` timer, reducing N writes per interval to at most one `setMany` call.
+`coalesceCursorStore` is a write-coalescing decorator for any `CursorStore` implementation in `@orbital-stellar/pulse-core`. High-throughput Stellar event engines call `set` after every processed event; stores like Postgres and S3 charge per write, making per-event persistence expensive. The wrapper buffers all writes in an in-memory `Map` (the PendingBuffer) and drains it to the underlying store on a configurable `setInterval` timer, reducing N writes per interval to at most one `setMany` call.
 
 The wrapper is transparent to callers — it extends `CursorStore` and overrides all four read/write methods — and adds two lifecycle methods: `flush()` for graceful shutdown and `dispose()` to cancel the background timer. The maximum data-loss window on an unclean exit is bounded by `intervalMs`.
 

--- a/.kiro/specs/coalesce-cursor-store/tasks.md
+++ b/.kiro/specs/coalesce-cursor-store/tasks.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Implement `coalesceCursorStore`, a write-coalescing decorator for any `CursorStore` in `@orbital/pulse-core`. The implementation lives in a single new source file, is exported from the package index, and is covered by both example-based unit tests (with Vitest fake timers) and property-based tests (fast-check) for all 9 correctness properties defined in the design.
+Implement `coalesceCursorStore`, a write-coalescing decorator for any `CursorStore` in `@orbital-stellar/pulse-core`. The implementation lives in a single new source file, is exported from the package index, and is covered by both example-based unit tests (with Vitest fake timers) and property-based tests (fast-check) for all 9 correctness properties defined in the design.
 
 ## Tasks
 

--- a/.kiro/specs/cursor-store-batch-operations/design.md
+++ b/.kiro/specs/cursor-store-batch-operations/design.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-This feature extends the `CursorStore` abstraction in `@orbital/pulse-core` with optional batch methods — `getMany` and `setMany` — that allow multi-source engines to read and write N cursors in a single network or database round-trip instead of N sequential calls.
+This feature extends the `CursorStore` abstraction in `@orbital-stellar/pulse-core` with optional batch methods — `getMany` and `setMany` — that allow multi-source engines to read and write N cursors in a single network or database round-trip instead of N sequential calls.
 
 The design follows three principles:
 

--- a/.kiro/specs/cursor-store-batch-operations/requirements.md
+++ b/.kiro/specs/cursor-store-batch-operations/requirements.md
@@ -84,10 +84,10 @@ Multi-source engines (e.g., engines watching multiple Stellar addresses simultan
 
 ### Requirement 6: Batch Methods Are Exported from pulse-core Public API
 
-**User Story:** As a consumer of the `@orbital/pulse-core` package, I want `getMany` and `setMany` to be part of the exported `CursorStore` type, so that I can use them without importing internal modules.
+**User Story:** As a consumer of the `@orbital-stellar/pulse-core` package, I want `getMany` and `setMany` to be part of the exported `CursorStore` type, so that I can use them without importing internal modules.
 
 #### Acceptance Criteria
 
-1. THE `@orbital/pulse-core` package SHALL export the updated `CursorStore` abstract base class — including the `getMany(keys: string[]): Promise<Record<string, string | null>>` and `setMany(entries: Record<string, string>): Promise<void>` method signatures — from its public `index.ts`, without removing any previously exported symbols.
-2. THE `@orbital/pulse-core` package SHALL export the `RedisCursorStore` class and the `RedisLike` interface (as defined in the Glossary) from its public `index.ts` as named exports.
-3. WHEN a consumer imports `CursorStore` from `@orbital/pulse-core`, THE imported type SHALL include `getMany` and `setMany` method signatures resolvable by the TypeScript compiler without requiring any additional imports.
+1. THE `@orbital-stellar/pulse-core` package SHALL export the updated `CursorStore` abstract base class — including the `getMany(keys: string[]): Promise<Record<string, string | null>>` and `setMany(entries: Record<string, string>): Promise<void>` method signatures — from its public `index.ts`, without removing any previously exported symbols.
+2. THE `@orbital-stellar/pulse-core` package SHALL export the `RedisCursorStore` class and the `RedisLike` interface (as defined in the Glossary) from its public `index.ts` as named exports.
+3. WHEN a consumer imports `CursorStore` from `@orbital-stellar/pulse-core`, THE imported type SHALL include `getMany` and `setMany` method signatures resolvable by the TypeScript compiler without requiring any additional imports.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-This file rolls up changes across the public packages: `@orbital/pulse-core`,
-`@orbital/pulse-webhooks`, and `@orbital/pulse-notify`. Per-package changelogs
+This file rolls up changes across the public packages: `@orbital-stellar/pulse-core`,
+`@orbital-stellar/pulse-webhooks`, and `@orbital-stellar/pulse-notify`. Per-package changelogs
 live in each package directory.
 
 ## [Unreleased]
@@ -30,10 +30,10 @@ in Phase 1 (Q2–Q3 2026).
 
 ### Added
 
-- `@orbital/pulse-core`: `EventEngine` — Horizon SSE subscription with AWS
+- `@orbital-stellar/pulse-core`: `EventEngine` — Horizon SSE subscription with AWS
   Full-Jitter exponential backoff, automatic reconnection, and a per-address
   `Watcher` pub/sub model built on Node's `EventEmitter`.
-- `@orbital/pulse-core`: full classic operation taxonomy normalized into a
+- `@orbital-stellar/pulse-core`: full classic operation taxonomy normalized into a
   typed `NormalizedEvent` discriminated union:
   - Payments: `payment.received`, `payment.sent`, `payment.self`
   - Accounts: `account.created`, `account.merged`, `account.options_changed`,
@@ -44,55 +44,55 @@ in Phase 1 (Q2–Q3 2026).
   - Claimable balances: `claimable.created`, `claimable.claimed`
   - Liquidity pools: `lp.deposited`, `lp.withdrawn`
   - Data entries: `data.set`, `data.cleared`
-- `@orbital/pulse-core`: lifecycle notifications — `engine.reconnecting`,
+- `@orbital-stellar/pulse-core`: lifecycle notifications — `engine.reconnecting`,
   `engine.reconnected`, `engine.rate_limited` (with parsed `Retry-After`),
   and `engine.stopped`.
-- `@orbital/pulse-core`: `CoreConfig.horizonUrl` override for self-hosted
+- `@orbital-stellar/pulse-core`: `CoreConfig.horizonUrl` override for self-hosted
   Horizon nodes, regional mirrors, and futurenet.
-- `@orbital/pulse-core`: `EventEngine.unsubscribeAll()` to drain watchers
+- `@orbital-stellar/pulse-core`: `EventEngine.unsubscribeAll()` to drain watchers
   without closing the SSE stream.
-- `@orbital/pulse-core`: optional `filter` predicate on
+- `@orbital-stellar/pulse-core`: optional `filter` predicate on
   `EventEngine.subscribe()` for per-watcher event suppression.
-- `@orbital/pulse-webhooks`: `WebhookDelivery` with HMAC-SHA256 signing
+- `@orbital-stellar/pulse-webhooks`: `WebhookDelivery` with HMAC-SHA256 signing
   (`x-orbital-signature`, `x-orbital-timestamp`, `x-orbital-attempt`),
   exponential-backoff retry with jitter, per-attempt `AbortController`
   timeout, and a concurrent-retry cap.
-- `@orbital/pulse-webhooks`: `verifyWebhook` (Node `crypto`, timing-safe
+- `@orbital-stellar/pulse-webhooks`: `verifyWebhook` (Node `crypto`, timing-safe
   comparison) and `verifyWebhookEdge` (Web Crypto) for Cloudflare Workers,
   Vercel Edge, Deno, and browsers.
-- `@orbital/pulse-notify`: `useStellarEvent<T>` with generic type narrowing,
+- `@orbital-stellar/pulse-notify`: `useStellarEvent<T>` with generic type narrowing,
   positional and config-object call signatures, and stable dep-array keys
   for array event allowlists.
-- `@orbital/pulse-notify`: `useStellarPayment` and `useStellarActivity`
+- `@orbital-stellar/pulse-notify`: `useStellarPayment` and `useStellarActivity`
   convenience hooks.
-- `@orbital/pulse-core`: testnet + mainnet network selectors via
+- `@orbital-stellar/pulse-core`: testnet + mainnet network selectors via
   `network: "mainnet" | "testnet"`.
 
 ### Changed
 
-- `@orbital/pulse-core`: `EventEngine.start()` now returns a boolean
+- `@orbital-stellar/pulse-core`: `EventEngine.start()` now returns a boolean
   (`true` on a fresh start, `false` if the engine was already running). Pass
   `{ strict: true }` to throw `EngineAlreadyStartedError` instead.
-- `@orbital/pulse-core`: `WatcherNotification.timestamp` renamed to
+- `@orbital-stellar/pulse-core`: `WatcherNotification.timestamp` renamed to
   `emittedAt` to distinguish it from the on-chain `created_at` timestamp
   used in operation events.
-- `@orbital/pulse-core`: self-payments where `from === to` now emit a single
+- `@orbital-stellar/pulse-core`: self-payments where `from === to` now emit a single
   `payment.self` event instead of separate `payment.received` and
   `payment.sent` events.
 
 ### Fixed
 
-- `@orbital/pulse-webhooks`: cap concurrent retries to prevent unbounded
+- `@orbital-stellar/pulse-webhooks`: cap concurrent retries to prevent unbounded
   memory growth when consumer endpoints are unreachable.
-- `@orbital/pulse-core`: align reconnect attempt numbers across logs and
+- `@orbital-stellar/pulse-core`: align reconnect attempt numbers across logs and
   `engine.reconnecting` notifications.
-- `@orbital/pulse-core`: warn when listeners are added after `Watcher.stop()`.
+- `@orbital-stellar/pulse-core`: warn when listeners are added after `Watcher.stop()`.
 
 ### Security
 
-- `@orbital/pulse-webhooks`: timing-safe HMAC comparison via
+- `@orbital-stellar/pulse-webhooks`: timing-safe HMAC comparison via
   `crypto.timingSafeEqual` (Node) and constant-time XOR (Web Crypto).
-- `@orbital/pulse-webhooks`: SSRF hardening on delivery targets — private,
+- `@orbital-stellar/pulse-webhooks`: SSRF hardening on delivery targets — private,
   loopback, and link-local IP ranges are blocked by default, with DNS
   rebinding defense.
 - Strict TypeScript across all packages (`noUncheckedIndexedAccess`,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,12 +73,12 @@ pnpm test
 
 **Run tests for one package:**
 ```bash
-pnpm --filter @orbital/pulse-core test
+pnpm --filter @orbital-stellar/pulse-core test
 ```
 
 **Run tests in watch mode:**
 ```bash
-pnpm --filter @orbital/pulse-core exec vitest
+pnpm --filter @orbital-stellar/pulse-core exec vitest
 ```
 
 **Start the marketing/docs site:**
@@ -111,7 +111,7 @@ All packages use [Vitest](https://vitest.dev). Tests live in `packages/<name>/te
 
 - Write a test for every new public API.
 - Update existing tests when you change behaviour.
-- Coverage is tracked with `@vitest/coverage-v8`. Run `pnpm --filter @orbital/pulse-core test:coverage` to generate a report.
+- Coverage is tracked with `@vitest/coverage-v8`. Run `pnpm --filter @orbital-stellar/pulse-core test:coverage` to generate a report.
 
 CI runs tests on Node 20 and Node 22. Make sure your changes pass on both.
 

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -62,7 +62,7 @@ orbital_stellar/
 
 ## Core Packages
 
-### 1. `@orbital/pulse-core` — Event Engine
+### 1. `@orbital-stellar/pulse-core` — Event Engine
 
 Subscribes to Horizon SSE, normalizes raw operations into a typed `NormalizedEvent` taxonomy, and routes them to per-address `Watcher` instances. Handles reconnection, backoff, and rate-limit responses automatically.
 
@@ -70,7 +70,7 @@ Subscribes to Horizon SSE, normalizes raw operations into a typed `NormalizedEve
 
 See [`packages/pulse-core/README.md`](./packages/pulse-core/README.md) for the API and [`packages/pulse-core/CHANGELOG.md`](./packages/pulse-core/CHANGELOG.md) for the per-feature commit trail.
 
-### 2. `@orbital/pulse-webhooks` — Webhook Delivery
+### 2. `@orbital-stellar/pulse-webhooks` — Webhook Delivery
 
 Attaches to a `Watcher` and POSTs every event to one or more endpoints with HMAC-SHA256 signing, exponential backoff retry, configurable timeout, and SSRF hardening. `verifyWebhook` (Node) and `verifyWebhookEdge` (Web Crypto) are exported for the receiver side.
 
@@ -78,7 +78,7 @@ Attaches to a `Watcher` and POSTs every event to one or more endpoints with HMAC
 
 See [`packages/pulse-webhooks/README.md`](./packages/pulse-webhooks/README.md).
 
-### 3. `@orbital/pulse-notify` — React Hooks
+### 3. `@orbital-stellar/pulse-notify` — React Hooks
 
 Browser-side React hooks (`useStellarEvent`, `useStellarPayment`, `useStellarActivity`) that open an SSE connection to your Orbital-powered backend and re-render on each event. Generic type narrowing supported on `useStellarEvent<T>`.
 
@@ -127,12 +127,12 @@ NEXT_PUBLIC_NETWORK=testnet pnpm --filter orbital/web dev
 Stellar Network (Horizon REST/SSE + Stellar RPC)
         │
         ▼
-@orbital/pulse-core
+@orbital-stellar/pulse-core
 EventEngine · Watcher · Normalization · Reconnect · Backoff
         │
    ┌────┴─────────────────┐
    ▼                      ▼
-@orbital/pulse-webhooks   @orbital/pulse-notify
+@orbital-stellar/pulse-webhooks   @orbital-stellar/pulse-notify
 HMAC delivery             React hooks (browser SSE)
 SSRF hardening            useStellarEvent
 Edge-runtime verify       useStellarPayment
@@ -169,8 +169,8 @@ These are **not** in Phase 0 and are tracked for Phase 1 or later:
 2. **Cursor persistence** — resumable streams across process restarts. Phase 1.
 3. **Webhook replay store** — durable retry adapters for Redis/Postgres/S3. Phase 1.
 4. **Production hosting** — multi-region orchestration, persistent registries, leader election. Belongs in **Orbital Cloud** (separate closed product), not in this repository.
-5. **`@orbital/hooks`, `@orbital/payments`, `@orbital/auth`** — Phase 2 SDK family. See [`ROADMAP.md`](./ROADMAP.md).
-6. **`@orbital/x402`, `@orbital/agent-sdk`** — Phase 3. See [`ROADMAP.md`](./ROADMAP.md).
+5. **`@orbital-stellar/hooks`, `@orbital-stellar/payments`, `@orbital-stellar/auth`** — Phase 2 SDK family. See [`ROADMAP.md`](./ROADMAP.md).
+6. **`@orbital-stellar/x402`, `@orbital-stellar/agent-sdk`** — Phase 3. See [`ROADMAP.md`](./ROADMAP.md).
 
 ---
 
@@ -181,7 +181,7 @@ These are **not** in Phase 0 and are tracked for Phase 1 or later:
 | **Events** | Soroban event subscription (Stellar RPC) | ABI registry client for typed decoding |
 | **Types** | Discriminated union refinement (exhaustive `switch`) | — |
 | **Persistence** | Cursor persistence in `pulse-core` | Pluggable replay adapters in `pulse-webhooks` |
-| **Distribution** | Starter boilerplates (`next`, `express`, `anchor`) | npm publish under `@orbital/` |
+| **Distribution** | Starter boilerplates (`next`, `express`, `anchor`) | npm publish under `@orbital-stellar/` |
 | **Stability** | — | `v1.0` stability pledge — semver contract |
 
 See [`ROADMAP.md`](./ROADMAP.md) for the full multi-year vision and [`docs/proposal.md`](./docs/proposal.md) for the Phase 1 SCF funding proposal.
@@ -192,7 +192,7 @@ See [`ROADMAP.md`](./ROADMAP.md) for the full multi-year vision and [`docs/propo
 
 ### As a Stellar Developer
 1. Read [Getting Started](./apps/web/content/getting-started/introduction.md)
-2. Install: `pnpm add @orbital/pulse-core @orbital/pulse-webhooks @orbital/pulse-notify`
+2. Install: `pnpm add @orbital-stellar/pulse-core @orbital-stellar/pulse-webhooks @orbital-stellar/pulse-notify`
 3. Follow the [Quick Start](./apps/web/content/getting-started/quick-start.md)
 
 ### As a Contributor

--- a/README.md
+++ b/README.md
@@ -49,10 +49,10 @@ The longer-form thesis, the multi-year vision, and the SCF grant case live in [`
 
 | Package | Description | Status |
 |---|---|---|
-| [`@orbital/pulse-core`](./packages/pulse-core) | EventEngine — Horizon subscription, normalization, reconnection, rate-limit handling | ✅ Phase 0 |
-| [`@orbital/pulse-webhooks`](./packages/pulse-webhooks) | HMAC-signed webhook delivery + verification (Node + edge runtimes) | ✅ Phase 0 |
-| [`@orbital/pulse-notify`](./packages/pulse-notify) | React hooks — `useStellarEvent`, `useStellarPayment`, `useStellarActivity` | ✅ Phase 0 |
-| [`@orbital/abi-registry`](./packages/abi-registry) | Canonical Soroban ABI client, schema helpers, and registry publisher interface | ✅ Phase 1 |
+| [`@orbital-stellar/pulse-core`](./packages/pulse-core) | EventEngine — Horizon subscription, normalization, reconnection, rate-limit handling | ✅ Phase 0 |
+| [`@orbital-stellar/pulse-webhooks`](./packages/pulse-webhooks) | HMAC-signed webhook delivery + verification (Node + edge runtimes) | ✅ Phase 0 |
+| [`@orbital-stellar/pulse-notify`](./packages/pulse-notify) | React hooks — `useStellarEvent`, `useStellarPayment`, `useStellarActivity` | ✅ Phase 0 |
+| [`@orbital-stellar/abi-registry`](./packages/abi-registry) | Canonical Soroban ABI client, schema helpers, and registry publisher interface | ✅ Phase 1 |
 
 > The full classic-operation taxonomy is shipped (payments, account create/merge/options/bump-sequence, trustlines + auth, offers, claimables, liquidity pools, manage-data). Soroban contract events are Phase 1 (Q2–Q3 2026) — see [`ROADMAP.md`](ROADMAP.md).
 
@@ -71,15 +71,15 @@ pnpm install
 Once published, install only what you need:
 
 ```bash
-pnpm add @orbital/pulse-core             # always
-pnpm add @orbital/pulse-webhooks         # if you push events to HTTPS endpoints
-pnpm add @orbital/pulse-notify react     # if you render live events in React
+pnpm add @orbital-stellar/pulse-core             # always
+pnpm add @orbital-stellar/pulse-webhooks         # if you push events to HTTPS endpoints
+pnpm add @orbital-stellar/pulse-notify react     # if you render live events in React
 ```
 
 ### Subscribe to events directly
 
 ```ts
-import { EventEngine } from "@orbital/pulse-core";
+import { EventEngine } from "@orbital-stellar/pulse-core";
 
 const engine = new EventEngine({ network: "testnet" });
 engine.start();
@@ -98,8 +98,8 @@ watcher.on("*", (event) => {
 ### Deliver events to a webhook
 
 ```ts
-import { EventEngine } from "@orbital/pulse-core";
-import { WebhookDelivery } from "@orbital/pulse-webhooks";
+import { EventEngine } from "@orbital-stellar/pulse-core";
+import { WebhookDelivery } from "@orbital-stellar/pulse-webhooks";
 
 const engine = new EventEngine({ network: "mainnet" });
 engine.start();
@@ -119,7 +119,7 @@ Receivers verify the signature with `verifyWebhook` (Node) or `verifyWebhookEdge
 
 ```tsx
 "use client";
-import { useStellarPayment } from "@orbital/pulse-notify";
+import { useStellarPayment } from "@orbital-stellar/pulse-notify";
 
 export function IncomingPayments({ address }: { address: string }) {
   const { event, connected } = useStellarPayment(
@@ -145,18 +145,18 @@ flowchart LR
     RPC["Stellar RPC<br/>(Soroban) — Phase 1"]
   end
 
-  subgraph Core["@orbital/pulse-core"]
+  subgraph Core["@orbital-stellar/pulse-core"]
     Engine["EventEngine<br/>subscribe · reconnect · backoff"]
     Watcher["Watcher<br/>per-address pub/sub"]
     Normalize["Normalize<br/>13 op types → typed events"]
   end
 
-  subgraph Webhooks["@orbital/pulse-webhooks"]
+  subgraph Webhooks["@orbital-stellar/pulse-webhooks"]
     Sign["HMAC-SHA256<br/>+ retry + SSRF"]
     Verify["verifyWebhook<br/>verifyWebhookEdge"]
   end
 
-  subgraph Notify["@orbital/pulse-notify"]
+  subgraph Notify["@orbital-stellar/pulse-notify"]
     Hooks["useStellarEvent<br/>useStellarPayment<br/>useStellarActivity"]
   end
 
@@ -204,8 +204,8 @@ Two paths:
 
 - **Now (Phase 0)** — Full classic operation taxonomy, edge-runtime webhook verification, React hooks ✅
 - **Q2–Q3 2026 (Phase 1, `v1.0`)** — Soroban event subscription, ABI registry client, cursor persistence, replay adapters, npm publish, stability pledge
-- **2027 (Phase 2)** — `@orbital/hooks`, `@orbital/payments`, `@orbital/auth`, first SEP submission
-- **2028+ (Phase 3)** — `@orbital/x402`, `@orbital/agent-sdk`, intent compiler
+- **2027 (Phase 2)** — `@orbital-stellar/hooks`, `@orbital-stellar/payments`, `@orbital-stellar/auth`, first SEP submission
+- **2028+ (Phase 3)** — `@orbital-stellar/x402`, `@orbital-stellar/agent-sdk`, intent compiler
 
 Full multi-year plan in [`ROADMAP.md`](ROADMAP.md).
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -19,9 +19,9 @@
 |---|---|---|---|---|
 | **Phase 0 — Foundation** | Typed SDKs for Stellar classic operations | `v0.1.0` | `pnpm -r typecheck && pnpm test` green; tag pushed; CHANGELOG entry shipped | 🟢 **Released 2026-05-29** |
 | **Phase 1 — Production SDK** | Soroban + cursor persistence + stability pledge | `v1.0.0` | `pnpm publish -r --filter "./packages/*"` succeeds; STABILITY.md merged; Soroban e2e test green | ⚪ Q2–Q3 2026 |
-| **Phase 2 — SDK Ecosystem** | `@orbital/hooks`, `@orbital/payments`, `@orbital/auth`, first SEP | `v2.0.0` | First SEP submission accepted or under review by SDF; `useBalance` + `useTransaction` on npm | ⚪ 2027 |
+| **Phase 2 — SDK Ecosystem** | `@orbital-stellar/hooks`, `@orbital-stellar/payments`, `@orbital-stellar/auth`, first SEP | `v2.0.0` | First SEP submission accepted or under review by SDF; `useBalance` + `useTransaction` on npm | ⚪ 2027 |
 | **Phase 3 — Trust & Agent Layer** | x402, agent-sdk, intent compiler, shadow-fork | `v3.0.0` | x402 reference deployed; intent compiler OSS; ≥1,000 agent integrations | ⚪ 2028+ |
-| **Phase 4 — Protocol Permanence** | Identity layer, reactor library, 10+ SEPs | n/a | 10 SEPs authored or co-authored; Orbital identity in `@orbital/auth` ≥80% of major Stellar apps | ⚪ long-term |
+| **Phase 4 — Protocol Permanence** | Identity layer, reactor library, 10+ SEPs | n/a | 10 SEPs authored or co-authored; Orbital identity in `@orbital-stellar/auth` ≥80% of major Stellar apps | ⚪ long-term |
 
 ---
 
@@ -85,7 +85,7 @@
 
 ### Wave 1.2 — ABI Registry
 
-- [ ] `@orbital/abi-registry` client package (TBD final naming)
+- [ ] `@orbital-stellar/abi-registry` client package (TBD final naming)
 - [ ] Schema spec published as a draft SEP
 - [ ] Hosted registry service (operated; client is MIT — see [`docs/open-source-policy.md`](./docs/open-source-policy.md))
 - [ ] `decodedData` field on `contract.emitted` for registered contracts
@@ -105,7 +105,7 @@
 ### Wave 1.5 — Distribution
 
 - [ ] Starter boilerplates: `orbital-next-starter`, `orbital-express-starter`, `orbital-anchor-starter`
-- [ ] `pnpm add @orbital/pulse-core` works against npm
+- [ ] `pnpm add @orbital-stellar/pulse-core` works against npm
 - [ ] [`STABILITY.md`](./STABILITY.md) — semver contract, deprecation window (6 months), breaking-change policy
 - [ ] `v1.0.0` git tag with full release notes
 
@@ -115,12 +115,12 @@
 
 **Goal:** own the full Stellar developer SDK surface with a coherent, composable package family.
 
-**Release gate:** first SEP submission accepted or under review by SDF; at least three data hooks (`useBalance`, `useTransaction`, `useAccount`) shipped to npm under `@orbital/hooks`; reference reactor contract published.
+**Release gate:** first SEP submission accepted or under review by SDF; at least three data hooks (`useBalance`, `useTransaction`, `useAccount`) shipped to npm under `@orbital-stellar/hooks`; reference reactor contract published.
 
-- [ ] **`@orbital/hooks`** — complete data-hook library: `useAccount`, `useBalance`, `useTransaction`, `useOrderBook`, full account activity surface
-- [ ] **`@orbital/payments`** — transaction primitives: send, receive, path payment, payroll batch, with typed results
-- [ ] **`@orbital/auth`** — embedded wallets via WebAuthn/passkeys, fee sponsorship, WalletConnect
-- [ ] **`@orbital/analytics`** — client library and event-volume reference dashboards
+- [ ] **`@orbital-stellar/hooks`** — complete data-hook library: `useAccount`, `useBalance`, `useTransaction`, `useOrderBook`, full account activity surface
+- [ ] **`@orbital-stellar/payments`** — transaction primitives: send, receive, path payment, payroll batch, with typed results
+- [ ] **`@orbital-stellar/auth`** — embedded wallets via WebAuthn/passkeys, fee sponsorship, WalletConnect
+- [ ] **`@orbital-stellar/analytics`** — client library and event-volume reference dashboards
 - [ ] **Reactor contracts** — reference SDK and library of Soroban Rust contracts that react to events from other contracts
 - [ ] **First SEP submission** — formalize the event normalization format so other implementations can interoperate
 
@@ -130,11 +130,11 @@
 
 **Goal:** turn event subscriptions into programmable intent pipelines and capture the AI-agent economy on Stellar.
 
-**Release gate:** `@orbital/x402` middleware deployed in a public reference application; intent compiler OSS published; ≥1,000 agent integrations recorded against `@orbital/agent-sdk`.
+**Release gate:** `@orbital-stellar/x402` middleware deployed in a public reference application; intent compiler OSS published; ≥1,000 agent integrations recorded against `@orbital-stellar/agent-sdk`.
 
-- [ ] **`@orbital/x402`** — Express/Next.js middleware for payment-gated API access via the HTTP 402 / x402 protocol
-- [ ] **`@orbital/agent-sdk`** — payment client for autonomous AI agents; integrates with x402 for agent-to-agent and agent-to-service payments on Stellar
-- [ ] **`@orbital/anchor-sdk`** — client library for SEP-24 and SEP-31 lifecycle events
+- [ ] **`@orbital-stellar/x402`** — Express/Next.js middleware for payment-gated API access via the HTTP 402 / x402 protocol
+- [ ] **`@orbital-stellar/agent-sdk`** — payment client for autonomous AI agents; integrates with x402 for agent-to-agent and agent-to-service payments on Stellar
+- [ ] **`@orbital-stellar/anchor-sdk`** — client library for SEP-24 and SEP-31 lifecycle events
 - [ ] **Intent compiler** — declare "when X happens, do Y" as a typed intent; the compiler produces a webhook + reactor contract + replay policy
 - [ ] **Shadow-Fork simulator (OSS core)** — fork any ledger state, inject hypothetical operations, replay Soroban invocations
 - [ ] **Additional SEPs** — reactor contract spec, intent schema, attestation format

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -1,4 +1,4 @@
-# @orbital/web
+# @orbital-stellar/web
 
 **The public Orbital site** — landing page, documentation, and live testnet demos. Built with Next.js 16, Tailwind CSS, and Framer Motion. Also hosts the marketing-demo API routes (`/api/events/[address]`, `/api/webhook-sample`) that power the on-page sandbox.
 

--- a/apps/web/app/api/events/[address]/route.ts
+++ b/apps/web/app/api/events/[address]/route.ts
@@ -1,4 +1,4 @@
-import { StrKey } from "@orbital/pulse-core";
+import { StrKey } from "@orbital-stellar/pulse-core";
 import { getEngine } from "@/lib/engine";
 import {
   DEMO_LIMITS,

--- a/apps/web/app/api/webhook-sample/route.ts
+++ b/apps/web/app/api/webhook-sample/route.ts
@@ -66,8 +66,8 @@ export async function POST(req: Request) {
     },
     secret: generatedSecret ? secret : undefined,
     verify: {
-      node: `import { verifyWebhook } from "@orbital/pulse-webhooks";\nverifyWebhook(payload, signature, secret, timestamp);`,
-      edge: `import { verifyWebhookEdge } from "@orbital/pulse-webhooks/edge";\nawait verifyWebhookEdge(payload, signature, secret, timestamp);`,
+      node: `import { verifyWebhook } from "@orbital-stellar/pulse-webhooks";\nverifyWebhook(payload, signature, secret, timestamp);`,
+      edge: `import { verifyWebhookEdge } from "@orbital-stellar/pulse-webhooks/edge";\nawait verifyWebhookEdge(payload, signature, secret, timestamp);`,
     },
   });
 }

--- a/apps/web/components/Footer.tsx
+++ b/apps/web/components/Footer.tsx
@@ -104,8 +104,8 @@ export default function Footer() {
           <div>
             <span style={labelStyle}>Packages</span>
             {[
-              'npm i @orbital/pulse-webhooks',
-              'npm i @orbital/pulse-notify',
+              'npm i @orbital-stellar/pulse-webhooks',
+              'npm i @orbital-stellar/pulse-notify',
             ].map((cmd) => (
               <p
                 key={cmd}

--- a/apps/web/components/SDKEcosystem.tsx
+++ b/apps/web/components/SDKEcosystem.tsx
@@ -4,37 +4,37 @@ import { useState } from 'react'
 
 const PACKAGES = [
   {
-    pkg: '@orbital/pulse-webhooks',
+    pkg: '@orbital-stellar/pulse-webhooks',
     title: 'Pulse Webhooks',
     description: 'Signed webhook delivery with retries, secrets, and delivery logs for your server.',
     status: 'Live' as const,
   },
   {
-    pkg: '@orbital/pulse-notify',
+    pkg: '@orbital-stellar/pulse-notify',
     title: 'Pulse Notify',
     description: 'React hooks for real-time Stellar events. Drop in, subscribe, done.',
     status: 'Live' as const,
   },
   {
-    pkg: '@orbital/hooks',
+    pkg: '@orbital-stellar/hooks',
     title: 'Stellar Hooks',
     description: 'useAccount, useTransaction, useBalance and more data hooks for React.',
     status: 'Coming soon' as const,
   },
   {
-    pkg: '@orbital/auth',
+    pkg: '@orbital-stellar/auth',
     title: 'Auth SDK',
     description: 'Embedded wallets, passkeys, and fee sponsorship for Stellar apps.',
     status: 'Coming soon' as const,
   },
   {
-    pkg: '@orbital/payments',
+    pkg: '@orbital-stellar/payments',
     title: 'Payments SDK',
     description: 'Send, receive, swap and programmable payroll on Stellar.',
     status: 'Coming soon' as const,
   },
   {
-    pkg: '@orbital/testing',
+    pkg: '@orbital-stellar/testing',
     title: 'Testing Utils',
     description: 'Mock Horizon responses and local testnet helpers for CI.',
     status: 'Coming soon' as const,

--- a/apps/web/content/api/pulse-core.md
+++ b/apps/web/content/api/pulse-core.md
@@ -5,20 +5,20 @@ description: Event engine for Stellar Horizon — normalization, watchers, recon
 
 ## Overview
 
-`@orbital/pulse-core` opens a streaming connection to Horizon, normalizes each incoming record into a uniform `NormalizedEvent`, and emits it to any `Watcher` subscribed to the affected address. Reconnection, backoff, and rate-limit handling are automatic.
+`@orbital-stellar/pulse-core` opens a streaming connection to Horizon, normalizes each incoming record into a uniform `NormalizedEvent`, and emits it to any `Watcher` subscribed to the affected address. Reconnection, backoff, and rate-limit handling are automatic.
 
-Install when you want to consume Stellar events in-process — typically inside a server, background worker, or CLI. Layer [`@orbital/pulse-webhooks`](./pulse-webhooks) or [`@orbital/pulse-notify`](./pulse-notify) on top for delivery and React integration.
+Install when you want to consume Stellar events in-process — typically inside a server, background worker, or CLI. Layer [`@orbital-stellar/pulse-webhooks`](./pulse-webhooks) or [`@orbital-stellar/pulse-notify`](./pulse-notify) on top for delivery and React integration.
 
 ## Installation
 
 ```bash
-pnpm add @orbital/pulse-core
+pnpm add @orbital-stellar/pulse-core
 ```
 
 ## EventEngine
 
 ```ts
-import { EventEngine } from "@orbital/pulse-core";
+import { EventEngine } from "@orbital-stellar/pulse-core";
 
 const engine = new EventEngine({
   network: "testnet",

--- a/apps/web/content/api/pulse-notify.md
+++ b/apps/web/content/api/pulse-notify.md
@@ -5,14 +5,14 @@ description: React hooks for subscribing to live Stellar events.
 
 ## Overview
 
-`@orbital/pulse-notify` opens a browser-native `EventSource` connection to a backend that exposes Orbital events as Server-Sent Events, subscribes to an address, and re-renders your component whenever a new event arrives.
+`@orbital-stellar/pulse-notify` opens a browser-native `EventSource` connection to a backend that exposes Orbital events as Server-Sent Events, subscribes to an address, and re-renders your component whenever a new event arrives.
 
-The hooks are intentionally thin — no global store, no custom cache, no peer dependency on a state manager. You point them at your own backend (built on `@orbital/pulse-core` — `apps/web` ships a copy-paste reference at `app/api/events/[address]/route.ts`) or at Orbital Cloud (in development), and pass the address you want to watch.
+The hooks are intentionally thin — no global store, no custom cache, no peer dependency on a state manager. You point them at your own backend (built on `@orbital-stellar/pulse-core` — `apps/web` ships a copy-paste reference at `app/api/events/[address]/route.ts`) or at Orbital Cloud (in development), and pass the address you want to watch.
 
 ## Installation
 
 ```bash
-pnpm add @orbital/pulse-notify react
+pnpm add @orbital-stellar/pulse-notify react
 ```
 
 **Peer dependency:** React 18 or 19. Designed for Next.js App Router, Vite, Remix, and plain React apps.
@@ -23,7 +23,7 @@ The base hook. Subscribes to one event type, an allowlist of types, or all event
 
 ```tsx
 "use client";
-import { useStellarEvent } from "@orbital/pulse-notify";
+import { useStellarEvent } from "@orbital-stellar/pulse-notify";
 
 // Single type
 const { event, connected, error } = useStellarEvent(
@@ -75,7 +75,7 @@ A [React Suspense](https://react.dev/reference/react/Suspense)-compatible hook. 
 ```tsx
 "use client";
 import { Suspense } from "react";
-import { useStellarEventSuspense } from "@orbital/pulse-notify";
+import { useStellarEventSuspense } from "@orbital-stellar/pulse-notify";
 
 // The component never receives null — it is suspended until data arrives.
 function LiveBalance({ address }: { address: string }) {
@@ -121,7 +121,7 @@ Uses the same connection pool as `useStellarEvent` — multiple hook instances w
 Convenience hook — only updates on `payment.received` events. Equivalent to `useStellarEvent(serverUrl, address, { event: "payment.received" })`.
 
 ```tsx
-import { useStellarPayment } from "@orbital/pulse-notify";
+import { useStellarPayment } from "@orbital-stellar/pulse-notify";
 
 function IncomingPayments({ address }: { address: string }) {
   const { event, connected } = useStellarPayment(
@@ -147,7 +147,7 @@ function IncomingPayments({ address }: { address: string }) {
 Convenience hook — updates on all events (`*`). Equivalent to `useStellarEvent(serverUrl, address, { event: "*" })`.
 
 ```tsx
-import { useStellarActivity } from "@orbital/pulse-notify";
+import { useStellarActivity } from "@orbital-stellar/pulse-notify";
 
 const { event, connected } = useStellarActivity(serverUrl, address);
 ```
@@ -158,7 +158,7 @@ Small status indicator that opens its own `EventSource` and renders connection h
 
 ```tsx
 "use client";
-import { StellarConnectionStatus } from "@orbital/pulse-notify";
+import { StellarConnectionStatus } from "@orbital-stellar/pulse-notify";
 
 <StellarConnectionStatus serverUrl={serverUrl} address={address} />;
 ```
@@ -178,8 +178,8 @@ The component sets `data-status` to `connecting`, `connected`, or `error`, and a
 Pass a narrower union as `T` to get full IDE support and avoid manual casts:
 
 ```tsx
-import type { NormalizedEvent } from "@orbital/pulse-core";
-import { useStellarEvent } from "@orbital/pulse-notify";
+import type { NormalizedEvent } from "@orbital-stellar/pulse-core";
+import { useStellarEvent } from "@orbital-stellar/pulse-notify";
 
 type WalletEvents = Extract<
   NormalizedEvent,

--- a/apps/web/content/api/pulse-webhooks.md
+++ b/apps/web/content/api/pulse-webhooks.md
@@ -5,21 +5,21 @@ description: HMAC-signed webhook delivery with automatic retry, Node + edge veri
 
 ## Overview
 
-`@orbital/pulse-webhooks` wraps a `pulse-core` `Watcher` and delivers events to one or more HTTPS endpoints. Each delivery is signed with HMAC-SHA256 so your server can verify authenticity. On transient failure each URL is retried independently with exponential backoff; on permanent failure a `webhook.failed` event is emitted.
+`@orbital-stellar/pulse-webhooks` wraps a `pulse-core` `Watcher` and delivers events to one or more HTTPS endpoints. Each delivery is signed with HMAC-SHA256 so your server can verify authenticity. On transient failure each URL is retried independently with exponential backoff; on permanent failure a `webhook.failed` event is emitted.
 
 Two verifiers are exported for the receiver side: `verifyWebhook` (Node.js `crypto`) and `verifyWebhookEdge` (Web Crypto API — works in Cloudflare Workers, Vercel Edge, Deno, and browsers).
 
 ## Installation
 
 ```bash
-pnpm add @orbital/pulse-webhooks @orbital/pulse-core
+pnpm add @orbital-stellar/pulse-webhooks @orbital-stellar/pulse-core
 ```
 
 ## WebhookDelivery
 
 ```ts
-import { EventEngine } from "@orbital/pulse-core";
-import { WebhookDelivery } from "@orbital/pulse-webhooks";
+import { EventEngine } from "@orbital-stellar/pulse-core";
+import { WebhookDelivery } from "@orbital-stellar/pulse-webhooks";
 
 const engine = new EventEngine({ network: "testnet" });
 engine.start();
@@ -60,7 +60,7 @@ To also stop the underlying subscription, call `engine.unsubscribe(address)`.
 ## verifyWebhook (Node.js)
 
 ```ts
-import { verifyWebhook } from "@orbital/pulse-webhooks";
+import { verifyWebhook } from "@orbital-stellar/pulse-webhooks";
 
 // req.body must be the raw Buffer (use express.raw() middleware)
 const event = verifyWebhook(
@@ -78,7 +78,7 @@ Uses `crypto.timingSafeEqual` under the hood — never roll your own HMAC compar
 ## verifyWebhookEdge (Cloudflare Workers / Vercel Edge / Deno / browsers)
 
 ```ts
-import { verifyWebhookEdge } from "@orbital/pulse-webhooks";
+import { verifyWebhookEdge } from "@orbital-stellar/pulse-webhooks";
 
 const event = await verifyWebhookEdge(
   payload,                 // string

--- a/apps/web/content/getting-started/installation.md
+++ b/apps/web/content/getting-started/installation.md
@@ -14,13 +14,13 @@ Install only the packages you need — each is independently usable.
 
 ```bash
 # Event engine — required by everything else
-pnpm add @orbital/pulse-core
+pnpm add @orbital-stellar/pulse-core
 
 # Webhook delivery (optional)
-pnpm add @orbital/pulse-webhooks
+pnpm add @orbital-stellar/pulse-webhooks
 
 # React hooks (optional)
-pnpm add @orbital/pulse-notify react
+pnpm add @orbital-stellar/pulse-notify react
 ```
 
 ## TypeScript
@@ -39,7 +39,7 @@ The event union (`NormalizedEvent`) is a discriminated union — `switch` on `ev
 
 ## Edge runtimes
 
-`@orbital/pulse-webhooks` exports two verifiers:
+`@orbital-stellar/pulse-webhooks` exports two verifiers:
 
 - **`verifyWebhook`** — Node.js (`crypto` module)
 - **`verifyWebhookEdge`** — Web Crypto API; works in Cloudflare Workers, Vercel Edge, Deno, and browsers
@@ -48,7 +48,7 @@ Pick the one that matches your runtime. The signing side (`WebhookDelivery`) req
 
 ## React
 
-`@orbital/pulse-notify` is browser-only — it uses `EventSource`, which doesn't exist in Node. In Next.js App Router, mark consuming components with `"use client"`. In Remix or Vite SSR, gate the hook behind a client-only boundary.
+`@orbital-stellar/pulse-notify` is browser-only — it uses `EventSource`, which doesn't exist in Node. In Next.js App Router, mark consuming components with `"use client"`. In Remix or Vite SSR, gate the hook behind a client-only boundary.
 
 ## Trying the reference composition (optional)
 

--- a/apps/web/content/getting-started/introduction.md
+++ b/apps/web/content/getting-started/introduction.md
@@ -7,9 +7,9 @@ description: What Orbital is and why you need it.
 
 Orbital is **Stellar's open-source real-time event SDK family** — three MIT-licensed packages on npm that turn Horizon and Stellar RPC's raw firehose into typed, application-shaped events you can subscribe to in any Node.js, edge, or React runtime.
 
-- **`@orbital/pulse-core`** — event engine: Horizon SSE subscription, normalization, reconnection, rate-limit handling
-- **`@orbital/pulse-webhooks`** — HMAC-signed webhook delivery (Node) and verification (Node + edge runtimes)
-- **`@orbital/pulse-notify`** — React hooks for live events in the browser
+- **`@orbital-stellar/pulse-core`** — event engine: Horizon SSE subscription, normalization, reconnection, rate-limit handling
+- **`@orbital-stellar/pulse-webhooks`** — HMAC-signed webhook delivery (Node) and verification (Node + edge runtimes)
+- **`@orbital-stellar/pulse-notify`** — React hooks for live events in the browser
 
 ## Why use it?
 
@@ -28,12 +28,12 @@ Orbital ships those primitives once, openly, so you can `pnpm add` them instead 
 Stellar Network (Horizon REST/SSE + Stellar RPC)
         │
         ▼
-  @orbital/pulse-core
+  @orbital-stellar/pulse-core
   EventEngine · Watcher · Normalization · Reconnect
         │
    ┌────┴─────────────────┐
    ▼                      ▼
-@orbital/pulse-webhooks   @orbital/pulse-notify
+@orbital-stellar/pulse-webhooks   @orbital-stellar/pulse-notify
 HMAC delivery (Node)      React hooks (browser SSE)
 Edge verification         useStellarEvent, useStellarPayment
 ```
@@ -42,9 +42,9 @@ Edge verification         useStellarEvent, useStellarPayment
 
 | Package | Description |
 |---------|-------------|
-| `@orbital/pulse-core` | Event engine: Horizon subscription, event normalization, reconnection |
-| `@orbital/pulse-webhooks` | HMAC-signed webhook delivery + verification (Node + edge runtimes) |
-| `@orbital/pulse-notify` | React hooks for client-side event subscription |
+| `@orbital-stellar/pulse-core` | Event engine: Horizon subscription, event normalization, reconnection |
+| `@orbital-stellar/pulse-webhooks` | HMAC-signed webhook delivery + verification (Node + edge runtimes) |
+| `@orbital-stellar/pulse-notify` | React hooks for client-side event subscription |
 
 ## Event taxonomy
 

--- a/apps/web/content/getting-started/quick-start.md
+++ b/apps/web/content/getting-started/quick-start.md
@@ -10,7 +10,7 @@ This guide walks you through the three SDK packages with the smallest possible w
 The fastest path. Install `pulse-core`, instantiate `EventEngine`, subscribe to an address, handle events.
 
 ```ts
-import { EventEngine } from "@orbital/pulse-core";
+import { EventEngine } from "@orbital-stellar/pulse-core";
 
 const engine = new EventEngine({ network: "testnet" });
 engine.start();
@@ -40,8 +40,8 @@ Run it on testnet, send a test payment to that address from the [Stellar Laborat
 Want to push events to an HTTPS endpoint with signed retries? Layer `WebhookDelivery` on top of a watcher:
 
 ```ts
-import { EventEngine } from "@orbital/pulse-core";
-import { WebhookDelivery } from "@orbital/pulse-webhooks";
+import { EventEngine } from "@orbital-stellar/pulse-core";
+import { WebhookDelivery } from "@orbital-stellar/pulse-webhooks";
 
 const engine = new EventEngine({ network: "testnet" });
 engine.start();
@@ -59,7 +59,7 @@ new WebhookDelivery(watcher, {
 Verify on the receiver side:
 
 ```ts
-import { verifyWebhook } from "@orbital/pulse-webhooks";
+import { verifyWebhook } from "@orbital-stellar/pulse-webhooks";
 import express from "express";
 
 const app = express();
@@ -85,7 +85,7 @@ The React hooks open a browser `EventSource` connection to a backend that expose
 
 ```tsx
 "use client";
-import { useStellarPayment } from "@orbital/pulse-notify";
+import { useStellarPayment } from "@orbital-stellar/pulse-notify";
 
 export function LiveBalance({ address }: { address: string }) {
   const { event, connected, error } = useStellarPayment(

--- a/apps/web/content/guides/real-time-events.md
+++ b/apps/web/content/guides/real-time-events.md
@@ -1,19 +1,19 @@
 ---
 title: Real-time Events
-description: Stream live Stellar events with @orbital/pulse-core and React hooks.
+description: Stream live Stellar events with @orbital-stellar/pulse-core and React hooks.
 ---
 
 There are two ways to consume Orbital events in real time:
 
-1. **Server-side** — `@orbital/pulse-core` opens a streaming connection to Horizon directly. Use this in Node.js, edge workers, or background processes.
-2. **Browser-side** — `@orbital/pulse-notify` React hooks open a browser `EventSource` to a backend you operate (which uses `pulse-core` under the hood).
+1. **Server-side** — `@orbital-stellar/pulse-core` opens a streaming connection to Horizon directly. Use this in Node.js, edge workers, or background processes.
+2. **Browser-side** — `@orbital-stellar/pulse-notify` React hooks open a browser `EventSource` to a backend you operate (which uses `pulse-core` under the hood).
 
 The server-side path is the lowest layer; the React hooks sit on top.
 
 ## Server-side subscription with `pulse-core`
 
 ```ts
-import { EventEngine } from "@orbital/pulse-core";
+import { EventEngine } from "@orbital-stellar/pulse-core";
 
 const engine = new EventEngine({
   network: "testnet",
@@ -43,14 +43,14 @@ Always call `engine.stop()` in your shutdown path.
 
 ## Browser-side with React hooks
 
-`@orbital/pulse-notify` opens an `EventSource` connection to a backend that exposes Orbital events as Server-Sent Events. The `apps/web` marketing site ships a Next.js route handler that does this (`app/api/events/[address]/route.ts`); you can copy that or stand up an equivalent SSE endpoint with about 30 lines of `pulse-core` + Express in your own backend.
+`@orbital-stellar/pulse-notify` opens an `EventSource` connection to a backend that exposes Orbital events as Server-Sent Events. The `apps/web` marketing site ships a Next.js route handler that does this (`app/api/events/[address]/route.ts`); you can copy that or stand up an equivalent SSE endpoint with about 30 lines of `pulse-core` + Express in your own backend.
 
 ### Standing up an SSE endpoint
 
 If you're not using the reference server, here's the shape of what your backend needs to expose:
 
 ```ts
-import { EventEngine } from "@orbital/pulse-core";
+import { EventEngine } from "@orbital-stellar/pulse-core";
 import express from "express";
 
 const app = express();
@@ -83,7 +83,7 @@ Subscribe to one event type, several types, or all events on an address:
 
 ```tsx
 "use client";
-import { useStellarEvent } from "@orbital/pulse-notify";
+import { useStellarEvent } from "@orbital-stellar/pulse-notify";
 
 // Single type
 const { event, connected, error } = useStellarEvent(
@@ -142,8 +142,8 @@ useEffect(() => {
 `useStellarEvent` is generic — pass a narrower union as `T` to get full IDE support and avoid manual casts:
 
 ```tsx
-import type { NormalizedEvent } from "@orbital/pulse-core";
-import { useStellarEvent } from "@orbital/pulse-notify";
+import type { NormalizedEvent } from "@orbital-stellar/pulse-core";
+import { useStellarEvent } from "@orbital-stellar/pulse-notify";
 
 type WalletEvents = Extract<
   NormalizedEvent,

--- a/apps/web/content/guides/webhooks.md
+++ b/apps/web/content/guides/webhooks.md
@@ -1,19 +1,19 @@
 ---
 title: Webhooks
-description: Sign, deliver, and verify Stellar event webhooks with @orbital/pulse-webhooks.
+description: Sign, deliver, and verify Stellar event webhooks with @orbital-stellar/pulse-webhooks.
 ---
 
 ## Overview
 
-`@orbital/pulse-webhooks` is the "push" side of Orbital. Attach it to a `pulse-core` `Watcher` and every event becomes one or more outbound HTTPS POSTs with a verifiable HMAC-SHA256 signature, retry on failure, configurable timeout, and SSRF hardening.
+`@orbital-stellar/pulse-webhooks` is the "push" side of Orbital. Attach it to a `pulse-core` `Watcher` and every event becomes one or more outbound HTTPS POSTs with a verifiable HMAC-SHA256 signature, retry on failure, configurable timeout, and SSRF hardening.
 
 This guide covers both sides: setting up delivery in your backend, and verifying signatures in the receiving service (Node or edge runtime).
 
 ## Sender side — `WebhookDelivery`
 
 ```ts
-import { EventEngine } from "@orbital/pulse-core";
-import { WebhookDelivery } from "@orbital/pulse-webhooks";
+import { EventEngine } from "@orbital-stellar/pulse-core";
+import { WebhookDelivery } from "@orbital-stellar/pulse-webhooks";
 
 const engine = new EventEngine({ network: "testnet" });
 engine.start();
@@ -79,7 +79,7 @@ Other event types (`account.created`, `trustline.added`, `offer.updated`, etc.) 
 Use `verifyWebhook` with raw-body middleware:
 
 ```ts
-import { verifyWebhook } from "@orbital/pulse-webhooks";
+import { verifyWebhook } from "@orbital-stellar/pulse-webhooks";
 import express from "express";
 
 const app = express();
@@ -112,7 +112,7 @@ app.post("/hooks/stellar", express.raw({ type: "application/json" }), (req, res)
 Cloudflare Workers and Vercel Edge runtimes don't ship Node.js `crypto`. Use `verifyWebhookEdge`, which uses Web Crypto API and is async:
 
 ```js
-import { verifyWebhookEdge } from "@orbital/pulse-webhooks";
+import { verifyWebhookEdge } from "@orbital-stellar/pulse-webhooks";
 
 export default {
   async fetch(request, env) {

--- a/apps/web/lib/engine.ts
+++ b/apps/web/lib/engine.ts
@@ -1,4 +1,4 @@
-import { EventEngine } from "@orbital/pulse-core";
+import { EventEngine } from "@orbital-stellar/pulse-core";
 import { getNetwork } from "./network";
 
 const g = globalThis as unknown as { __orbitalEngine?: EventEngine };

--- a/apps/web/lib/network.ts
+++ b/apps/web/lib/network.ts
@@ -1,4 +1,4 @@
-import type { Network } from "@orbital/pulse-core";
+import type { Network } from "@orbital-stellar/pulse-core";
 
 const VALID: readonly Network[] = ["mainnet", "testnet"] as const;
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@orbital/pulse-core": "workspace:*",
+    "@orbital-stellar/pulse-core": "workspace:*",
     "framer-motion": "^12.36.0",
     "geist": "^1.7.0",
     "gray-matter": "^4.0.3",

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -29,16 +29,16 @@
 
 Orbital is three planes sharing one vocabulary — the **normalized event**:
 
-- **Subscription plane** — `@orbital/pulse-core` opens and maintains a
+- **Subscription plane** — `@orbital-stellar/pulse-core` opens and maintains a
   connection to Stellar (Horizon today, Stellar RPC + Soroban in Phase 1),
   normalizes raw operations into a typed `NormalizedEvent` union, and routes
   each event to per-address `Watcher` subscribers.
-- **Delivery plane** — `@orbital/pulse-webhooks` attaches to a `Watcher`,
+- **Delivery plane** — `@orbital-stellar/pulse-webhooks` attaches to a `Watcher`,
   signs each event with HMAC-SHA256, and POSTs it to one or more HTTPS
   endpoints with retry, timeout, and SSRF safety. A second export
   (`verifyWebhookEdge`) lets receivers verify the signature on Cloudflare
   Workers, Vercel Edge, Deno, and browsers without Node `crypto`.
-- **Consumption plane** — `@orbital/pulse-notify` opens a browser
+- **Consumption plane** — `@orbital-stellar/pulse-notify` opens a browser
   `EventSource` to a backend that re-emits the events as Server-Sent
   Events, and re-renders React components on each event.
 
@@ -49,18 +49,18 @@ flowchart LR
     RPC["Stellar RPC<br/>Soroban — 🛠️ Phase 1"]
   end
 
-  subgraph Subscribe["Subscription plane<br/>@orbital/pulse-core"]
+  subgraph Subscribe["Subscription plane<br/>@orbital-stellar/pulse-core"]
     Engine["EventEngine"]
     Normalize["Normalize<br/>13 op types → 21 events"]
     Watcher["Watcher<br/>per-address pub/sub"]
   end
 
-  subgraph Deliver["Delivery plane<br/>@orbital/pulse-webhooks"]
+  subgraph Deliver["Delivery plane<br/>@orbital-stellar/pulse-webhooks"]
     Sign["HMAC-SHA256<br/>+ retry + SSRF + timeout"]
     Verify["verifyWebhook<br/>verifyWebhookEdge"]
   end
 
-  subgraph Consume["Consumption plane<br/>@orbital/pulse-notify"]
+  subgraph Consume["Consumption plane<br/>@orbital-stellar/pulse-notify"]
     Hooks["useStellarEvent<br/>useStellarPayment<br/>useStellarActivity"]
   end
 
@@ -90,7 +90,7 @@ together inside a single Next.js route handler — about 50 lines of glue.
 | **`WebhookDelivery`** | Attaches to a `Watcher`, signs each event, POSTs it with retry + timeout + concurrent-retry cap. Emits `webhook.failed` / `webhook.dropped` on terminal failure. | `packages/pulse-webhooks/src/index.ts` | ✅ |
 | **`verifyWebhook`** | Node-side HMAC verifier using `crypto.timingSafeEqual`. | `packages/pulse-webhooks/src/index.ts` | ✅ |
 | **`verifyWebhookEdge`** | Edge-runtime HMAC verifier using Web Crypto API + constant-time XOR. | `packages/pulse-webhooks/src/edge.ts` | ✅ |
-| **`@orbital/abi-registry`** | Shared Soroban ABI package that exports the canonical registry client, publisher interface, and scval conversion helpers. | `packages/abi-registry/src/index.ts` | ✅ |
+| **`@orbital-stellar/abi-registry`** | Shared Soroban ABI package that exports the canonical registry client, publisher interface, and scval conversion helpers. | `packages/abi-registry/src/index.ts` | ✅ |
 | **`useStellarEvent<T>`** | React hook that opens an `EventSource`, parses incoming SSE messages, optionally filters by event type, and re-renders on each event. Stable dep-array via sorted `eventKey`. | `packages/pulse-notify/src/index.ts` | ✅ |
 | **`useStellarPayment` / `useStellarActivity`** | Convenience wrappers over `useStellarEvent`. | `packages/pulse-notify/src/index.ts` | ✅ |
 | **Reference composition** | A Next.js Node-runtime route handler that subscribes to an address and streams events as SSE; plus a `webhook-sample` route that returns an HMAC-signed payload for the demo. | `apps/web/app/api/events/[address]/route.ts`, `apps/web/app/api/webhook-sample/route.ts` | ✅ |
@@ -100,9 +100,9 @@ together inside a single Next.js route handler — about 50 lines of glue.
 
 ---
 
-## 2.1 ABI Registry (`@orbital/abi-registry`)
+## 2.1 ABI Registry (`@orbital-stellar/abi-registry`)
 
-`@orbital/abi-registry` is the shared contract-interface package for Orbital.
+`@orbital-stellar/abi-registry` is the shared contract-interface package for Orbital.
 
 - It holds the canonical ABI client surface for Soroban event decoding and publishing.
 - It keeps ABI-related helpers in one place instead of duplicating schema logic in `pulse-core` or application code.
@@ -390,7 +390,7 @@ API:
   (`contract.invoked`, `contract.emitted`) join the `NormalizedEvent` union;
   existing consumers ignore them unless they subscribe.
 - **ABI Registry client.** Decodes Soroban event topics + data into typed,
-  human-readable JSON. Lives in the separate `@orbital/abi-registry`
+  human-readable JSON. Lives in the separate `@orbital-stellar/abi-registry`
   package so the registry data layer is independently versioned.
 - **Cursor persistence.** A pluggable `CursorStore` interface stored on
   `EventEngine` config. Implementations: in-memory (default, current

--- a/docs/COOKBOOK.md
+++ b/docs/COOKBOOK.md
@@ -33,7 +33,7 @@
 The shortest path. Subscribe, attach a handler, wait for events. ✅
 
 ```ts
-import { EventEngine } from "@orbital/pulse-core";
+import { EventEngine } from "@orbital-stellar/pulse-core";
 
 const engine = new EventEngine({ network: "testnet" });
 engine.start();
@@ -54,7 +54,7 @@ Send a test payment from the [Stellar Laboratory](https://laboratory.stellar.org
 One Horizon connection, many watchers. The engine fans events out internally — no extra network cost per subscriber. ✅
 
 ```ts
-import { EventEngine } from "@orbital/pulse-core";
+import { EventEngine } from "@orbital-stellar/pulse-core";
 
 const engine = new EventEngine({ network: "mainnet" });
 engine.start();
@@ -78,7 +78,7 @@ for (const address of accounts) {
 Pass a `filter` function on `subscribe()` to suppress events you don't want delivered. The filter runs before any `on(…)` handler fires. ✅
 
 ```ts
-import { EventEngine, type NormalizedEvent } from "@orbital/pulse-core";
+import { EventEngine, type NormalizedEvent } from "@orbital-stellar/pulse-core";
 
 const engine = new EventEngine({ network: "mainnet" });
 engine.start();
@@ -103,7 +103,7 @@ A predicate that throws is treated as `false` (suppress, with a warn log) — th
 Lifecycle notifications surface alongside operation events on every watcher. Surface them as toasts, banners, or structured logs. ✅
 
 ```ts
-import { EventEngine } from "@orbital/pulse-core";
+import { EventEngine } from "@orbital-stellar/pulse-core";
 
 const engine = new EventEngine({ network: "mainnet" });
 engine.start();
@@ -136,7 +136,7 @@ The engine parses `Retry-After` headers on 429 responses and uses that exact del
 Self-hosted node, regional mirror, or futurenet. The `network` field still picks the chain context; `horizonUrl` overrides the HTTP target. ✅
 
 ```ts
-import { EventEngine } from "@orbital/pulse-core";
+import { EventEngine } from "@orbital-stellar/pulse-core";
 
 const engine = new EventEngine({
   network: "mainnet",
@@ -158,8 +158,8 @@ The URL must be `http://` or `https://`. The engine validates the URL at constru
 **Sender side** — attach delivery to the watcher:
 
 ```ts
-import { EventEngine } from "@orbital/pulse-core";
-import { WebhookDelivery } from "@orbital/pulse-webhooks";
+import { EventEngine } from "@orbital-stellar/pulse-core";
+import { WebhookDelivery } from "@orbital-stellar/pulse-webhooks";
 
 const engine = new EventEngine({ network: "mainnet" });
 engine.start();
@@ -177,7 +177,7 @@ new WebhookDelivery(watcher, {
 **Receiver side** — verify the signature and enforce the replay window with `maxAgeMs`:
 
 ```ts
-import { verifyWebhook } from "@orbital/pulse-webhooks";
+import { verifyWebhook } from "@orbital-stellar/pulse-webhooks";
 import express from "express";
 
 const app = express();
@@ -214,7 +214,7 @@ Each request carries `x-orbital-signature` (hex HMAC-SHA256 over `${timestamp}.$
 `verifyWebhookEdge` uses Web Crypto, so it runs on Cloudflare Workers, Vercel Edge, Deno, and browsers — anywhere without Node's `crypto` module. ✅
 
 ```ts
-import { verifyWebhookEdge } from "@orbital/pulse-webhooks";
+import { verifyWebhookEdge } from "@orbital-stellar/pulse-webhooks";
 
 export default {
   async fetch(request: Request, env: { WEBHOOK_SECRET: string }) {
@@ -274,8 +274,8 @@ The `webhook.failed` event (see recipe 9) fires per-URL, so you can detect which
 When a delivery exhausts its retries, the watcher emits `webhook.failed` with the original event in `raw.originalEvent` and the failed URL in `raw.url`. Catch it and persist to a DLQ. ✅
 
 ```ts
-import { EventEngine, type NormalizedEvent } from "@orbital/pulse-core";
-import { WebhookDelivery, type WebhookFailureRaw } from "@orbital/pulse-webhooks";
+import { EventEngine, type NormalizedEvent } from "@orbital-stellar/pulse-core";
+import { WebhookDelivery, type WebhookFailureRaw } from "@orbital-stellar/pulse-webhooks";
 
 const engine = new EventEngine({ network: "mainnet" });
 engine.start();
@@ -312,8 +312,8 @@ declare function persistToDLQ(record: unknown): Promise<void>;
 
 ```tsx
 "use client";
-import { useStellarEvent } from "@orbital/pulse-notify";
-import type { NormalizedEvent } from "@orbital/pulse-core";
+import { useStellarEvent } from "@orbital-stellar/pulse-notify";
+import type { NormalizedEvent } from "@orbital-stellar/pulse-core";
 
 type WalletEvents = Extract<
   NormalizedEvent,
@@ -352,7 +352,7 @@ The hooks expect a backend that re-emits Orbital events as Server-Sent Events. T
 
 ```ts
 // app/api/events/[address]/route.ts
-import { EventEngine } from "@orbital/pulse-core";
+import { EventEngine } from "@orbital-stellar/pulse-core";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
@@ -411,7 +411,7 @@ Phase 1, lands in `v1.0`. Subscribes to smart-contract events by contract ID and
 
 ```ts
 // 🛠️ Planned API — Phase 1 (Q2–Q3 2026)
-import { EventEngine } from "@orbital/pulse-core";
+import { EventEngine } from "@orbital-stellar/pulse-core";
 
 const engine = new EventEngine({
   network: "mainnet",
@@ -440,8 +440,8 @@ Decoding to typed `decodedData` requires the ABI Registry client (also Phase 1).
 Inject a custom RNG into `WebhookDelivery` to make exponential backoff delays deterministic in your test suite. ✅
 
 ```ts
-import { Watcher } from "@orbital/pulse-core";
-import { WebhookDelivery } from "@orbital/pulse-webhooks";
+import { Watcher } from "@orbital-stellar/pulse-core";
+import { WebhookDelivery } from "@orbital-stellar/pulse-webhooks";
 import { vi } from "vitest";
 
 // A simple seeded RNG for deterministic results

--- a/docs/adr/003-hmac-no-versioning.md
+++ b/docs/adr/003-hmac-no-versioning.md
@@ -4,7 +4,7 @@
 |---|---|
 | **Status** | Accepted |
 | **Date** | 2026-05-29 |
-| **Affected** | `@orbital/pulse-webhooks` (`WebhookDelivery`, `verifyWebhook`, `verifyWebhookEdge`) |
+| **Affected** | `@orbital-stellar/pulse-webhooks` (`WebhookDelivery`, `verifyWebhook`, `verifyWebhookEdge`) |
 | **Supersedes** | — |
 
 ---

--- a/docs/adr/005-reference-composition-in-apps-web.md
+++ b/docs/adr/005-reference-composition-in-apps-web.md
@@ -80,7 +80,7 @@ Per [`docs/open-source-policy.md`](../open-source-policy.md), the production ans
 
 - The SDK public API is unchanged. No package code moved.
 - The webhook signing scheme, verification surface, and React hook API are independent of the reference-composition location.
-- The Cloud product's planned interface stays the same — it imports `@orbital/pulse-core` and `@orbital/pulse-webhooks`, layers a multi-tenant control plane on top, and ships that as a managed runtime.
+- The Cloud product's planned interface stays the same — it imports `@orbital-stellar/pulse-core` and `@orbital-stellar/pulse-webhooks`, layers a multi-tenant control plane on top, and ships that as a managed runtime.
 
 ---
 

--- a/docs/open-source-policy.md
+++ b/docs/open-source-policy.md
@@ -41,9 +41,9 @@ Everything below is in `packages/` or `apps/` today, or will be added to one of 
 
 ### Today (Phase 0, `v0.1.0`)
 
-- `@orbital/pulse-core` — EventEngine, Watcher, normalization layer, reconnection state machine
-- `@orbital/pulse-webhooks` — `WebhookDelivery`, `verifyWebhook`, `verifyWebhookEdge`
-- `@orbital/pulse-notify` — `useStellarEvent`, `useStellarPayment`, `useStellarActivity`
+- `@orbital-stellar/pulse-core` — EventEngine, Watcher, normalization layer, reconnection state machine
+- `@orbital-stellar/pulse-webhooks` — `WebhookDelivery`, `verifyWebhook`, `verifyWebhookEdge`
+- `@orbital-stellar/pulse-notify` — `useStellarEvent`, `useStellarPayment`, `useStellarActivity`
 - Event schemas — the `NormalizedEvent` discriminated union and per-event TypeScript shapes
 - Webhook delivery contract — header format, signing scheme, retry rules
 - Reference composition — the Next.js route handlers in `apps/web/app/api/*` that wire the three packages together end-to-end
@@ -62,7 +62,7 @@ Everything below is in `packages/` or `apps/` today, or will be added to one of 
 
 ### ABI Registry
 
-`@orbital/abi-registry` is the MIT package surface for Soroban ABI client code, schema helpers, and publishing interfaces.
+`@orbital-stellar/abi-registry` is the MIT package surface for Soroban ABI client code, schema helpers, and publishing interfaces.
 
 - Technical map: [`docs/ARCHITECTURE.md`](./ARCHITECTURE.md)
 - Package README: [`packages/abi-registry/README.md`](../packages/abi-registry/README.md)
@@ -71,18 +71,18 @@ The hosted verification / publishing service remains a separate Cloud product. T
 
 ### Phase 2 (2027)
 
-- `@orbital/hooks` — `useAccount`, `useBalance`, `useTransaction`, `useOrderBook`
-- `@orbital/payments` — send, receive, path-payment, payroll-batch primitives
-- `@orbital/auth` — WebAuthn / passkey embedded wallet SDK
-- `@orbital/analytics` — client library + event-volume reference dashboards
+- `@orbital-stellar/hooks` — `useAccount`, `useBalance`, `useTransaction`, `useOrderBook`
+- `@orbital-stellar/payments` — send, receive, path-payment, payroll-batch primitives
+- `@orbital-stellar/auth` — WebAuthn / passkey embedded wallet SDK
+- `@orbital-stellar/analytics` — client library + event-volume reference dashboards
 - First SEP submission — formalized event normalization format
 - Reference reactor contracts (Soroban Rust, open for anyone to fork)
 
 ### Phase 3 (2028+)
 
-- `@orbital/x402` — Express / Next.js middleware for payment-gated API access
-- `@orbital/agent-sdk` — payment client for autonomous AI agents
-- `@orbital/anchor-sdk` — SEP-24 / SEP-31 lifecycle client
+- `@orbital-stellar/x402` — Express / Next.js middleware for payment-gated API access
+- `@orbital-stellar/agent-sdk` — payment client for autonomous AI agents
+- `@orbital-stellar/anchor-sdk` — SEP-24 / SEP-31 lifecycle client
 - Intent compiler — at maturity, the DSL + graph runtime become OSS
 - Shadow-fork simulator OSS core
 - ZK-proof generation library (Noir / RiscZero circuits) — runnable locally
@@ -167,7 +167,7 @@ If you are not sure where a PR falls, open an issue with the `policy-question` l
 ## License commitment
 
 - **All current packages** ship under MIT and will not be relicensed. Specifically, Orbital commits to **not** adopting source-available licenses (SSPL, BSL, Elastic License, Functional Source License, or successors) for any code that has shipped under MIT.
-- **All future SDK packages** under the `@orbital/` namespace will ship under MIT.
+- **All future SDK packages** under the `@orbital-stellar/` namespace will ship under MIT.
 - **Reference implementations, schemas, and specs** ship under MIT. This includes the event normalization format, the webhook delivery contract, and the Soroban ABI Registry schema.
 - **The marketing and documentation site** (`apps/web/`) is MIT — you may fork and adapt it.
 

--- a/docs/proposal.md
+++ b/docs/proposal.md
@@ -34,9 +34,9 @@ Three MIT-licensed packages, designed to be composed and (at Phase 1) published 
 
 | Package | Role |
 |---|---|
-| `@orbital/pulse-core` | Event engine — Horizon + Stellar RPC subscription, normalized typed events, reconnection |
-| `@orbital/pulse-webhooks` | HMAC-signed webhook delivery, retry, SSRF hardening, edge-runtime verification |
-| `@orbital/pulse-notify` | React hooks (`useStellarEvent`, `useStellarPayment`, `useStellarActivity`) |
+| `@orbital-stellar/pulse-core` | Event engine — Horizon + Stellar RPC subscription, normalized typed events, reconnection |
+| `@orbital-stellar/pulse-webhooks` | HMAC-signed webhook delivery, retry, SSRF hardening, edge-runtime verification |
+| `@orbital-stellar/pulse-notify` | React hooks (`useStellarEvent`, `useStellarPayment`, `useStellarActivity`) |
 
 Phase 0 (foundation) shipped as [`v0.1.0`](../CHANGELOG.md) — full classic operation taxonomy, edge-runtime verification, React hooks, reference composition. This proposal funds **Phase 1: production-grade `v1.0`** — the milestone at which any Stellar team can build on Orbital with a stability pledge.
 
@@ -141,9 +141,9 @@ Three reference projects: `orbital-next-starter`, `orbital-express-starter`, `or
 
 ### M6 · `v1.0` stability pledge + npm publish
 
-All three packages published under `@orbital/` on npm with a documented stability contract: no breaking changes within `v1.x` without a 6-month deprecation window.
+All three packages published under `@orbital-stellar/` on npm with a documented stability contract: no breaking changes within `v1.x` without a 6-month deprecation window.
 
-**Done when:** `pnpm add @orbital/pulse-core` works, semver policy is documented in `STABILITY.md`, and a v1.0 release is tagged on GitHub.
+**Done when:** `pnpm add @orbital-stellar/pulse-core` works, semver policy is documented in `STABILITY.md`, and a v1.0 release is tagged on GitHub.
 
 ---
 
@@ -211,8 +211,8 @@ Phase 1 will be delivered by the same founder with the same commit transparency.
 
 Reproduced from [`ROADMAP.md`](../ROADMAP.md) for context only — these are not Phase 1 deliverables and not part of this funding ask:
 
-- **Phase 2 (2027)** — `@orbital/hooks` data hook library, `@orbital/payments` transaction primitives, `@orbital/auth` passkey embedded wallets, `@orbital/analytics`, **first SEP submission** formalizing the event normalization format.
-- **Phase 3 (2028+)** — `@orbital/x402` payment-gated middleware, `@orbital/agent-sdk` for autonomous AI agent payments on Stellar, `@orbital/anchor-sdk` for SEP-24/SEP-31, intent compiler, shadow-fork simulator.
+- **Phase 2 (2027)** — `@orbital-stellar/hooks` data hook library, `@orbital-stellar/payments` transaction primitives, `@orbital-stellar/auth` passkey embedded wallets, `@orbital-stellar/analytics`, **first SEP submission** formalizing the event normalization format.
+- **Phase 3 (2028+)** — `@orbital-stellar/x402` payment-gated middleware, `@orbital-stellar/agent-sdk` for autonomous AI agent payments on Stellar, `@orbital-stellar/anchor-sdk` for SEP-24/SEP-31, intent compiler, shadow-fork simulator.
 - **Phase 4 (long-term)** — identity layer, reactor-contract library, 10+ SEPs.
 
 Each future phase will be a separate proposal if grant support is sought.

--- a/packages/abi-registry/README.md
+++ b/packages/abi-registry/README.md
@@ -1,9 +1,9 @@
-# @orbital/abi-registry
+# @orbital-stellar/abi-registry
 
 **Shared Soroban ABI registry for Orbital.** This package holds the canonical client surface for ABI-aware code, along with schema helpers and publisher abstractions that keep Soroban integration logic consistent across the repo.
 
 ```bash
-pnpm add @orbital/abi-registry
+pnpm add @orbital-stellar/abi-registry
 ```
 
 ## What it does
@@ -27,7 +27,7 @@ import {
   RegistryPublisher,
   jsToScval,
   scvalToJs,
-} from "@orbital/abi-registry";
+} from "@orbital-stellar/abi-registry";
 
 const client = new AbiRegistryClient({
   baseUrl: "https://abi.example.com",

--- a/packages/abi-registry/package-lock.json
+++ b/packages/abi-registry/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@orbital/abi-registry",
+  "name": "@orbital-stellar/abi-registry",
   "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@orbital/abi-registry",
+      "name": "@orbital-stellar/abi-registry",
       "version": "0.0.0",
       "devDependencies": {
         "@types/node": "^25.5.0",

--- a/packages/abi-registry/package.json
+++ b/packages/abi-registry/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@orbital/abi-registry",
+  "name": "@orbital-stellar/abi-registry",
   "version": "0.1.0",
   "description": "Canonical Soroban ABI client, schema helpers, and registry publisher interface for Orbital.",
   "license": "MIT",

--- a/packages/abi-registry/specs/README.md
+++ b/packages/abi-registry/specs/README.md
@@ -83,7 +83,7 @@ A contract qualifies as a well-known spec when it meets **all** of the following
 
 1. **Check eligibility** — confirm the contract meets all four criteria above.
 2. **Derive the contract ID** — use the Stellar CLI or SDK to obtain the canonical C-prefixed address.
-3. **Author the spec** — create `specs/well-known/<token-symbol-lowercase>.json` following the schema. Run `pnpm --filter @orbital/abi-registry validate` to confirm it passes before opening a PR.
+3. **Author the spec** — create `specs/well-known/<token-symbol-lowercase>.json` following the schema. Run `pnpm --filter @orbital-stellar/abi-registry validate` to confirm it passes before opening a PR.
 4. **Update the index** — add an entry to `specs/well-known/index.json` with `name`, `contract_id`, `file`, `description`, and `tags`.
 5. **Open a pull request** — include:
    - The new spec file.
@@ -127,7 +127,7 @@ All specs are validated against `specs/well-known/schema.json` using the `valida
 
 ```bash
 # From the repo root
-pnpm --filter @orbital/abi-registry validate
+pnpm --filter @orbital-stellar/abi-registry validate
 
 # Or from the package directory
 cd packages/abi-registry
@@ -144,4 +144,4 @@ node validate.js
 - `0` — all specs pass.
 - `1` — one or more specs fail; errors are printed to stderr with the file path and the failing field.
 
-CI runs `pnpm --filter @orbital/abi-registry validate` on every pull request that touches `packages/abi-registry/`.
+CI runs `pnpm --filter @orbital-stellar/abi-registry validate` on every pull request that touches `packages/abi-registry/`.

--- a/packages/pulse-core/README.md
+++ b/packages/pulse-core/README.md
@@ -1,21 +1,21 @@
-# @orbital/pulse-core
+# @orbital-stellar/pulse-core
 
 **The event engine at the center of Orbital.** Subscribes to Stellar network activity, normalizes it into a typed event model, and routes it to per-address watchers.
 
 ```bash
-pnpm add @orbital/pulse-core
+pnpm add @orbital-stellar/pulse-core
 ```
 
 ## What it does
 
 `pulse-core` opens a single streaming connection to Horizon (and, coming soon, Stellar RPC for Soroban events), normalizes each incoming record into a uniform shape, and emits it to any `Watcher` subscribed to the affected address. Reconnection, backoff, and cleanup are handled automatically.
 
-You install `pulse-core` when you want to consume Stellar events in-process — typically inside a server, background worker, or CLI. If you need webhook delivery or React integration, layer [`@orbital/pulse-webhooks`](../pulse-webhooks) or [`@orbital/pulse-notify`](../pulse-notify) on top.
+You install `pulse-core` when you want to consume Stellar events in-process — typically inside a server, background worker, or CLI. If you need webhook delivery or React integration, layer [`@orbital-stellar/pulse-webhooks`](../pulse-webhooks) or [`@orbital-stellar/pulse-notify`](../pulse-notify) on top.
 
 ## Quickstart
 
 ```ts
-import { EventEngine } from "@orbital/pulse-core";
+import { EventEngine } from "@orbital-stellar/pulse-core";
 
 const engine = new EventEngine({
   network: "testnet",
@@ -67,7 +67,7 @@ Stops and removes the watcher for the given address.
 `pulse-core` exports `NETWORK_PASSPHRASES` as the source of truth for the supported Stellar network passphrases:
 
 ```ts
-import { NETWORK_PASSPHRASES } from "@orbital/pulse-core";
+import { NETWORK_PASSPHRASES } from "@orbital-stellar/pulse-core";
 
 NETWORK_PASSPHRASES.mainnet; // "Public Global Stellar Network ; September 2015"
 NETWORK_PASSPHRASES.testnet; // "Test SDF Network ; September 2015"
@@ -97,7 +97,7 @@ Normalized asset strings follow one rule across every event payload:
 | `webhook.dropped` | `NormalizedEvent` | A pending webhook retry is dropped because the concurrency cap is reached (emitted by `pulse-webhooks`) |
 
 > [!NOTE]
-> Webhook events (`webhook.failed` and `webhook.dropped`) are emitted on the `Watcher` by the [`@orbital/pulse-webhooks`](../pulse-webhooks/README.md) package when attached. For these events, the `NormalizedEvent`'s `raw` field is populated with specialized metadata objects (`WebhookFailureRaw` and `WebhookDroppedRaw`, respectively). See the [Failure events section of `@orbital/pulse-webhooks`](../pulse-webhooks/README.md#failure-events) for detailed documentation and payload schemas.
+> Webhook events (`webhook.failed` and `webhook.dropped`) are emitted on the `Watcher` by the [`@orbital-stellar/pulse-webhooks`](../pulse-webhooks/README.md) package when attached. For these events, the `NormalizedEvent`'s `raw` field is populated with specialized metadata objects (`WebhookFailureRaw` and `WebhookDroppedRaw`, respectively). See the [Failure events section of `@orbital-stellar/pulse-webhooks`](../pulse-webhooks/README.md#failure-events) for detailed documentation and payload schemas.
 
 > [!NOTE]
 > For `engine.cursor_expired` notifications, the `WatcherNotification` payload includes additional fields:
@@ -133,7 +133,7 @@ Every event includes a `timestamp` (ISO 8601) and a `raw` field with the origina
 Use the `isEventType` helper to narrow events to specific types in a type-safe way:
 
 ```ts
-import { EventEngine, isEventType } from "@orbital/pulse-core";
+import { EventEngine, isEventType } from "@orbital-stellar/pulse-core";
 
 const engine = new EventEngine({ network: "testnet" });
 engine.start();
@@ -182,7 +182,7 @@ watcher.on("*", (event) => {
 Run it with:
 
 ```bash
-pnpm --filter @orbital/pulse-core exec node --expose-gc --import tsx bench/throughput.ts --records=100000
+pnpm --filter @orbital-stellar/pulse-core exec node --expose-gc --import tsx bench/throughput.ts --records=100000
 ```
 
 The harness subscribes `N` watchers and replays `M` synthetic payment records through the engine's normalize + route path, then reports memory and routed events/sec.
@@ -204,7 +204,7 @@ Soroban contract event subscription has a matching replay benchmark at `bench/so
 Run it with:
 
 ```bash
-pnpm --filter @orbital/pulse-core exec node --expose-gc --import tsx bench/soroban-throughput.ts
+pnpm --filter @orbital-stellar/pulse-core exec node --expose-gc --import tsx bench/soroban-throughput.ts
 ```
 
 The harness subscribes `N` contract watchers with exact `contractIds` filters, synthesizes `getEvents` responses, and replays each RPC event through the engine's normalize + route + emit path. Use `--responses=100 --events-per-response=100` to scale the replay size.

--- a/packages/pulse-core/package-lock.json
+++ b/packages/pulse-core/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@orbital/pulse-core",
+  "name": "@orbital-stellar/pulse-core",
   "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@orbital/pulse-core",
+      "name": "@orbital-stellar/pulse-core",
       "version": "0.0.0",
       "dependencies": {
         "@stellar/stellar-sdk": "^15.0.1"

--- a/packages/pulse-core/package.json
+++ b/packages/pulse-core/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@orbital/pulse-core",
+  "name": "@orbital-stellar/pulse-core",
   "version": "0.1.0",
   "description": "EventEngine for Stellar — Horizon subscription, event normalization, reconnection, and rate-limit handling.",
   "license": "MIT",

--- a/packages/pulse-core/src/events.ts
+++ b/packages/pulse-core/src/events.ts
@@ -1,9 +1,9 @@
 /**
  * Per-event named types for pulse-core, grouped for precise type narrowing.
- * Accessible via the `events` namespace export from "@orbital/pulse-core".
+ * Accessible via the `events` namespace export from "@orbital-stellar/pulse-core".
  *
  * @example
- * import type { events } from "@orbital/pulse-core";
+ * import type { events } from "@orbital-stellar/pulse-core";
  * type Payment = events.PaymentEvent;
  */
 export type {

--- a/packages/pulse-core/src/index.ts
+++ b/packages/pulse-core/src/index.ts
@@ -320,7 +320,7 @@ export type AccountMergeEvent = {
  * namespace export:
  *
  * ```ts
- * import type { events } from "@orbital/pulse-core";
+ * import type { events } from "@orbital-stellar/pulse-core";
  * type Payment = events.PaymentEvent;
  * type AccountCreated = events.AccountCreatedEvent;
  * ```
@@ -422,7 +422,7 @@ export interface Logger {
 
 /**
  * Minimal interface for an ABI registry client.
- * Satisfied by `AbiRegistryClient` from `@orbital/abi-registry`, or any
+ * Satisfied by `AbiRegistryClient` from `@orbital-stellar/abi-registry`, or any
  * object with a compatible `getSpec` method (useful for testing).
  */
 export interface AbiRegistryClientLike {
@@ -569,7 +569,7 @@ export type ContractSubscribeOptions = {
  * @see {@link events} for the full list of narrower per-event types.
  *
  * @example
- * import type { events } from "@orbital/pulse-core";
+ * import type { events } from "@orbital-stellar/pulse-core";
  * function handlePayment(e: events.PaymentEvent) { ... }
  */
 export * as events from "./events.js";

--- a/packages/pulse-notify/README.md
+++ b/packages/pulse-notify/README.md
@@ -1,9 +1,9 @@
-# @orbital/pulse-notify
+# @orbital-stellar/pulse-notify
 
 **React hooks for live Stellar events.** Drop a hook into any component and receive real-time payment, activity, or custom event streams from an Orbital server — with automatic reconnection and zero wiring.
 
 ```bash
-pnpm add @orbital/pulse-notify react
+pnpm add @orbital-stellar/pulse-notify react
 ```
 
 Requires React 18 or 19. Designed for Next.js App Router, Vite, Remix, and plain React apps.
@@ -18,7 +18,7 @@ You point the hook at your own Orbital server (self-hosted or managed) and pass 
 
 ```tsx
 "use client";
-import { useStellarPayment } from "@orbital/pulse-notify";
+import { useStellarPayment } from "@orbital-stellar/pulse-notify";
 
 export function LiveBalance({ address }: { address: string }) {
   const { event, connected, error } = useStellarPayment(
@@ -54,7 +54,7 @@ This package's own `test/connectionPool.test.ts` shows the `EventSource` polyfil
 import { http, HttpResponse } from "msw";
 import { setupServer } from "msw/node";
 import { renderHook, act } from "@testing-library/react";
-import { useStellarActivity } from "@orbital/pulse-notify";
+import { useStellarActivity } from "@orbital-stellar/pulse-notify";
 
 class MockEventSource {
   static instances: MockEventSource[] = [];
@@ -161,7 +161,7 @@ Small client-side status indicator for places that need connection health but do
 
 ```tsx
 "use client";
-import { StellarConnectionStatus } from "@orbital/pulse-notify";
+import { StellarConnectionStatus } from "@orbital-stellar/pulse-notify";
 
 export function HeaderConnection({ address }: { address: string }) {
   return (
@@ -202,8 +202,8 @@ type EventState<T extends NormalizedEvent = NormalizedEvent> = {
 `useStellarEvent` is generic — pass a narrower union as `T` to get full IDE support and avoid manual casts. Use TypeScript's `Extract` to pull specific event types out of `NormalizedEvent`:
 
 ```tsx
-import type { NormalizedEvent } from "@orbital/pulse-core";
-import { useStellarEvent } from "@orbital/pulse-notify";
+import type { NormalizedEvent } from "@orbital-stellar/pulse-core";
+import { useStellarEvent } from "@orbital-stellar/pulse-notify";
 
 type WalletEvents = Extract<
   NormalizedEvent,

--- a/packages/pulse-notify/TRANSPORTS.md
+++ b/packages/pulse-notify/TRANSPORTS.md
@@ -38,4 +38,4 @@
 }
 ```
 
-All fields match the `NormalizedEvent` union from `@orbital/pulse-core`.
+All fields match the `NormalizedEvent` union from `@orbital-stellar/pulse-core`.

--- a/packages/pulse-notify/package.json
+++ b/packages/pulse-notify/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@orbital/pulse-notify",
+  "name": "@orbital-stellar/pulse-notify",
   "version": "0.1.0",
   "description": "React hooks for live Stellar events — useStellarEvent, useStellarPayment, useStellarActivity.",
   "license": "MIT",
@@ -26,7 +26,7 @@
     "size": "size-limit"
   },
   "dependencies": {
-    "@orbital/pulse-core": "workspace:*"
+    "@orbital-stellar/pulse-core": "workspace:*"
   },
   "devDependencies": {
     "@size-limit/preset-small-lib": "^11.0.0",

--- a/packages/pulse-notify/src/connectionPool.ts
+++ b/packages/pulse-notify/src/connectionPool.ts
@@ -1,4 +1,4 @@
-import type { NormalizedEvent } from "@orbital/pulse-core";
+import type { NormalizedEvent } from "@orbital-stellar/pulse-core";
 
 type ConnectionKey = {
   serverUrl: string;

--- a/packages/pulse-notify/src/index.ts
+++ b/packages/pulse-notify/src/index.ts
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef } from "react";
-import type { NormalizedEvent, PaymentEvent } from "@orbital/pulse-core";
+import type { NormalizedEvent, PaymentEvent } from "@orbital-stellar/pulse-core";
 import { acquireEventConnection } from "./connectionPool.js";
 import { acquireWsConnection } from "./wsTransport.js";
 export { useStellarEventSuspense } from "./useStellarEventSuspense.js";

--- a/packages/pulse-notify/src/useStellarEventSuspense.ts
+++ b/packages/pulse-notify/src/useStellarEventSuspense.ts
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from "react";
-import type { NormalizedEvent } from "@orbital/pulse-core";
+import type { NormalizedEvent } from "@orbital-stellar/pulse-core";
 import { acquireEventConnection } from "./connectionPool.js";
 import type { UseEventConfig } from "./index.js";
 
@@ -82,7 +82,7 @@ function getOrCreateResource<T extends NormalizedEvent>(
  * ```tsx
  * "use client";
  * import { Suspense } from "react";
- * import { useStellarEventSuspense } from "@orbital/pulse-notify";
+ * import { useStellarEventSuspense } from "@orbital-stellar/pulse-notify";
  *
  * function LiveBalance({ address }: { address: string }) {
  *   // Never returns null — component is suspended until data arrives.

--- a/packages/pulse-notify/src/vitePlugin.ts
+++ b/packages/pulse-notify/src/vitePlugin.ts
@@ -2,16 +2,16 @@
  * pulseNotifyVitePlugin
  * ---------------------
  * Stubs the browser-only `EventSource` global during Vite SSR so that
- * importing `@orbital/pulse-notify` in a server-side render context does not
+ * importing `@orbital-stellar/pulse-notify` in a server-side render context does not
  * throw "EventSource is not defined".
  *
  * ### Usage (vite.config.ts)
  * ```ts
- * import { pulseNotifyVitePlugin } from "@orbital/pulse-notify/vitePlugin";
+ * import { pulseNotifyVitePlugin } from "@orbital-stellar/pulse-notify/vitePlugin";
  *
  * export default defineConfig({
  *   plugins: [pulseNotifyVitePlugin()],
- *   ssr: { noExternal: ["@orbital/pulse-notify"] },
+ *   ssr: { noExternal: ["@orbital-stellar/pulse-notify"] },
  * });
  * ```
  *

--- a/packages/pulse-notify/src/wsTransport.ts
+++ b/packages/pulse-notify/src/wsTransport.ts
@@ -1,4 +1,4 @@
-import type { NormalizedEvent } from "@orbital/pulse-core";
+import type { NormalizedEvent } from "@orbital-stellar/pulse-core";
 
 type ConnectionKey = {
   serverUrl: string;

--- a/packages/pulse-webhooks/README.md
+++ b/packages/pulse-webhooks/README.md
@@ -1,9 +1,9 @@
-# @orbital/pulse-webhooks
+# @orbital-stellar/pulse-webhooks
 
 **HMAC-signed webhook delivery for Stellar events.** Attach to a `pulse-core` watcher and every event becomes one or more outbound HTTPS POSTs with a verifiable signature, retry on failure, and configurable timeout.
 
 ```bash
-pnpm add @orbital/pulse-webhooks @orbital/pulse-core
+pnpm add @orbital-stellar/pulse-webhooks @orbital-stellar/pulse-core
 ```
 
 ## What it does
@@ -15,8 +15,8 @@ Consumers verify the signature using the shared secret you provisioned — `veri
 ## Quickstart — sender side
 
 ```ts
-import { EventEngine } from "@orbital/pulse-core";
-import { WebhookDelivery } from "@orbital/pulse-webhooks";
+import { EventEngine } from "@orbital-stellar/pulse-core";
+import { WebhookDelivery } from "@orbital-stellar/pulse-webhooks";
 
 const engine = new EventEngine({ network: "testnet" });
 engine.start();
@@ -37,7 +37,7 @@ new WebhookDelivery(watcher, {
 ## Quickstart — receiver side
 
 ```ts
-import { verifyWebhook } from "@orbital/pulse-webhooks";
+import { verifyWebhook } from "@orbital-stellar/pulse-webhooks";
 import express from "express";
 
 const app = express();
@@ -71,7 +71,7 @@ app.post(
 Cloudflare Workers don't have Node.js crypto — they use Web Crypto API. Use `verifyWebhookEdge` for edge runtime compatibility:
 
 ```js
-import { verifyWebhookEdge } from "@orbital/pulse-webhooks";
+import { verifyWebhookEdge } from "@orbital-stellar/pulse-webhooks";
 
 export default {
   async fetch(request, env, ctx) {
@@ -157,7 +157,7 @@ When a delivery cannot be completed, the `Watcher` emits special events for rout
 Emitted after all retry attempts are exhausted for a given URL. The event payload is a `NormalizedEvent` where the `raw` field is a `WebhookFailureRaw` object:
 
 ```ts
-import type { WebhookFailureRaw } from "@orbital/pulse-webhooks";
+import type { WebhookFailureRaw } from "@orbital-stellar/pulse-webhooks";
 
 watcher.on("webhook.failed", (event) => {
   const meta = event.raw as WebhookFailureRaw;
@@ -171,7 +171,7 @@ watcher.on("webhook.failed", (event) => {
 Emitted when a pending retry is dropped because the `maxConcurrentRetries` cap has been reached. This happens before the retry is even attempted. The `raw` field is a `WebhookDroppedRaw` object:
 
 ```ts
-import type { WebhookDroppedRaw } from "@orbital/pulse-webhooks";
+import type { WebhookDroppedRaw } from "@orbital-stellar/pulse-webhooks";
 
 watcher.on("webhook.dropped", (event) => {
   const meta = event.raw as WebhookDroppedRaw;
@@ -197,7 +197,7 @@ watcher.on("webhook.dropped", (event) => {
 Failed webhooks are automatically tracked in a `DeadLetterStore`. Query failures by URL, time window, or limit.
 
 ```ts
-import { DeadLetterStore, WebhookDelivery } from "@orbital/pulse-webhooks";
+import { DeadLetterStore, WebhookDelivery } from "@orbital-stellar/pulse-webhooks";
 
 const dlq = new DeadLetterStore();
 

--- a/packages/pulse-webhooks/package.json
+++ b/packages/pulse-webhooks/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@orbital/pulse-webhooks",
+  "name": "@orbital-stellar/pulse-webhooks",
   "version": "0.1.0",
   "description": "HMAC-signed webhook delivery and verification for Stellar events (Node + edge runtimes).",
   "license": "MIT",
@@ -24,7 +24,7 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@orbital/pulse-core": "workspace:*"
+    "@orbital-stellar/pulse-core": "workspace:*"
   },
   "devDependencies": {
     "@types/node": "^25.6.0",

--- a/packages/pulse-webhooks/src/MemoryDeadLetterStore.ts
+++ b/packages/pulse-webhooks/src/MemoryDeadLetterStore.ts
@@ -1,4 +1,4 @@
-import type { NormalizedEvent } from "@orbital/pulse-core";
+import type { NormalizedEvent } from "@orbital-stellar/pulse-core";
 
 export interface DeadLetterEntry {
   id: string;

--- a/packages/pulse-webhooks/src/PostgresDeadLetterStore.ts
+++ b/packages/pulse-webhooks/src/PostgresDeadLetterStore.ts
@@ -1,4 +1,4 @@
-import type { NormalizedEvent } from "@orbital/pulse-core";
+import type { NormalizedEvent } from "@orbital-stellar/pulse-core";
 
 export type PgQueryResult<Row> = {
   rows: Row[];

--- a/packages/pulse-webhooks/src/edge.ts
+++ b/packages/pulse-webhooks/src/edge.ts
@@ -1,4 +1,4 @@
-import type { NormalizedEvent } from "@orbital/pulse-core";
+import type { NormalizedEvent } from "@orbital-stellar/pulse-core";
 
 import type { VerifyWebhookOptions } from "./types.js";
 import { DEFAULT_MAX_AGE_MS, DEFAULT_CLOCK_SKEW_MS } from "./types.js";

--- a/packages/pulse-webhooks/src/index.ts
+++ b/packages/pulse-webhooks/src/index.ts
@@ -1,4 +1,4 @@
-import type { NormalizedEvent, Watcher, WatcherNotification } from "@orbital/pulse-core";
+import type { NormalizedEvent, Watcher, WatcherNotification } from "@orbital-stellar/pulse-core";
 import { createHmac, timingSafeEqual } from "crypto";
 
 import { DeadLetterStore } from "./MemoryDeadLetterStore.js";

--- a/packages/pulse-webhooks/src/types.ts
+++ b/packages/pulse-webhooks/src/types.ts
@@ -54,5 +54,5 @@ export type VerifyWebhookOptions = {
   /** Optional schema hook to validate the parsed `NormalizedEvent`. When provided, the verifier
    *  will run this after signature verification and return `null` if it returns `false`.
    */
-  schema?: (event: import("@orbital/pulse-core").NormalizedEvent) => boolean;
+  schema?: (event: import("@orbital-stellar/pulse-core").NormalizedEvent) => boolean;
 };

--- a/packages/pulse-webhooks/test/RedisRetryQueue.test.ts
+++ b/packages/pulse-webhooks/test/RedisRetryQueue.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import type { NormalizedEvent } from "@orbital/pulse-core";
+import type { NormalizedEvent } from "@orbital-stellar/pulse-core";
 import {
   RedisRetryQueue,
   type RedisLike,

--- a/packages/pulse-webhooks/test/pulse-webhooks.test.ts
+++ b/packages/pulse-webhooks/test/pulse-webhooks.test.ts
@@ -1,7 +1,7 @@
 import { createHmac } from "crypto";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { Watcher } from "@orbital/pulse-core";
+import { Watcher } from "@orbital-stellar/pulse-core";
 import type { WebhookMetrics } from "../src/index.js";
 import {
   DeadLetterStore,

--- a/packages/pulse-webhooks/vitest.config.ts
+++ b/packages/pulse-webhooks/vitest.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
     },
     resolve: {
         alias: {
-            "@orbital/pulse-core": fileURLToPath(
+            "@orbital-stellar/pulse-core": fileURLToPath(
                 new URL("../pulse-core/src/index.ts", import.meta.url)
             ),
         },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,7 +19,7 @@ importers:
 
   apps/web:
     dependencies:
-      '@orbital/pulse-core':
+      '@orbital-stellar/pulse-core':
         specifier: workspace:*
         version: link:../../packages/pulse-core
       framer-motion:
@@ -124,7 +124,7 @@ importers:
 
   packages/pulse-notify:
     dependencies:
-      '@orbital/pulse-core':
+      '@orbital-stellar/pulse-core':
         specifier: workspace:*
         version: link:../pulse-core
     devDependencies:
@@ -164,7 +164,7 @@ importers:
 
   packages/pulse-webhooks:
     dependencies:
-      '@orbital/pulse-core':
+      '@orbital-stellar/pulse-core':
         specifier: workspace:*
         version: link:../pulse-core
     devDependencies:


### PR DESCRIPTION
The bare `@orbital` scope is already taken on npm by an unrelated project (`@orbital/core` "the CLI framework from the future"), so we cannot publish under it. Rescopes all four packages to **`@orbital-stellar`** (matches the repo name `orbital_stellar`).

Renames package names, `workspace:*` deps, all TypeScript imports, README/docs examples, and the CLI bin (253 replacements across 61 files).

**Verified:** build green, all suites green (abi-registry 78, pulse-core 431, pulse-webhooks 73, pulse-notify 12), and `pnpm -r publish --dry-run` shows `@orbital-stellar/*` @ `0.1.0` with `workspace:*` correctly rewritten to `0.1.0`.