### PR TITLE
Offer event rational form

### DIFF
--- a/packages/pulse-core/src/EventEngine.ts
+++ b/packages/pulse-core/src/EventEngine.ts
@@ -33,6 +33,7 @@ import type {
   NormalizedEvent,
   OfferEvent,
   OfferEventType,
+  PriceR,
   PaymentEvent,
   PaymentEventType,
   ReconnectConfig,
@@ -1303,6 +1304,7 @@ export class EventEngine {
       selling_asset,
       amount: toStellarAmount(amount),
       price: r.price as string,
+      price_r: r.price_r as PriceR,
       timestamp: r.created_at,
       raw: raw as RawHorizonManageSellOffer | RawHorizonManageBuyOffer,
     };

--- a/packages/pulse-core/src/index.ts
+++ b/packages/pulse-core/src/index.ts
@@ -215,6 +215,9 @@ export type AccountOptionsEvent = {
   raw?: RawHorizonSetOptions;
 };
 
+/** Rational (numerator/denominator) form of an offer's price, as returned by Horizon. */
+export type PriceR = { n: number; d: number };
+
 export type OfferEvent = {
   type: OfferEventType;
   offer_id: string;
@@ -223,6 +226,8 @@ export type OfferEvent = {
   selling_asset: string;
   amount: StellarAmount;
   price: string;
+  /** Rational form of `price` (exact, avoids floating-point rounding). */
+  price_r: PriceR;
   timestamp: string;
   /** Lazy, cached `Date` derived from `event.timestamp`. Non-enumerable; does not appear in JSON.stringify output. */
   readonly timestampDate: Date;

--- a/packages/pulse-core/src/raw-horizon.ts
+++ b/packages/pulse-core/src/raw-horizon.ts
@@ -56,6 +56,7 @@ export interface RawHorizonManageSellOffer extends RawHorizonBaseOperation {
   selling_asset_code?: string;
   selling_asset_issuer?: string;
   price: string;
+  price_r: { n: number; d: number };
 }
 
 export interface RawHorizonManageBuyOffer extends RawHorizonBaseOperation {
@@ -69,6 +70,7 @@ export interface RawHorizonManageBuyOffer extends RawHorizonBaseOperation {
   selling_asset_code?: string;
   selling_asset_issuer?: string;
   price: string;
+  price_r: { n: number; d: number };
 }
 
 export interface RawHorizonBumpSequence extends RawHorizonBaseOperation {

--- a/packages/pulse-core/test/pulse-core.test.ts
+++ b/packages/pulse-core/test/pulse-core.test.ts
@@ -1080,6 +1080,7 @@ describe("pulse-core EventEngine", () => {
         selling_asset_code: "USDC",
         selling_asset_issuer: "GISSUER",
         price: "0.5",
+        price_r: { n: 1, d: 2 },
         created_at: "2026-04-28T14:00:00.000Z",
         ...overrides,
       };
@@ -1104,6 +1105,22 @@ describe("pulse-core EventEngine", () => {
           selling_asset: "USDC:GISSUER",
           amount: "100",
         }),
+      );
+    });
+
+    it("includes price_r (rational form) alongside price", () => {
+      const engine = new EventEngine({ network: "testnet" });
+      const watcher = engine.subscribe("GSRC");
+      const handler = vi.fn();
+      watcher.on("offer.created", handler);
+
+      engine.start();
+      latestStream().handlers.onmessage(
+        makeOfferRecord({ offer_id: "0", amount: "100", price: "0.5", price_r: { n: 1, d: 2 } }),
+      );
+
+      expect(handler).toHaveBeenCalledWith(
+        expect.objectContaining({ price: "0.5", price_r: { n: 1, d: 2 } }),
       );
     });
 


### PR DESCRIPTION
Closes #658

## What changed and why

Adds `price_r: { n: number; d: number }` (rational form) to `OfferEvent`, wired from Horizon's `manage_sell_offer`/`manage_buy_offer` records. `LiquidityPoolReserve` was already exported on `main`, so this completes the remaining half of #658.

Note: this PR's original branch was based on a very old commit of `main` (predating a large `pulse-core` type-system refactor) and its diff would have deleted a lot of already-shipped code. The branch was reset to current `main` plus just this addition, cleanly.

## Test plan

- [x] Existing tests pass (`pnpm test`)
- [x] New test added (`price_r` assertion in the offer-event test suite)
- [x] Typechecks pass (`pnpm -r typecheck`)