### PR TITLE
chore(pulse-core): route console.* through the injectable logger

### DIFF
--- a/packages/pulse-core/src/EventEngine.ts
+++ b/packages/pulse-core/src/EventEngine.ts
@@ -157,7 +157,7 @@ export class EventEngine {
   private lastEventAt: string | null = null;
   private horizonCursor?: string;
   private filters: Map<string, (event: NormalizedEvent) => boolean> = new Map();
-  private log: Required<NonNullable<CoreConfig["logger"]>>;
+  private log: Logger;
   private cursorStore?: CursorStore;
   private readonly network: Network;
   private streamKey: string;
@@ -1886,14 +1886,14 @@ export interface RpcContractEmittedEvent {
  * Handles malformed fields safely by logging warnings and returning null.
  */
 export function normalizeContractEvent(
-  rawRpcEvent: any
+  rawRpcEvent: any,
+  logger?: Logger
 ): RpcContractInvokedEvent | RpcContractEmittedEvent | null {
-  // export function normalizeContractEvent(rawRpcEvent: any): SorobanContractInvokedEvent | SorobanContractEmittedEvent | null {
   // 1. Structural check patterns
   if (!rawRpcEvent || typeof rawRpcEvent !== "object") {
-    console.warn(
+    logger?.warn(
       "[pulse-core] Dropping malformed Soroban event: payload is not a valid object.",
-      rawRpcEvent
+      { event: rawRpcEvent }
     );
     return null;
   }
@@ -1911,9 +1911,9 @@ export function normalizeContractEvent(
   ];
   for (const field of requiredFields) {
     if (e[field] === undefined || e[field] === null) {
-      console.warn(
+      logger?.warn(
         `[pulse-core] Dropping malformed Soroban event: missing required field "${field}".`,
-        rawRpcEvent
+        { event: rawRpcEvent }
       );
       return null;
     }
@@ -1932,7 +1932,7 @@ export function normalizeContractEvent(
 
   if (type === "system" || type === "diagnostic") {
     if (typeof rawRpcEvent.function !== "string") {
-      console.warn("[pulse-core] Dropping malformed contract invoked event: missing function field.", rawRpcEvent);
+      logger?.warn("[pulse-core] Dropping malformed contract invoked event: missing function field.", { event: rawRpcEvent });
       return null;
     }
     return {
@@ -1950,9 +1950,9 @@ export function normalizeContractEvent(
 
   if (type === "contract") {
     if (!Array.isArray(topic) || value === undefined || value === null) {
-      console.warn(
+      logger?.warn(
         "[pulse-core] Dropping malformed contract emitted event: missing topics array or data payload.",
-        rawRpcEvent
+        { event: rawRpcEvent }
       );
       return null;
     }
@@ -1972,9 +1972,9 @@ export function normalizeContractEvent(
     };
   }
 
-  console.warn(
+  logger?.warn(
     `[pulse-core] Dropping malformed Soroban event: unknown event type category "${type}".`,
-    rawRpcEvent
+    { event: rawRpcEvent }
   );
   return null;
 }

--- a/packages/pulse-core/src/FileCursorStore.ts
+++ b/packages/pulse-core/src/FileCursorStore.ts
@@ -2,6 +2,7 @@ import { promises as fsPromises, constants as fsConstants } from "fs";
 import fs from "fs";
 import path from "path";
 import { CursorStore } from "./CursorStore.js";
+import type { Logger } from "./index.js";
 
 function safeFilename(streamKey: string): string {
   return encodeURIComponent(streamKey) + ".json";
@@ -9,10 +10,12 @@ function safeFilename(streamKey: string): string {
 
 export class FileCursorStore extends CursorStore {
   private readonly dir: string;
+  private readonly logger?: Logger;
 
-  constructor(dir: string) {
+  constructor(dir: string, logger?: Logger) {
     super();
     this.dir = dir;
+    this.logger = logger;
   }
 
   private filePathFor(streamKey: string): string {
@@ -32,8 +35,9 @@ export class FileCursorStore extends CursorStore {
         if (parsed && typeof parsed.cursor === "string") return parsed.cursor;
         return null;
       } catch (err) {
-        console.warn(
+        this.logger?.warn(
           `FileCursorStore: failed to parse cursor file ${file}, treating as missing`,
+          { file },
         );
         return null;
       }

--- a/packages/pulse-core/src/SorobanRpcClient.ts
+++ b/packages/pulse-core/src/SorobanRpcClient.ts
@@ -1,4 +1,4 @@
-import type { ContractSubscriptionFilter } from "./index.js";
+import type { ContractSubscriptionFilter, Logger } from "./index.js";
 import { SorobanRpcError, type SorobanRpcErrorCode } from "./errors.js";
 
 export type SorobanNetworkInfo = {
@@ -29,6 +29,8 @@ export interface SorobanRpcClientOptions {
   headers?: Record<string, string>;
   /** Injectable `fetch` implementation (for testing). Defaults to `globalThis.fetch`. */
   fetchImpl?: typeof fetch;
+  /** Optional logger. Per-request diagnostics go to `logger.debug` (header values redacted). */
+  logger?: Logger;
 }
 
 /** Result of a `getEvents` call: the JSON-RPC `result` payload with `events` guaranteed. */
@@ -118,6 +120,7 @@ export class SorobanRpcClient {
   private readonly url: string;
   private readonly headers: Record<string, string>;
   private readonly fetchImpl?: typeof fetch;
+  private readonly logger?: Logger;
 
   /**
    * @param options - Configuration for the RPC client.
@@ -126,6 +129,7 @@ export class SorobanRpcClient {
     this.url = (options.rpcUrl ?? options.url) as string;
     this.headers = { ...(options.headers ?? {}) };
     this.fetchImpl = options.fetchImpl;
+    this.logger = options.logger;
   }
 
   /**
@@ -159,12 +163,10 @@ export class SorobanRpcClient {
       params,
     });
 
-    console.log(
-      "[SorobanRpcClient] Sending request:",
+    this.logger?.debug?.("[SorobanRpcClient] sending request", {
       method,
-      "with headers:",
-      this.getRedactedHeaders()
-    );
+      headers: this.getRedactedHeaders(),
+    });
 
     const fetchImpl = this.fetchImpl ?? globalThis.fetch;
 

--- a/packages/pulse-core/src/index.ts
+++ b/packages/pulse-core/src/index.ts
@@ -403,21 +403,8 @@ export interface Logger {
   info(message: string, meta?: Record<string, unknown>): void;
   warn(message: string, meta?: Record<string, unknown>): void;
   error(message: string, meta?: Record<string, unknown>): void;
-}
-
-/**
- * Core configuration for initializing the EventEngine.
- *
- * @example
- * const config: CoreConfig = {
- *   network: "testnet",
- *   reconnect: { initialDelayMs: 2000, maxRetries: 5 }
- * };
- */
-export interface Logger {
-  info(message: string, meta?: Record<string, unknown>): void;
-  warn(message: string, meta?: Record<string, unknown>): void;
-  error(message: string, meta?: Record<string, unknown>): void;
+  /** Optional verbose channel for per-request / per-event diagnostics. */
+  debug?(message: string, meta?: Record<string, unknown>): void;
 }
 
 /**

--- a/packages/pulse-core/test/EventEngine.normalizeContract.test.ts
+++ b/packages/pulse-core/test/EventEngine.normalizeContract.test.ts
@@ -35,17 +35,17 @@ describe("Soroban Event Normalizer Utility Suite", () => {
     expect(emittedEvent.raw).toStrictEqual(mockTestnetEvent);
   });
 
-  it("should output null and log a console warning for broken payloads instead of throwing", () => {
-    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  it("should output null and log a warning for broken payloads instead of throwing", () => {
+    const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
 
     const brokenPayload = {
       type: "contract",
       ledger: 485921,
     };
 
-    const result = normalizeContractEvent(brokenPayload);
+    const result = normalizeContractEvent(brokenPayload, logger);
 
     expect(result).toBeNull();
-    expect(warnSpy).toHaveBeenCalled();
+    expect(logger.warn).toHaveBeenCalled();
   });
 });

--- a/packages/pulse-core/test/FileCursorStore.test.ts
+++ b/packages/pulse-core/test/FileCursorStore.test.ts
@@ -34,7 +34,8 @@ describe("FileCursorStore", () => {
   });
 
   it("returns null and warns on corrupted JSON file", async () => {
-    const store = new FileCursorStore(dir);
+    const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+    const store = new FileCursorStore(dir, logger);
     const key = "test-corrupt";
     const filename = path.join(dir, encodeURIComponent(key) + ".json");
 
@@ -42,12 +43,8 @@ describe("FileCursorStore", () => {
     fs.mkdirSync(dir, { recursive: true });
     fs.writeFileSync(filename, "{ not valid json", "utf8");
 
-    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
-
     const result = await store.get(key);
     expect(result).toBeNull();
-    expect(warnSpy).toHaveBeenCalled();
-
-    warnSpy.mockRestore();
+    expect(logger.warn).toHaveBeenCalled();
   });
 });

--- a/packages/pulse-core/test/SorobanRpcClient.auth.test.ts
+++ b/packages/pulse-core/test/SorobanRpcClient.auth.test.ts
@@ -130,26 +130,25 @@ describe("SorobanRpcClient — authenticated RPC providers", () => {
         json: async () => ({ jsonrpc: "2.0", id: 1, result: {} }),
       });
       vi.stubGlobal("fetch", fetchMock);
-      const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+      const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() };
 
       const client = new SorobanRpcClient({
         url: "https://soroban-rpc.example.com",
         headers: {
           Authorization: "Bearer super-secret-token-abc-123",
         },
+        logger,
       });
 
       await client.request("ping");
 
-      expect(consoleSpy).toHaveBeenCalledWith(
-        "[SorobanRpcClient] Sending request:",
-        "ping",
-        "with headers:",
-        { Authorization: "[REDACTED]" }
+      expect(logger.debug).toHaveBeenCalledWith(
+        "[SorobanRpcClient] sending request",
+        { method: "ping", headers: { Authorization: "[REDACTED]" } }
       );
-      // Verify the actual secret value does not appear in any log call
-      expect(consoleSpy).not.toHaveBeenCalledWith(
-        expect.stringContaining("super-secret-token-abc-123")
+      // The raw secret must never appear in any logged metadata.
+      expect(JSON.stringify(logger.debug.mock.calls)).not.toContain(
+        "super-secret-token-abc-123"
       );
     });
 
@@ -160,7 +159,7 @@ describe("SorobanRpcClient — authenticated RPC providers", () => {
         json: async () => ({ jsonrpc: "2.0", id: 1, result: {} }),
       });
       vi.stubGlobal("fetch", fetchMock);
-      const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+      const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() };
 
       const client = new SorobanRpcClient({
         url: "https://soroban-rpc.example.com",
@@ -168,15 +167,14 @@ describe("SorobanRpcClient — authenticated RPC providers", () => {
           "X-Api-Key": "my-api-key",
           "X-Secret": "my-secret-value",
         },
+        logger,
       });
 
       await client.request("ping");
 
-      expect(consoleSpy).toHaveBeenCalledWith(
-        "[SorobanRpcClient] Sending request:",
-        "ping",
-        "with headers:",
-        { "X-Api-Key": "[REDACTED]", "X-Secret": "[REDACTED]" }
+      expect(logger.debug).toHaveBeenCalledWith(
+        "[SorobanRpcClient] sending request",
+        { method: "ping", headers: { "X-Api-Key": "[REDACTED]", "X-Secret": "[REDACTED]" } }
       );
     });
   });


### PR DESCRIPTION
Library code no longer bypasses the configured logger with raw `console.*` (which printed regardless of the user's logger config).

- `normalizeContractEvent` takes an optional logger; malformed-event drops go to `logger.warn`.
- `SorobanRpcClient` takes an optional logger; the per-request diagnostic (redacted headers) goes to `logger.debug`.
- `FileCursorStore` takes an optional logger for its parse-failure warning.
- `Logger` gains an optional `debug()` channel; removed a duplicate `Logger` interface declaration.

Coupled tests now assert the injected logger instead of `console`. **No public API breaks** (all new params/methods optional). Build + all suites green; `apps/web` typechecks.