### PR TITLE
feat(webhooks): guard edge verifier signature versions

### DIFF
--- a/packages/pulse-webhooks/README.md
+++ b/packages/pulse-webhooks/README.md
@@ -138,15 +138,16 @@ Uses `crypto.timingSafeEqual` under the hood — do not roll your own comparison
 
 | Option        | Type     | Default   | Description                                                    |
 | ------------- | -------- | --------- | -------------------------------------------------------------- |
-| `maxAgeMs`    | `number` | `300_000` | Reject signatures older than this many milliseconds            |
-| `clockSkewMs` | `number` | `30_000`  | Clock-skew allowance for sender/receiver time differences      |
-| `nowMs`       | `number` | `Date.now()` | Override current time (useful in tests)                     |
+| `maxAgeMs`    | `number`        | `300_000`    | Reject signatures older than this many milliseconds                            |
+| `clockSkewMs` | `number`        | `30_000`     | Clock-skew allowance for sender/receiver time differences                      |
+| `nowMs`       | `number`        | `Date.now()` | Override current time (useful in tests)                                        |
+| `version`     | `"v1" \| "v2"` | `"v1"`       | Signature-version selector; `v2` is a reserved placeholder for the future `x-orbital-signature-v2` format |
 
 ### `verifyWebhookEdge(payload, signature, secret, timestamp, options?)` → `Promise<NormalizedEvent | null>`
 
 Edge-compatible version of `verifyWebhook` using Web Crypto API. Works in Cloudflare Workers, Deno, and browsers. Returns a Promise that resolves to the parsed event on success, `null` on any failure (including signatures outside the replay window).
 
-Uses constant-time comparison and Web Crypto for HMAC-SHA256 verification. Accepts the same `options` as `verifyWebhook` (`maxAgeMs`, `clockSkewMs`, `nowMs`).
+Uses constant-time comparison and Web Crypto for HMAC-SHA256 verification. Accepts the same `options` as `verifyWebhook` (`maxAgeMs`, `clockSkewMs`, `nowMs`, `version`).
 
 ### Failure events
 

--- a/packages/pulse-webhooks/src/edge.ts
+++ b/packages/pulse-webhooks/src/edge.ts
@@ -56,6 +56,9 @@ export async function verifyWebhookEdgeRaw(
   timestamp: string,
   options: VerifyWebhookOptions = {},
 ): Promise<boolean> {
+  const version = options.version ?? "v1";
+  if (version !== "v1" && version !== "v2") return false;
+
   if (!/^\d+$/.test(timestamp)) return false;
 
   const timestampMs = Number(timestamp);
@@ -74,6 +77,8 @@ export async function verifyWebhookEdgeRaw(
   }
 
   try {
+    // `v2` is reserved for a future x-orbital-signature-v2 format. Until that
+    // format exists, it intentionally uses the v1 verification path.
     const keyData = new TextEncoder().encode(secret);
     const key = await crypto.subtle.importKey(
       "raw",

--- a/packages/pulse-webhooks/test/pulse-webhooks.test.ts
+++ b/packages/pulse-webhooks/test/pulse-webhooks.test.ts
@@ -962,6 +962,18 @@ describe("pulse-webhooks verifyWebhookEdgeRaw", () => {
     expect(result).toBe(true);
   });
 
+  it("fails closed for unsupported signature versions", async () => {
+    const payload = JSON.stringify(deliveryEvent);
+    const timestamp = "1714176000000";
+    const signature = signWebhookPayload("top-secret", payload, timestamp);
+
+    const result = await verifyWebhookEdgeRaw(payload, signature, "top-secret", timestamp, {
+      version: "v3",
+    } as never);
+
+    expect(result).toBe(false);
+  });
+
   it("returns false when timestamp is missing or invalid", async () => {
     const payload = JSON.stringify(deliveryEvent);
     const signature = signWebhookPayload("top-secret", payload, "1714176000000");


### PR DESCRIPTION
Closes #390

## What changed
- Added runtime signature-version selection in `verifyWebhookEdgeRaw`, defaulting to `v1`.
- Accepts the documented `v1` and reserved `v2` values while failing closed for unsupported versions.
- Documented the `version` option and clarified that `v2` is a placeholder for future `x-orbital-signature-v2` support.
- Added focused test coverage for unsupported-version rejection.

## Scope note
This keeps current `v1` verification behavior unchanged. The `v2` path is intentionally documented as reserved and currently uses the existing verification path; implementing the future v2 header format is out of scope for this issue.

## Verification
- `pnpm --dir /home/tunir/stellar-wave-6/workspaces/orbital-stellar-390 --filter @orbital-stellar/pulse-webhooks test -- pulse-webhooks.test.ts` passed: 3 test files, 74 tests.
- `pnpm --dir /home/tunir/stellar-wave-6/workspaces/orbital-stellar-390 --filter @orbital-stellar/pulse-core build` passed.
- `pnpm --dir /home/tunir/stellar-wave-6/workspaces/orbital-stellar-390 --filter @orbital-stellar/pulse-webhooks build` passed.
- `git diff --check origin/main...HEAD` passed.