### PR TITLE
Add StellarEventBoundary component and integrate with StellarConnecti…

### DIFF
--- a/packages/pulse-notify/src/StellarConnectionStatus.tsx
+++ b/packages/pulse-notify/src/StellarConnectionStatus.tsx
@@ -1,4 +1,5 @@
 import { createElement, useEffect, useMemo, useState } from "react";
+import { StellarEventBoundary } from "./StellarEventBoundary.js";
 import type { ComponentPropsWithoutRef, CSSProperties, ReactElement } from "react";
 
 export type StellarConnectionStatusState = "connecting" | "connected" | "error";
@@ -103,21 +104,25 @@ export function StellarConnectionStatus({
   );
 
   return createElement(
-    "span",
-    {
-      ...spanProps,
-      "aria-label": ariaLabel ?? `Stellar connection ${label}`,
-      "aria-live": spanProps["aria-live"] ?? "polite",
-      className: statusClassName,
-      "data-status": status,
-      role: spanProps.role ?? "status",
-      style: rootStyle,
-    },
-    createElement("span", {
-      "aria-hidden": true,
-      className: "stellar-connection-status__dot",
-      style: dotStyle,
-    }),
-    createElement("span", { className: "stellar-connection-status__label" }, label),
+    StellarEventBoundary,
+    { fallback: null },
+    createElement(
+      "span",
+      {
+        ...spanProps,
+        "aria-label": ariaLabel ?? `Stellar connection ${label}`,
+        "aria-live": spanProps["aria-live"] ?? "polite",
+        className: statusClassName,
+        "data-status": status,
+        role: spanProps.role ?? "status",
+        style: rootStyle,
+      },
+      createElement("span", {
+        "aria-hidden": true,
+        className: "stellar-connection-status__dot",
+        style: dotStyle,
+      }),
+      createElement("span", { className: "stellar-connection-status__label" }, label),
+    ),
   );
 }

--- a/packages/pulse-notify/src/StellarEventBoundary.tsx
+++ b/packages/pulse-notify/src/StellarEventBoundary.tsx
@@ -1,0 +1,33 @@
+'use client';
+import { useEffect, useState, ReactElement, ReactNode } from 'react';
+
+export type StellarEventBoundaryProps = {
+  /**
+   * Fallback UI rendered during server-side rendering or before hydration.
+   * Defaults to null.
+   */
+  fallback?: ReactNode;
+  /**
+   * Client‑only children to render after component mounts.
+   */
+  children: ReactNode;
+};
+
+/**
+ * StellarEventBoundary renders a fallback on the server and switches to rendering
+ * its children once the component has mounted on the client. This avoids SSR
+ * hydration mismatches for components that rely on browser‑only APIs such as
+ * EventSource or WebSocket.
+ */
+export function StellarEventBoundary({
+  fallback = null,
+  children,
+}: StellarEventBoundaryProps): ReactElement {
+  const [isMounted, setIsMounted] = useState(false);
+
+  useEffect(() => {
+    setIsMounted(true);
+  }, []);
+
+  return isMounted ? <>{children}</> : <>{fallback}</>;
+}

--- a/packages/pulse-notify/src/index.ts
+++ b/packages/pulse-notify/src/index.ts
@@ -202,6 +202,7 @@ export {
   type StellarConnectionStatusProps,
   type StellarConnectionStatusState,
 } from "./StellarConnectionStatus.js";
+export { StellarEventBoundary } from "./StellarEventBoundary.js";
 
 export { pulseNotifyVitePlugin } from "./vitePlugin.js";
 export type { PulseNotifyVitePlugin } from "./vitePlugin.js";


### PR DESCRIPTION
this pr closes #695 

Add StellarEventBoundary for client‑only rendering with SSR fallback

- Introduces `StellarEventBoundary` component that renders a fallback during server‑side rendering and switches to its children after client hydration.
- Wraps the output of `StellarConnectionStatus` in `StellarEventBoundary` to prevent hydration mismatches for EventSource/WebSocket‑based components.
- Exports `StellarEventBoundary` from the package entry point.
- Updates imports and exports accordingly.

This resolves the DX issue of repetitive connection‑error handling and provides a reusable boundary for client‑only event components.