### PR TITLE
Dedup receiver helper for receiver side idempotency

### DIFF
--- a/packages/pulse-webhooks/src/cli.ts
+++ b/packages/pulse-webhooks/src/cli.ts
@@ -1,8 +1,4 @@
-import {
-  DeadLetterStore,
-  type DeadLetterEntry,
-  type DeadLetterFilter,
-} from "./MemoryDeadLetterStore.js";
+import { DeadLetterStore, type DeadLetterFilter } from "./MemoryDeadLetterStore.js";
 
 /**
  * List DLQ entries with optional filters and output each as a line‑delimited JSON string.

--- a/packages/pulse-webhooks/src/dedup.ts
+++ b/packages/pulse-webhooks/src/dedup.ts
@@ -1,0 +1,47 @@
+import type { NormalizedEvent } from "@orbital-stellar/pulse-core";
+
+export interface DedupStore {
+  seen(id: string): Promise<boolean>;
+  mark(id: string): Promise<void>;
+}
+
+export class MemoryDedupStore implements DedupStore {
+  private readonly ids = new Set<string>();
+
+  async seen(id: string): Promise<boolean> {
+    return this.ids.has(id);
+  }
+
+  async mark(id: string): Promise<void> {
+    this.ids.add(id);
+  }
+
+  clear(): void {
+    this.ids.clear();
+  }
+}
+
+export type DedupReceiverOptions = {
+  idExtractor?: (event: NormalizedEvent) => string;
+};
+
+const DEFAULT_ID_EXTRACTOR = (event: NormalizedEvent): string => {
+  const id = (event as Record<string, unknown>).raw as Record<string, unknown> | null | undefined;
+  if (id != null && typeof id.id === "string") return id.id;
+  throw new Error("dedupReceiver: event has no raw.id string — provide a custom idExtractor");
+};
+
+export function dedupReceiver(
+  handler: (event: NormalizedEvent) => Promise<void>,
+  store: DedupStore,
+  options?: DedupReceiverOptions,
+): (event: NormalizedEvent) => Promise<void> {
+  const extractId = options?.idExtractor ?? DEFAULT_ID_EXTRACTOR;
+
+  return async (event: NormalizedEvent): Promise<void> => {
+    const id = extractId(event);
+    if (await store.seen(id)) return;
+    await store.mark(id);
+    await handler(event);
+  };
+}

--- a/packages/pulse-webhooks/src/index.ts
+++ b/packages/pulse-webhooks/src/index.ts
@@ -24,6 +24,8 @@ export { RedisRetryQueue } from "./RedisRetryQueue.js";
 export { MemoryRetryQueue } from "./MemoryRetryQueue.js";
 export { SqsRetryQueue } from "./SqsRetryQueue.js";
 export { verifyWebhookEdge, verifyWebhookEdgeRaw } from "./edge.js";
+export { dedupReceiver, MemoryDedupStore } from "./dedup.js";
+export type { DedupStore, DedupReceiverOptions } from "./dedup.js";
 export type {
   DeadLetterEntry,
   DeadLetterFilter as MemoryDeadLetterFilter,
@@ -106,6 +108,8 @@ export class WebhookDelivery {
   // Map of timer -> event so we can evict the newest entry when the cap is hit.
   private retryTimers: Map<ReturnType<typeof setTimeout>, { event: NormalizedEvent; url: string }> =
     new Map();
+  private retryQueue?: RetryQueue;
+  private pollerTimer?: ReturnType<typeof setInterval>;
   // Map to store idempotency delivery IDs per event and URL
   private deliveryIds: Map<NormalizedEvent, Map<string, string>> = new Map();
 
@@ -124,15 +128,22 @@ export class WebhookDelivery {
       maxConcurrentRetries: 100,
       random: Math.random,
       backoff: exponentialJittered,
+      retryQueuePollIntervalMs: 1000,
       ...config,
       tracer: config.tracer,
       urls: Array.isArray(config.url) ? [...config.url] : [config.url],
     };
     this.config.maxConcurrentRetries = Math.max(1, this.config.maxConcurrentRetries);
+    this.retryQueue = config.retryQueue;
 
     this.watcher.addStopHandler(() => {
       this.clearRetryTimers();
+      this.stopPoller();
     });
+
+    if (this.retryQueue) {
+      this.startPoller();
+    }
 
     this.watcher.on(
       "*",
@@ -150,30 +161,31 @@ export class WebhookDelivery {
     return this.dlq;
   }
 
-  private async deliverToUrl(event: NormalizedEvent, url: string, attempt = 1): Promise<void> {
-    if (this.watcher.stopped) return;
+  private async doAttempt(
+    event: NormalizedEvent,
+    url: string,
+    attempt: number,
+  ): Promise<{ ok: true } | { ok: false; error: string; terminal?: boolean }> {
+    if (this.watcher.stopped) return { ok: false, error: "stopped", terminal: true };
 
     const builtInValidationError = this.validateUrl(url);
     if (builtInValidationError) {
       this.emitFailure(event, url, builtInValidationError, attempt);
-      return;
+      return { ok: false, error: builtInValidationError, terminal: true };
     }
 
     let customValidationError: string | null = null;
     try {
       customValidationError = this.config.urlValidator ? await this.config.urlValidator(url) : null;
     } catch (err) {
-      if (this.watcher.stopped) return;
-
-      this.emitFailure(event, url, this.getErrorMessage(err), attempt);
-      return;
+      if (this.watcher.stopped) return { ok: false, error: "stopped", terminal: true };
+      return { ok: false, error: this.getErrorMessage(err), terminal: true };
     }
 
-    if (this.watcher.stopped) return;
+    if (this.watcher.stopped) return { ok: false, error: "stopped", terminal: true };
 
     if (customValidationError) {
-      this.emitFailure(event, url, customValidationError, attempt);
-      return;
+      return { ok: false, error: customValidationError, terminal: true };
     }
 
     const payload = JSON.stringify(event);
@@ -234,6 +246,7 @@ export class WebhookDelivery {
       this.config.metrics?.recordAttempt(url, attempt, successMs, "success");
       this.config.metrics?.recordTerminal(url, "success");
       this.dlq.recordSuccess(url);
+      return { ok: true };
     } catch (err) {
       const failureMs = Date.now() - startMs;
       span?.setAttribute("webhook.latency_ms", failureMs);
@@ -241,42 +254,85 @@ export class WebhookDelivery {
       span?.setAttribute("webhook.error", this.getErrorMessage(err));
       span?.setAttribute("error", this.getErrorMessage(err));
 
-      if (this.watcher.stopped) return;
+      if (this.watcher.stopped) return { ok: false, error: "stopped" };
 
       const errorMessage = this.getErrorMessage(err);
       this.config.metrics?.recordAttempt(url, attempt, failureMs, "failure");
       this.dlq.recordFailure(url);
-
-      if (attempt < this.config.retries) {
-        if (this.config.retryQueue) {
-          // Durable path: persist the pending retry to the queue so it survives a
-          // process restart. A drain timer fires the redelivery at its due time.
-          await this.persistRetry(this.config.retryQueue, event, url, attempt + 1, errorMessage);
-        } else {
-          // In-process path: enforce the retry cap by evicting the newest pending
-          // retry when at limit.
-          if (this.retryTimers.size >= this.config.maxConcurrentRetries) {
-            // Evict the newest (last-inserted) retry — it has waited the least, so dropping it wastes the least elapsed time.
-            const newestTimer = [...this.retryTimers.keys()].at(-1)!;
-            const newest = this.retryTimers.get(newestTimer)!;
-            clearTimeout(newestTimer);
-            this.retryTimers.delete(newestTimer);
-            this.emitDropped(newest.event, newest.url);
-          }
-
-          const delay = this.config.backoff(attempt, this.config.random);
-          const retryTimer = setTimeout(() => {
-            this.retryTimers.delete(retryTimer);
-            void this.deliverToUrl(event, url, attempt + 1);
-          }, delay);
-          this.retryTimers.set(retryTimer, { event, url });
-        }
-      } else {
-        this.emitFailure(event, url, errorMessage, attempt);
-      }
+      return { ok: false, error: errorMessage };
     } finally {
       clearTimeout(abortTimer);
       span?.end();
+    }
+  }
+
+  private async deliverToUrl(event: NormalizedEvent, url: string, attempt = 1): Promise<void> {
+    const result = await this.doAttempt(event, url, attempt);
+    if (result.ok) return;
+    if (this.watcher.stopped) return;
+
+    const errorMessage = result.error;
+
+    if (!result.terminal && attempt < this.config.retries) {
+      if (this.config.retryQueue) {
+        await this.persistRetry(this.config.retryQueue, event, url, attempt + 1, errorMessage);
+      } else {
+        if (this.retryTimers.size >= this.config.maxConcurrentRetries) {
+          const newestTimer = [...this.retryTimers.keys()].at(-1)!;
+          const newest = this.retryTimers.get(newestTimer)!;
+          clearTimeout(newestTimer);
+          this.retryTimers.delete(newestTimer);
+          this.emitDropped(newest.event, newest.url);
+        }
+
+        const delay = this.config.backoff(attempt, this.config.random);
+        const retryTimer = setTimeout(() => {
+          this.retryTimers.delete(retryTimer);
+          void this.deliverToUrl(event, url, attempt + 1);
+        }, delay);
+        this.retryTimers.set(retryTimer, { event, url });
+      }
+    } else {
+      this.emitFailure(event, url, errorMessage, attempt);
+    }
+  }
+
+  private startPoller(): void {
+    const intervalMs = this.config.retryQueuePollIntervalMs;
+    this.pollerTimer = setInterval(() => {
+      this.retryQueue!.dequeue().then((record) => {
+        if (record) {
+          void this.processQueueRecord(record);
+        }
+      });
+    }, intervalMs);
+  }
+
+  private stopPoller(): void {
+    if (this.pollerTimer !== undefined) {
+      clearInterval(this.pollerTimer);
+      this.pollerTimer = undefined;
+    }
+  }
+
+  private async processQueueRecord(record: RetryRecord): Promise<void> {
+    if (this.watcher.stopped) return;
+
+    const result = await this.doAttempt(
+      record.event as NormalizedEvent,
+      record.url,
+      record.attempt,
+    );
+    if (this.watcher.stopped) return;
+
+    if (result.ok) {
+      await this.retryQueue!.ack(record.id);
+    } else if (!result.terminal && record.attempt < this.config.retries) {
+      const delay = this.config.backoff(record.attempt, this.config.random);
+      await this.retryQueue!.nack(record.id, delay);
+    } else {
+      await this.retryQueue!.ack(record.id);
+      this.emitFailure(record.event as NormalizedEvent, record.url, result.error, record.attempt);
     }
   }
 

--- a/packages/pulse-webhooks/src/types.ts
+++ b/packages/pulse-webhooks/src/types.ts
@@ -41,12 +41,14 @@ export type WebhookConfig = {
   /** Optional metrics recorder for per-URL delivery observability. */
   metrics?: WebhookMetrics;
   /**
-   * Optional durable retry queue. When provided, retryable delivery failures are
-   * persisted to it (instead of the in-process timer set) so pending retries can
-   * survive a process restart. See {@link import("./RetryQueue.js").RetryQueue}
-   * and {@link import("./MemoryRetryQueue.js").MemoryRetryQueue}.
+   * Optional durable retry queue. When set, every retry is enqueued into
+   * this queue instead of scheduled via setTimeout. A separate poller
+   * dequeues records at `retryQueuePollIntervalMs` and drives delivery.
+   * Persists retries across restarts when backed by a durable store.
    */
   retryQueue?: import("./RetryQueue.js").RetryQueue;
