### PR TITLE
chore(pulse-core): remove duplicate pausedSources.clear() in stop()

### DIFF
--- a/packages/pulse-core/src/EventEngine.ts
+++ b/packages/pulse-core/src/EventEngine.ts
@@ -654,8 +654,6 @@ export class EventEngine {
       emittedAt: new Date().toISOString(),
     });
 
-    this.pausedSources.clear();
-
     for (const watcher of this.registry.values()) {
       watcher.stop();
     }


### PR DESCRIPTION
Follow-up cleanup after #488.

`EventEngine.stop()` called `this.pausedSources.clear()` twice — line 645 (pre-existing) and a duplicate added by #488. Nothing between the two calls re-populates the set, so the second is dead code. Removed it.

- typecheck: clean
- pulse-core tests: 432 passed, 6 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)