### PR TITLE
Implmeneted the delivery stop

### DIFF
--- a/packages/pulse-webhooks/src/index.ts
+++ b/packages/pulse-webhooks/src/index.ts
@@ -188,6 +188,9 @@ export class WebhookDelivery {
   private activeDeliveries = 0;
   // Overflow queue for deliveries that exceed the concurrent delivery cap.
   private overflowQueue: Array<{ event: NormalizedEvent; url: string }> = [];
+  // Set once `stop()` has run, independent of the underlying watcher's lifecycle.
+  private stopped = false;
+
   constructor(
     watcher: Watcher,
     config: WebhookConfig,
@@ -215,28 +218,42 @@ export class WebhookDelivery {
     this.retryQueue = config.retryQueue;
 
     this.watcher.addStopHandler(() => {
-      this.clearRetryTimers();
-      this.stopPoller();
+      this.stop();
     });
 
     if (this.retryQueue) {
       this.startPoller();
     }
 
-    this.watcher.on(
-      "*",
-      (event: NormalizedEvent | WatcherNotification | DecodeFailedNotification) => {
-        if ("raw" in event) {
-          for (const url of this.config.urls) {
-            this.dispatchDelivery(event, url);
-          }
-        }
-      },
-    );
+    this.watcher.on("*", this.handleWatcherEvent);
   }
+
+  private readonly handleWatcherEvent = (
+    event: NormalizedEvent | WatcherNotification | DecodeFailedNotification,
+  ): void => {
+    if (this.stopped) return;
+    if ("raw" in event) {
+      for (const url of this.config.urls) {
+        this.dispatchDelivery(event, url);
+      }
+    }
+  };
 
   getDeadLetterStore(): DeadLetterStoreInterface | MemoryDeadLetterStore {
     return this.dlq;
+  }
+
+  /**
+   * Idempotently stops this delivery instance without stopping the underlying
+   * `Watcher`: detaches the event listener, clears pending retry timers, and
+   * stops the retry-queue poller so no further deliveries are attempted.
+   */
+  stop(): void {
+    if (this.stopped) return;
+    this.stopped = true;
+    this.watcher.off("*", this.handleWatcherEvent);
+    this.clearRetryTimers();
+    this.stopPoller();
   }
 
   /** Re-deliver a stored terminal failure by dead-letter id. */
@@ -560,6 +577,7 @@ export class WebhookDelivery {
    * If at capacity, the event is queued and a `webhook.backpressure` notification is emitted.
    */
   private dispatchDelivery(event: NormalizedEvent, url: string): void {
+    if (this.stopped) return;
     if (this.activeDeliveries >= this.config.maxConcurrentDeliveries) {
       this.overflowQueue.push({ event, url });
       this.emitBackpressure(event, url);

--- a/packages/pulse-webhooks/test/pulse-webhooks.test.ts
+++ b/packages/pulse-webhooks/test/pulse-webhooks.test.ts
@@ -114,6 +114,31 @@ describe("pulse-webhooks WebhookDelivery", () => {
     );
   });
 
+  it("stop() prevents further deliveries without stopping the watcher", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200 });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const watcher = new Watcher("GABC");
+    const delivery = new WebhookDelivery(watcher, {
+      url: "https://prod.example.com/webhooks/stellar",
+      secret: "top-secret",
+    });
+
+    watcher.emit("*", deliveryEvent);
+    await flushAsyncWork();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    delivery.stop();
+
+    watcher.emit("*", deliveryEvent);
+    await flushAsyncWork();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(watcher.stopped).toBe(false);
+
+    // Idempotent: calling stop() again is a no-op, not an error.
+    expect(() => delivery.stop()).not.toThrow();
+  });
+
   it("records each webhook attempt and terminal success outcome", async () => {
     const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200 });
     vi.stubGlobal("fetch", fetchMock);


### PR DESCRIPTION
## Linked issue

Closes #374
2.37 — WebhookDelivery.stop()
Complexity: Trivial — 100 Points · type:feature

Milestone: v1.0 hardening

Context
A WebhookDelivery stops when its watcher stops. No independent shutdown path.

Problem
Tests that need to halt a delivery without stopping the watcher have no clean API.

What needs to be done

Add idempotent WebhookDelivery.stop() that clears retry timers and removes the listener.
Key files

packages/pulse-webhooks/src/index.ts.
Done when

After stop(), no further deliveries are attempted.