### PR TITLE
chore: minor polish — package metadata + README accuracy

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,8 +38,6 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: pnpm/action-setup@v6
-        with:
-          version: 10
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,8 +41,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v6
-        with:
-          version: 10
       - uses: actions/setup-node@v4
         with:
           node-version: 20
@@ -66,8 +64,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v6
-        with:
-          version: 10
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
@@ -93,8 +89,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v6
-        with:
-          version: 10
       - uses: actions/setup-node@v4
         with:
           node-version: 20
@@ -116,8 +110,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v6
-        with:
-          version: 10
       - uses: actions/setup-node@v4
         with:
           node-version: 20

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -23,8 +23,6 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: pnpm/action-setup@v6
-        with:
-          version: 10
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -22,8 +22,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
-        with:
-          version: 10
 
       - name: Setup Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,8 +23,6 @@ jobs:
           fetch-depth: 0
 
       - uses: pnpm/action-setup@v6
-        with:
-          version: 10
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -19,8 +19,6 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: pnpm/action-setup@v6
-        with:
-          version: 10
 
       - uses: actions/setup-node@v4
         with:

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![Node](https://img.shields.io/badge/node-20%20%7C%2022-339933?style=flat-square&logo=node.js)](.github/workflows/ci.yml)
 [![Conventional Commits](https://img.shields.io/badge/commits-conventional-fe5196?style=flat-square&logo=conventionalcommits)](https://www.conventionalcommits.org)
 
-> **Status**: Phase 0 — Foundation &nbsp;·&nbsp; **Networks**: testnet + mainnet &nbsp;·&nbsp; **License**: MIT
+> **Status**: Phase 0 — `v0.1.0` on npm &nbsp;·&nbsp; **Networks**: testnet + mainnet &nbsp;·&nbsp; **License**: MIT
 
 **Stellar's biggest developer-experience gap isn't a missing API — it's that Horizon's firehose still requires every team to build their own event delivery.**
 
@@ -61,20 +61,21 @@ The longer-form thesis, the multi-year vision, and the SCF grant case live in [`
 
 ## Quickstart
 
-> _Packages publish to npm at `v0.1.0` (Phase 0 milestone). Until then, clone the repo and use the workspace install below._
-
-```bash
-git clone https://github.com/determined-001/orbital_stellar.git
-cd orbital_stellar
-pnpm install
-```
-
-Once published, install only what you need:
+Install only what you need from npm:
 
 ```bash
 pnpm add @orbital-stellar/pulse-core             # always
 pnpm add @orbital-stellar/pulse-webhooks         # if you push events to HTTPS endpoints
 pnpm add @orbital-stellar/pulse-notify react     # if you render live events in React
+pnpm add @orbital-stellar/abi-registry           # if you decode Soroban contract events
+```
+
+Or clone the repo to work from source:
+
+```bash
+git clone https://github.com/determined-001/orbital_stellar.git
+cd orbital_stellar
+pnpm install
 ```
 
 ### Subscribe to events directly

--- a/apps/web/next-env.d.ts
+++ b/apps/web/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,11 @@
 {
-  "name": "orbit-stellar",
+  "name": "orbital-stellar",
   "private": true,
   "version": "0.0.0",
+  "packageManager": "pnpm@10.22.0",
+  "engines": {
+    "node": ">=20"
+  },
   "scripts": {
     "build": "pnpm -r --filter \"./packages/*\" run build",
     "test": "pnpm -r --if-present test",

--- a/packages/abi-registry/package.json
+++ b/packages/abi-registry/package.json
@@ -3,6 +3,9 @@
   "version": "0.1.0",
   "description": "Canonical Soroban ABI client, schema helpers, and registry publisher interface for Orbital.",
   "license": "MIT",
+  "engines": {
+    "node": ">=20"
+  },
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/pulse-core/package.json
+++ b/packages/pulse-core/package.json
@@ -3,6 +3,9 @@
   "version": "0.1.0",
   "description": "EventEngine for Stellar — Horizon subscription, event normalization, reconnection, and rate-limit handling.",
   "license": "MIT",
+  "engines": {
+    "node": ">=20"
+  },
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/pulse-notify/package.json
+++ b/packages/pulse-notify/package.json
@@ -3,6 +3,9 @@
   "version": "0.1.0",
   "description": "React hooks for live Stellar events — useStellarEvent, useStellarPayment, useStellarActivity.",
   "license": "MIT",
+  "engines": {
+    "node": ">=20"
+  },
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/pulse-webhooks/package.json
+++ b/packages/pulse-webhooks/package.json
@@ -3,6 +3,9 @@
   "version": "0.1.0",
   "description": "HMAC-signed webhook delivery and verification for Stellar events (Node + edge runtimes).",
   "license": "MIT",
+  "engines": {
+    "node": ">=20"
+  },
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
Knocks out the minor items from the final review.

- **Root package name** `orbit-stellar` → `orbital-stellar` (consistency).
- **`engines.node: ">=20"`** on root + all four published packages, so npm consumers get a Node-version signal; **`packageManager: pnpm@10.22.0`** on root.
- With `packageManager` as the source of truth, removed the explicit `version: 10` from every `pnpm/action-setup` step (otherwise v6 conflicts). `action-setup` now reads the version from `packageManager`.
- **README**: Quickstart now leads with `pnpm add` (packages are on npm); clone demoted to "from source". Status line → "`v0.1.0` on npm".

Verified locally: lint 0, format:check clean, build + `pnpm install` green. **The workflow change is the thing to watch** — confirming CI still resolves pnpm correctly.