### PR TITLE
test(pulse-notify): assert pool drains to zero after Strict Mode unmount

### DIFF
--- a/packages/pulse-notify/test/strictMode.test.tsx
+++ b/packages/pulse-notify/test/strictMode.test.tsx
@@ -27,13 +27,21 @@ function Subscriber() {
 }
 
 test("exactly one connection survives Strict Mode double-mount", () => {
+  let unmount: () => void = () => {};
+
   act(() => {
-    render(
+    ({ unmount } = render(
       <StrictMode>
         <Subscriber />
       </StrictMode>,
-    );
+    ));
   });
 
   expect(__getConnectionPoolSizeForTests()).toBe(1);
+
+  act(() => {
+    unmount();
+  });
+
+  expect(__getConnectionPoolSizeForTests()).toBe(0);
 });


### PR DESCRIPTION
## Summary
- Extends the existing Strict Mode double-mount test to also unmount and assert the connection pool drains back to zero, so a leak on cleanup would be caught (the prior test only checked the post-mount size).

## Test plan
- [x] `pnpm tsc --noEmit -p packages/pulse-notify/tsconfig.json`
- [x] `pnpm eslint` / `prettier --check` on the changed file

Closes determined-001/orbital_stellar#697