### PR TITLE
docs(webhooks): document RedisRetryQueue restart behavior

### DIFF
--- a/packages/pulse-webhooks/README.md
+++ b/packages/pulse-webhooks/README.md
@@ -179,6 +179,28 @@ watcher.on("webhook.dropped", (event) => {
 });
 ```
 
+## Durable Retry Queue Adapter
+
+`RedisRetryQueue` implements the exported `RetryQueue` interface using a Redis-compatible sorted set API. Pass a client that provides `zadd`, `zrangebyscore`, `zrevrange`, `zrem`, and `zcard`; this package does not bundle a Redis client.
+
+```ts
+import { RedisRetryQueue } from "@orbital-stellar/pulse-webhooks";
+
+const retryQueue = new RedisRetryQueue(redisClient, {
+  keyPrefix: "orbital:pulse-webhooks",
+  queueName: "payments",
+});
+```
+
+The key convention is:
+
+| Purpose | Key |
+| ------- | --- |
+| Scheduled retries | `<keyPrefix>:retry-queue:<queueName>` |
+| Dequeued but unacked retries | `<keyPrefix>:retry-queue:<queueName>:in-flight` |
+
+The default prefix is `orbital:pulse-webhooks` and the default queue name is `default`. The sorted-set score is the next retry timestamp in Unix milliseconds. Dequeued records move to the `:in-flight` set until `ack()` removes them, `nack()` requeues them with a new delay, or the visibility timeout expires and a later `dequeue()` reclaims them.
+
 ## Delivery contract
 
 - **Request method:** `POST`

--- a/packages/pulse-webhooks/test/RedisRetryQueue.test.ts
+++ b/packages/pulse-webhooks/test/RedisRetryQueue.test.ts
@@ -164,6 +164,35 @@ describe("RedisRetryQueue", () => {
     expect(await afterRestart.dequeue(1_500)).toEqual(inFlightRetry);
   });
 
+  it("reclaims in-flight retries after a queue instance restart", async () => {
+    const redis = new MockRedis();
+    const beforeRestart = new RedisRetryQueue(redis, {
+      keyPrefix: "orbital:test",
+      queueName: "restart",
+      visibilityTimeoutMs: 500,
+    });
+    const inFlightRetry = retryRecord({
+      id: "in-flight",
+      attempt: 3,
+      nextRetryAt: 1_500,
+    });
+
+    await beforeRestart.enqueue(inFlightRetry);
+    expect(await beforeRestart.dequeue(1_500)).toEqual(inFlightRetry);
+
+    const afterRestart = new RedisRetryQueue(redis, {
+      keyPrefix: "orbital:test",
+      queueName: "restart",
+      visibilityTimeoutMs: 500,
+    });
+
+    expect(await afterRestart.dequeue(1_999)).toBeNull();
+    expect(await afterRestart.dequeue(2_000)).toEqual({
+      ...inFlightRetry,
+      nextRetryAt: 2_000,
+    });
+  });
+
   it("keeps different queue names isolated under the same prefix", async () => {
     const redis = new MockRedis();
     const payments = new RedisRetryQueue(redis, {


### PR DESCRIPTION
Closes #376

## What changed
- Documented the `RedisRetryQueue` durable retry adapter and Redis sorted-set key convention.
- Added restart/reclaim coverage showing in-flight retries survive a queue instance restart after the visibility timeout.
- Kept Redis as an injected `RedisLike` dependency; no Redis client is bundled.

## Scope note
The current `main` branch already contains the `RedisRetryQueue` implementation and export. This PR completes the remaining issue-facing acceptance surface by documenting the adapter contract and adding explicit restart/in-flight reclaim test coverage.

## Verification
- `pnpm --dir /home/tunir/stellar-wave-6/workspaces/orbital_stellar-376 --filter @orbital-stellar/pulse-webhooks test -- RedisRetryQueue.test.ts` passed: 3 test files, 74 tests.
- `pnpm --dir /home/tunir/stellar-wave-6/workspaces/orbital_stellar-376 --filter @orbital-stellar/pulse-core build` passed.
- `pnpm --dir /home/tunir/stellar-wave-6/workspaces/orbital_stellar-376 --filter @orbital-stellar/pulse-webhooks build` passed.
- `git diff --check origin/main...HEAD` passed.