+  /** Poll interval for the retry queue dequeue loop. Defaults to 1000ms. */
+  retryQueuePollIntervalMs?: number;
 };
 
 export const DEFAULT_MAX_AGE_MS = 300_000;

--- a/packages/pulse-webhooks/src/url-validator.ts
+++ b/packages/pulse-webhooks/src/url-validator.ts
@@ -31,7 +31,7 @@ export class UrlValidator {
       }
 
       return null;
-    } catch (e) {
+    } catch {
       return "Invalid URL format";
     }
   }

--- a/packages/pulse-webhooks/test/SqsRetryQueue.test.ts
+++ b/packages/pulse-webhooks/test/SqsRetryQueue.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 
 import {
   SqsRetryQueue,

--- a/packages/pulse-webhooks/test/dedup.test.ts
+++ b/packages/pulse-webhooks/test/dedup.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from "vitest";
+import { vi } from "vitest";
+
+import { dedupReceiver, MemoryDedupStore } from "../src/index.js";
+import type { DedupStore } from "../src/index.js";
+
+function makeEvent(id: string) {
+  return {
+    type: "payment.received" as const,
+    to: "GDEST",
+    from: "GSRC",
+    amount: "10",
+    asset: "XLM",
+    timestamp: "2026-04-26T12:00:00.000Z",
+    raw: { id },
+  };
+}
+
+describe("MemoryDedupStore", () => {
+  it("returns false for unseen id", async () => {
+    const store = new MemoryDedupStore();
+    expect(await store.seen("evt_1")).toBe(false);
+  });
+
+  it("returns true after mark", async () => {
+    const store = new MemoryDedupStore();
+    await store.mark("evt_1");
+    expect(await store.seen("evt_1")).toBe(true);
+  });
+
+  it("tracks multiple ids independently", async () => {
+    const store = new MemoryDedupStore();
+    await store.mark("evt_1");
+    expect(await store.seen("evt_1")).toBe(true);
+    expect(await store.seen("evt_2")).toBe(false);
+  });
+
+  it("clear resets state", async () => {
+    const store = new MemoryDedupStore();
+    await store.mark("evt_1");
+    store.clear();
+    expect(await store.seen("evt_1")).toBe(false);
+  });
+});
+
+describe("dedupReceiver", () => {
+  it("invokes handler for unseen id", async () => {
+    const handler = vi.fn().mockResolvedValue(undefined);
+    const store = new MemoryDedupStore();
+    const wrapped = dedupReceiver(handler, store);
+
+    await wrapped(makeEvent("evt_1"));
+
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it("skips handler for already-seen id", async () => {
+    const handler = vi.fn().mockResolvedValue(undefined);
+    const store = new MemoryDedupStore();
+    const wrapped = dedupReceiver(handler, store);
+
+    await wrapped(makeEvent("evt_1"));
+    await wrapped(makeEvent("evt_1"));
+
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it("invokes handler for different ids", async () => {
+    const handler = vi.fn().mockResolvedValue(undefined);
+    const store = new MemoryDedupStore();
+    const wrapped = dedupReceiver(handler, store);
+
+    await wrapped(makeEvent("evt_1"));
+    await wrapped(makeEvent("evt_2"));
+
+    expect(handler).toHaveBeenCalledTimes(2);
+  });
+
+  it("uses custom idExtractor when provided", async () => {
+    const handler = vi.fn().mockResolvedValue(undefined);
+    const store = new MemoryDedupStore();
+    const extractor = (event: { txHash: string }) => event.txHash;
+    const wrapped = dedupReceiver(handler as any, store, { idExtractor: extractor as any });
+
+    await wrapped({ txHash: "hash1" } as any);
+    await wrapped({ txHash: "hash1" } as any);
+
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it("throws when event has no raw.id and no custom extractor", async () => {
+    const handler = vi.fn().mockResolvedValue(undefined);
+    const store = new MemoryDedupStore();
+    const wrapped = dedupReceiver(handler, store);
+
+    const badEvent = { type: "payment.received", raw: {} };
+
+    await expect(wrapped(badEvent as any)).rejects.toThrow("dedupReceiver");
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("marks before invoking handler (at-most-once even if handler throws)", async () => {
+    const handler = vi.fn().mockRejectedValue(new Error("handler error"));
+    const store = new MemoryDedupStore();
+    const wrapped = dedupReceiver(handler, store);
+
+    const event = makeEvent("evt_1");
+
+    await expect(wrapped(event)).rejects.toThrow("handler error");
+    expect(handler).toHaveBeenCalledTimes(1);
+
+    // Second call should be skipped — already marked
+    await wrapped(event);
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it("works with a custom store implementation", async () => {
+    const marks = new Set<string>();
+    const customStore: DedupStore = {
+      seen: async (id) => marks.has(id),
+      mark: async (id) => {
+        marks.add(id);
+      },
+    };
+
+    const handler = vi.fn().mockResolvedValue(undefined);
+    const wrapped = dedupReceiver(handler, customStore);
+
+    await wrapped(makeEvent("evt_1"));
+    await wrapped(makeEvent("evt_1"));
+
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/pulse-webhooks/test/pulse-webhooks.test.ts
+++ b/packages/pulse-webhooks/test/pulse-webhooks.test.ts
@@ -2,7 +2,7 @@ import { createHmac } from "crypto";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { Watcher } from "@orbital-stellar/pulse-core";
-import type { WebhookMetrics } from "../src/index.js";
+import type { RetryQueue, WebhookMetrics } from "../src/index.js";
 import {
   DeadLetterStore,
   MemoryRetryQueue,
@@ -1481,5 +1481,254 @@ describe("pulse-webhooks DeadLetterStore", () => {
     expect(failedCall.raw?.dlqId).toBe(entries[0]?.id);
 
     vi.useRealTimers();
+  });
+});
+
+describe("pulse-webhooks WebhookDelivery with retryQueue", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  function mockQueue(): RetryQueue {
+    return {
+      enqueue: vi.fn().mockResolvedValue(undefined),
+      dequeue: vi.fn().mockResolvedValue(null),
+      ack: vi.fn().mockResolvedValue(undefined),
+      nack: vi.fn().mockResolvedValue(undefined),
+      evictNewest: vi.fn().mockResolvedValue(null),
+      size: vi.fn().mockResolvedValue(0),
+    };
+  }
+
+  it("enqueues retry instead of setTimeout when retryQueue is configured", async () => {
+    const fetchMock = vi.fn().mockRejectedValue(new Error("network down"));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const queue = mockQueue();
+    const watcher = new Watcher("GABC");
+
+    new WebhookDelivery(watcher, {
+      url: "https://example.com/hook",
+      secret: "top-secret",
+      retries: 2,
+      random: () => 0.5,
+      retryQueue: queue,
+      retryQueuePollIntervalMs: 10_000,
+    });
+
+    watcher.emit("*", deliveryEvent);
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(queue.enqueue).toHaveBeenCalledTimes(1);
+    expect(queue.enqueue).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: "https://example.com/hook",
+        attempt: 2,
+        event: deliveryEvent,
+        nextRetryAt: expect.any(Number),
+      }),
+    );
+  });
+
+  it("dequeues and delivers a queued retry record via the poller", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200 });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const record = {
+      id: "rec_1",
+      event: deliveryEvent,
+      url: "https://example.com/hook",
+      attempt: 2,
+      nextRetryAt: Date.now(),
+    };
+
+    let callCount = 0;
+    const queue = mockQueue();
+    vi.mocked(queue.dequeue).mockImplementation(async () => {
+      callCount++;
+      return callCount === 1 ? record : null;
+    });
+
+    const watcher = new Watcher("GABC");
+
+    new WebhookDelivery(watcher, {
+      url: "https://example.com/hook",
+      secret: "top-secret",
+      retryQueue: queue,
+      retryQueuePollIntervalMs: 100,
+    });
+
+    await vi.advanceTimersByTimeAsync(100);
+
+    expect(queue.dequeue).toHaveBeenCalled();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(queue.ack).toHaveBeenCalledWith("rec_1");
+  });
+
+  it("calls nack with backoff delay when delivery fails and retries remain", async () => {
+    const fetchMock = vi.fn().mockRejectedValue(new Error("network down"));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const record = {
+      id: "rec_1",
+      event: deliveryEvent,
+      url: "https://example.com/hook",
+      attempt: 1,
+      nextRetryAt: Date.now(),
+    };
+
+    let callCount = 0;
+    const queue = mockQueue();
+    vi.mocked(queue.dequeue).mockImplementation(async () => {
+      callCount++;
+      return callCount === 1 ? record : null;
+    });
+
+    const watcher = new Watcher("GABC");
+
+    new WebhookDelivery(watcher, {
+      url: "https://example.com/hook",
+      secret: "top-secret",
+      retries: 3,
+      random: () => 0.5,
+      retryQueue: queue,
+      retryQueuePollIntervalMs: 100,
+    });
+
+    await vi.advanceTimersByTimeAsync(100);
+
+    expect(queue.nack).toHaveBeenCalledTimes(1);
+    // backoff(1, 0.5) = 500ms for exponentialJittered
+    expect(queue.nack).toHaveBeenCalledWith("rec_1", 500);
+  });
+
+  it("acks and emits failure when all retries are exhausted from the queue", async () => {
+    const fetchMock = vi.fn().mockRejectedValue(new Error("network down"));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const record = {
+      id: "rec_1",
+      event: deliveryEvent,
+      url: "https://example.com/hook",
+      attempt: 3,
+      nextRetryAt: Date.now(),
+    };
+
+    let callCount = 0;
+    const queue = mockQueue();
+    vi.mocked(queue.dequeue).mockImplementation(async () => {
+      callCount++;
+      return callCount === 1 ? record : null;
+    });
+
+    const watcher = new Watcher("GABC");
+    const failedHandler = vi.fn();
+    watcher.on("webhook.failed", failedHandler);
+
+    new WebhookDelivery(watcher, {
+      url: "https://example.com/hook",
+      secret: "top-secret",
+      retries: 3,
+      retryQueue: queue,
+      retryQueuePollIntervalMs: 100,
+    });
+
+    await vi.advanceTimersByTimeAsync(100);
+
+    expect(queue.ack).toHaveBeenCalledWith("rec_1");
+    expect(failedHandler).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not use setTimeout for retries when retryQueue is configured", async () => {
+    const fetchMock = vi.fn().mockRejectedValue(new Error("network down"));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
+
+    const queue = mockQueue();
+    const watcher = new Watcher("GABC");
+
+    new WebhookDelivery(watcher, {
+      url: "https://example.com/hook",
+      secret: "top-secret",
+      retries: 2,
+      retryQueue: queue,
+      retryQueuePollIntervalMs: 10_000,
+    });
+
+    watcher.emit("*", deliveryEvent);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // setTimeout should only be called for the abort timer (deliveryTimeoutMs), not retries
+    const retryTimeoutCalls = setTimeoutSpy.mock.calls.filter((args) => {
+      const delay = args[1] as number;
+      return delay !== 10000; // exclude the abort timer
+    });
+    expect(retryTimeoutCalls).toHaveLength(0);
+  });
+
+  it("continues to use setTimeout retries when retryQueue is not configured", async () => {
+    const fetchMock = vi.fn().mockRejectedValue(new Error("network down"));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
+
+    const watcher = new Watcher("GABC");
+
+    new WebhookDelivery(watcher, {
+      url: "https://example.com/hook",
+      secret: "top-secret",
+      retries: 2,
+      random: () => 0.5,
+    });
+
+    watcher.emit("*", deliveryEvent);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const retryTimeoutCalls = setTimeoutSpy.mock.calls.filter((args) => {
+      const delay = args[1] as number;
+      return delay !== 10000; // exclude the abort timer
+    });
+    expect(retryTimeoutCalls).toHaveLength(1);
+    expect(retryTimeoutCalls[0][1]).toBe(500); // exponentialJittered(1, 0.5)
+  });
+
+  it("stops the poller when the watcher stops", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200 });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const queue = mockQueue();
+    vi.mocked(queue.dequeue).mockResolvedValue(null);
+
+    const watcher = new Watcher("GABC");
+
+    new WebhookDelivery(watcher, {
+      url: "https://example.com/hook",
+      secret: "top-secret",
+      retryQueue: queue,
+      retryQueuePollIntervalMs: 100,
+    });
+
+    await vi.advanceTimersByTimeAsync(100);
+
+    expect(queue.dequeue).toHaveBeenCalledTimes(1);
+
+    watcher.stop();
+
+    const dequeueCountBefore = vi.mocked(queue.dequeue).mock.calls.length;
+    await vi.advanceTimersByTimeAsync(5000);
+
+    expect(vi.mocked(queue.dequeue).mock.calls.length).toBe(dequeueCountBefore);
   });
 });


### PR DESCRIPTION
## Linked issue

Closes #677

## What changed and why

<!-- One paragraph. What does this PR do, and why is the change needed? -->

## Test plan

<!-- How did you verify this works? Check everything that applies. -->

- [ ] Existing tests pass (`pnpm test`)
- [ ] New tests added for new behaviour
- [ ] Typechecks pass (`pnpm -r typecheck`)
- [ ] Manually tested against testnet / mainnet (describe what you tested)

## Breaking changes

<!-- Does this change any public API? If yes, describe the migration path. -->

None / Yes (describe below)

## Notes for reviewers

<!-- Anything the reviewer should pay special attention to, or context that isn't obvious from the diff. -->
