### PR TITLE
chore: clarify CursorStore cursor handling

### DIFF
--- a/packages/pulse-core/src/CursorStore.ts
+++ b/packages/pulse-core/src/CursorStore.ts
@@ -1,5 +1,8 @@
 /**
- * Pluggable durable store for the Horizon stream cursor.
+ * Pluggable durable store for Horizon and Soroban stream cursors.
+ *
+ * Cursor values are source-local opaque strings. Store implementations should
+ * persist and return them exactly as received from Horizon or Soroban RPC.
  *
  * Subclasses must implement the single-key {@link get} and {@link set}
  * primitives. The batch helpers ({@link getMany} / {@link setMany}) and


### PR DESCRIPTION
﻿Closes #713

## Summary

- rebased this branch on the latest `main`
- removed `docs/cursor-format.md` from the PR per review
- kept the `CursorStore` source comment focused on Horizon/Soroban opaque cursor values

## Validation

- `git diff --check`
- hidden/bidi/control-character scan on `packages/pulse-core/src/CursorStore.ts`

I kept this focused on the source change after the review.
