### PR TITLE
Benchmark: Soroban subscriber throughput

### DIFF
--- a/packages/pulse-core/README.md
+++ b/packages/pulse-core/README.md
@@ -213,9 +213,9 @@ The harness subscribes `N` contract watchers with exact `contractIds` filters, s
 
 | Contract subscriptions (`N`) | RPC events | Routed events | Duration (ms) | Events/sec | Subscribed heap (MB) | Post-replay heap (MB) | Post-replay RSS (MB) |
 |---|---:|---:|---:|---:|---:|---:|---:|
-| 1,000 | 1,000 | 2,000 | 473.32 | 4,225.49 | 18.80 | 18.79 | 122.21 |
-| 5,000 | 1,000 | 2,000 | 2,362.72 | 846.48 | 23.19 | 22.56 | 127.73 |
-| 10,000 | 1,000 | 2,000 | 5,290.83 | 378.01 | 28.56 | 27.30 | 130.18 |
+| 1,000 | 1,000 | 2,000 | 243.86 | 8,201.55 | 19.75 | 19.75 | 120.75 |
+| 5,000 | 1,000 | 2,000 | 1,036.03 | 1,930.45 | 24.11 | 23.48 | 126.32 |
+| 10,000 | 1,000 | 2,000 | 2,884.87 | 693.27 | 29.48 | 28.21 | 166.00 |
 
 Each matching contract subscription receives both the typed event and the `*` wildcard event. Results vary by CPU, Node version, and runtime load; rerun locally to compare changes over time.
 


### PR DESCRIPTION
## Linked issue

Closes #309

Here's a summary of what was done:

soroban-throughput.ts
 — already existed and was already complete. It:

Synthesizes N RPC getEvents responses containing contract_event records, each routed to a distinct contract ID
Replays them through the engine's private normalize → route → emit path via an EngineBenchInternals cast (same pattern as throughput.ts)
Subscribes 1k/5k/10k contract watchers with exact contractIds filters
Reports rpc_events, routed_events, duration_ms, events_per_sec, and all heap/RSS memory columns
Accepts --responses=N and --events-per-response=N CLI flags
Runs via pnpm --filter @orbital-stellar/pulse-core exec node --expose-gc --import tsx bench/soroban-throughput.ts
README.md — the ### Soroban Benchmark subsection was already present. I updated the baseline numbers table with fresh results from this machine (Node v24.12.0):

Subscriptions	Events/sec	Post-replay heap
1,000	8,201	19.75 MB
5,000	1,930	23.48 MB
10,000	693	28.21 MB
The benchmark runs cleanly end-to-end and the numbers are documented as the new baseline.
<!-- One paragraph. What does this PR do, and why is the change needed? -->

## Test plan

<!-- How did you verify this works? Check everything that applies. -->

- [ ] Existing tests pass (`pnpm test`)
- [ ] New tests added for new behaviour
- [ ] Typechecks pass (`pnpm -r typecheck`)
- [ ] Manually tested against testnet / mainnet (describe what you tested)

## Breaking changes

<!-- Does this change any public API? If yes, describe the migration path. -->

None / Yes (describe below)

## Notes for reviewers

<!-- Anything the reviewer should pay special attention to, or context that isn't obvious from the diff. -->
