### PR TITLE
feat(pulse-notify): add useContractEvent hook for Soroban event subsc…

### DIFF
--- a/packages/pulse-notify/README.md
+++ b/packages/pulse-notify/README.md
@@ -155,6 +155,48 @@ Shorthand for payments received. Equivalent to `useStellarEvent(serverUrl, addre
 
 Shorthand for all events on an address. Equivalent to `useStellarEvent(serverUrl, address, { event: "*" })`.
 
+### `useContractEvent(config)`
+
+Subscribes to Soroban contract events (either contract function invocations or emitted events).
+
+```ts
+const { event, connected, error } = useContractEvent({
+  serverUrl: "https://events.example.com",
+  contractId: "C...",
+  topics: ["transfer"],
+});
+```
+
+#### Backend SSE Contract
+The hook communicates with the backend SSE endpoint at:
+`${serverUrl}/contract_events/${contractId}`
+
+The following query parameters can be appended:
+- `topics`: Comma-separated list of event topics to subscribe to.
+- `token`: Authorization token forwarded as a query parameter.
+
+#### Type Narrowing for Contract Events
+`useContractEvent` accepts a type parameter `T` extending `ContractInvokedEvent | ContractEmittedEvent` to narrow the event payload:
+
+```tsx
+import type { ContractEmittedEvent } from "@orbital-stellar/pulse-core";
+import { useContractEvent } from "@orbital-stellar/pulse-notify";
+
+function TokenMonitor() {
+  const { event } = useContractEvent<ContractEmittedEvent>({
+    serverUrl: "https://events.example.com",
+    contractId: "C...",
+    topics: ["transfer"],
+  });
+
+  if (!event) return null;
+
+  // event is typed as ContractEmittedEvent
+  return <div>Data: {JSON.stringify(event.data)}</div>;
+}
+```
+
+
 ### `<StellarConnectionStatus serverUrl address />`
 
 Small client-side status indicator for places that need connection health but do not need to wire `connected` and `error` state by hand.

--- a/packages/pulse-notify/README.md
+++ b/packages/pulse-notify/README.md
@@ -155,48 +155,6 @@ Shorthand for payments received. Equivalent to `useStellarEvent(serverUrl, addre
 
 Shorthand for all events on an address. Equivalent to `useStellarEvent(serverUrl, address, { event: "*" })`.
 
-### `useContractEvent(config)`
-
-Subscribes to Soroban contract events (either contract function invocations or emitted events).
-
-```ts
-const { event, connected, error } = useContractEvent({
-  serverUrl: "https://events.example.com",
-  contractId: "C...",
-  topics: ["transfer"],
-});
-```
-
-#### Backend SSE Contract
-The hook communicates with the backend SSE endpoint at:
-`${serverUrl}/contract_events/${contractId}`
-
-The following query parameters can be appended:
-- `topics`: Comma-separated list of event topics to subscribe to.
-- `token`: Authorization token forwarded as a query parameter.
-
-#### Type Narrowing for Contract Events
-`useContractEvent` accepts a type parameter `T` extending `ContractInvokedEvent | ContractEmittedEvent` to narrow the event payload:
-
-```tsx
-import type { ContractEmittedEvent } from "@orbital-stellar/pulse-core";
-import { useContractEvent } from "@orbital-stellar/pulse-notify";
-
-function TokenMonitor() {
-  const { event } = useContractEvent<ContractEmittedEvent>({
-    serverUrl: "https://events.example.com",
-    contractId: "C...",
-    topics: ["transfer"],
-  });
-
-  if (!event) return null;
-
-  // event is typed as ContractEmittedEvent
-  return <div>Data: {JSON.stringify(event.data)}</div>;
-}
-```
-
-
 ### `<StellarConnectionStatus serverUrl address />`
 
 Small client-side status indicator for places that need connection health but do not need to wire `connected` and `error` state by hand.

--- a/packages/pulse-notify/src/connectionPool.ts
+++ b/packages/pulse-notify/src/connectionPool.ts
@@ -153,6 +153,122 @@ export function acquireEventConnection(key: ConnectionKey, subscriber: Connectio
   };
 }
 
+// --- Contract event connection helpers -------------------------------------------------
+// Build a unique key for contract subscriptions based on contractId, topics, and token.
+function getContractKey({ serverUrl, contractId, topics, token, withCredentials }: {
+  serverUrl: string;
+  contractId: string;
+  topics?: string[];
+  token?: string;
+  withCredentials?: boolean;
+}): string {
+  // Sort topics to ensure stable key irrespective of order.
+  const sortedTopics = topics ? [...topics].sort().join(',') : '';
+  // Include withCredentials flag for completeness.
+  return JSON.stringify([serverUrl, contractId, sortedTopics, token ?? "", withCredentials ?? false]);
+}
+
+// Construct EventSource URL for contract events, mirroring address logic.
+function getContractEventSourceUrl({ serverUrl, contractId, topics, token }: {
+  serverUrl: string;
+  contractId: string;
+  topics?: string[];
+  token?: string;
+}): string {
+  const base = `${serverUrl}/contract_events/${contractId}`;
+  const query: string[] = [];
+  if (topics && topics.length > 0) query.push(`topics=${encodeURIComponent(topics.join(','))}`);
+  if (token) query.push(`token=${encodeURIComponent(token)}`);
+  return query.length > 0 ? `${base}?${query.join('&')}` : base;
+}
+
+/** Acquire a connection for a contract event subscription.
+ *  Returns an object with `connected` flag and `unsubscribe` method similar to `acquireEventConnection`.
+ */
+export function acquireContractEventConnection(
+  key: { serverUrl: string; contractId: string; topics?: string[]; token?: string; withCredentials?: boolean },
+  subscriber: ConnectionSubscriber,
+) {
+  const poolKey = getContractKey(key);
+  let entry = pool.get(poolKey);
+
+  if (!entry) {
+    const newEntry: ConnectionEntry = {
+      source: new EventSource(
+        getContractEventSourceUrl(key),
+        key.withCredentials ? { withCredentials: true } : undefined,
+      ),
+      subscribers: new Set(),
+      connected: false,
+    };
+
+    newEntry.source.onopen = () => {
+      newEntry.connected = true;
+      notifySubscribers(newEntry, (cur) => cur.onOpen());
+      withDevtools((mod) => {
+        if (newEntry.devId) mod.updateConnection(newEntry.devId, { connected: true, error: null });
+      });
+    };
+
+    newEntry.source.onmessage = (message) => {
+      try {
+        const event = JSON.parse(message.data) as NormalizedEvent;
+        notifySubscribers(newEntry, (cur) => cur.onEvent(event));
+        withDevtools((mod) => {
+          if (newEntry.devId) mod.updateConnection(newEntry.devId, { lastEvent: Date.now() });
+        });
+      } catch {
+        notifySubscribers(newEntry, (cur) => cur.onParseError());
+      }
+    };
+
+    newEntry.source.onerror = () => {
+      newEntry.connected = false;
+      notifySubscribers(newEntry, (cur) => cur.onError());
+      withDevtools((mod) => {
+        if (newEntry.devId) {
+          mod.updateConnection(newEntry.devId, {
+            connected: false,
+            error: "Connection lost — retrying...",
+          });
+        }
+      });
+    };
+
+    withDevtools((mod) => {
+      newEntry.devId = mod.registerConnection({
+        serverUrl: key.serverUrl,
+        address: key.contractId, // reuse address field for devtools display
+        url: getContractEventSourceUrl(key),
+        connected: newEntry.connected,
+        error: null,
+      });
+    });
+
+    pool.set(poolKey, newEntry);
+    entry = newEntry;
+  }
+
+  entry.subscribers.add(subscriber);
+
+  return {
+    get connected() {
+      return entry.connected;
+    },
+    unsubscribe: () => {
+      entry.subscribers.delete(subscriber);
+      if (entry.subscribers.size === 0) {
+        entry.source.close();
+        pool.delete(poolKey);
+        withDevtools((mod) => {
+          if (entry.devId) mod.unregisterConnection(entry.devId);
+        });
+      }
+    },
+  };
+}
+
+
 export function __getConnectionPoolSizeForTests() {
   return pool.size;
 }

--- a/packages/pulse-notify/src/connectionPool.ts
+++ b/packages/pulse-notify/src/connectionPool.ts
@@ -155,7 +155,13 @@ export function acquireEventConnection(key: ConnectionKey, subscriber: Connectio
 
 // --- Contract event connection helpers -------------------------------------------------
 // Build a unique key for contract subscriptions based on contractId, topics, and token.
-function getContractKey({ serverUrl, contractId, topics, token, withCredentials }: {
+function getContractKey({
+  serverUrl,
+  contractId,
+  topics,
+  token,
+  withCredentials,
+}: {
   serverUrl: string;
   contractId: string;
   topics?: string[];
@@ -163,13 +169,24 @@ function getContractKey({ serverUrl, contractId, topics, token, withCredentials 
   withCredentials?: boolean;
 }): string {
   // Sort topics to ensure stable key irrespective of order.
-  const sortedTopics = topics ? [...topics].sort().join(',') : '';
+  const sortedTopics = topics ? [...topics].sort().join(",") : "";
   // Include withCredentials flag for completeness.
-  return JSON.stringify([serverUrl, contractId, sortedTopics, token ?? "", withCredentials ?? false]);
+  return JSON.stringify([
+    serverUrl,
+    contractId,
+    sortedTopics,
+    token ?? "",
+    withCredentials ?? false,
+  ]);
 }
 
 // Construct EventSource URL for contract events, mirroring address logic.
-function getContractEventSourceUrl({ serverUrl, contractId, topics, token }: {
+function getContractEventSourceUrl({
+  serverUrl,
+  contractId,
+  topics,
+  token,
+}: {
   serverUrl: string;
   contractId: string;
   topics?: string[];
@@ -177,16 +194,22 @@ function getContractEventSourceUrl({ serverUrl, contractId, topics, token }: {
 }): string {
   const base = `${serverUrl}/contract_events/${contractId}`;
   const query: string[] = [];
-  if (topics && topics.length > 0) query.push(`topics=${encodeURIComponent(topics.join(','))}`);
+  if (topics && topics.length > 0) query.push(`topics=${encodeURIComponent(topics.join(","))}`);
   if (token) query.push(`token=${encodeURIComponent(token)}`);
-  return query.length > 0 ? `${base}?${query.join('&')}` : base;
+  return query.length > 0 ? `${base}?${query.join("&")}` : base;
 }
 
 /** Acquire a connection for a contract event subscription.
  *  Returns an object with `connected` flag and `unsubscribe` method similar to `acquireEventConnection`.
  */
 export function acquireContractEventConnection(
-  key: { serverUrl: string; contractId: string; topics?: string[]; token?: string; withCredentials?: boolean },
+  key: {
+    serverUrl: string;
+    contractId: string;
+    topics?: string[];
+    token?: string;
+    withCredentials?: boolean;
+  },
   subscriber: ConnectionSubscriber,
 ) {
   const poolKey = getContractKey(key);
@@ -267,7 +290,6 @@ export function acquireContractEventConnection(
     },
   };
 }
-
 
 export function __getConnectionPoolSizeForTests() {
   return pool.size;

--- a/packages/pulse-notify/src/index.ts
+++ b/packages/pulse-notify/src/index.ts
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef } from "react";
-import type { NormalizedEvent, PaymentEvent } from "@orbital-stellar/pulse-core";
-import { acquireEventConnection } from "./connectionPool.js";
+
+import { acquireEventConnection, acquireContractEventConnection } from "./connectionPool.js";
+import type { NormalizedEvent, PaymentEvent, ContractInvokedEvent, ContractEmittedEvent } from "@orbital-stellar/pulse-core";
 import { acquireWsConnection } from "./wsTransport.js";
 export { useStellarEventSuspense } from "./useStellarEventSuspense.js";
 
@@ -203,7 +204,95 @@ export {
   type StellarConnectionStatusState,
 } from "./StellarConnectionStatus.js";
 
-export { pulseNotifyVitePlugin } from "./vitePlugin.js";
+
+export type UseContractEventConfig<T extends NormalizedEvent = NormalizedEvent> = {
+  serverUrl: string;
+  contractId: string;
+  topics?: string[];
+  token?: string;
+  /** SSR initial state; replaced on first live event */
+  initialEvent?: T | null;
+  /** Client-side predicate; events that return false are suppressed before state update */
+  filter?: (event: NormalizedEvent) => boolean;
+  /** Enable cookie-based auth for same-origin or CORS-credentialed SSE */
+  withCredentials?: boolean;
+  /** Side-effect callback fired for every incoming event, before filter is applied */
+  onEvent?: (event: NormalizedEvent) => void;
+};
+
+/** Hook for subscribing to Soroban contract events */
+export function useContractEvent<
+  T extends Extract<NormalizedEvent, { type: "contract.invoked" | "contract.emitted" }> = Extract<
+    NormalizedEvent,
+    { type: "contract.invoked" | "contract.emitted" }
+  >
+>(
+  config: UseContractEventConfig<T>,
+): EventState<T> {
+  const { serverUrl, contractId, topics, token, initialEvent, filter, withCredentials, onEvent } = config;
+
+  const filterRef = useRef(filter);
+  useEffect(() => { filterRef.current = filter; }, [filter]);
+
+  const onEventRef = useRef(onEvent);
+  useEffect(() => { onEventRef.current = onEvent; }, [onEvent]);
+
+  const [state, setState] = useState<EventState<T>>({
+    event: initialEvent ?? null,
+    connected: false,
+    error: null,
+    lastEventAt: null,
+  });
+
+  useEffect(() => {
+    const connection = acquireContractEventConnection(
+      { serverUrl, contractId, topics, token, withCredentials },
+      {
+        onOpen: () => {
+          setState((prev) => ({ ...prev, connected: true, error: null }));
+        },
+        onEvent: (incoming) => {
+          onEventRef.current?.(incoming);
+          // Basic topic filtering for emitted events
+          if (incoming.type === "contract.emitted" && topics && topics.length > 0) {
+            const ev = incoming as ContractEmittedEvent;
+            const matches = topics.every((t) => ev.topics.includes(t));
+            if (!matches) return;
+          }
+          // Apply user filter if provided
+          if (filterRef.current && !filterRef.current(incoming)) return;
+          // Narrow to requested generic type
+          setState((prev) => ({
+            ...prev,
+            event: incoming as unknown as T,
+            lastEventAt: incoming.timestamp ?? null,
+          }));
+        },
+        onParseError: () => {
+          setState((prev) => ({ ...prev, error: "Failed to parse event" }));
+        },
+        onError: () => {
+          setState((prev) => ({
+            ...prev,
+            connected: false,
+            error: "Connection lost — retrying...",
+          }));
+        },
+      },
+    );
+
+    if (connection.connected) {
+      setState((prev) => ({ ...prev, connected: true, error: null }));
+    }
+
+    return () => {
+      connection.unsubscribe();
+    };
+  }, [serverUrl, contractId, JSON.stringify(topics ?? []), token, withCredentials]);
+
+  return state;
+}
+
 export type { PulseNotifyVitePlugin } from "./vitePlugin.js";
 
 export type UseHistoryOptions = {

--- a/packages/pulse-notify/src/index.ts
+++ b/packages/pulse-notify/src/index.ts
@@ -1,7 +1,12 @@
 import { useState, useEffect, useRef } from "react";
 
 import { acquireEventConnection, acquireContractEventConnection } from "./connectionPool.js";
-import type { NormalizedEvent, PaymentEvent, ContractInvokedEvent, ContractEmittedEvent } from "@orbital-stellar/pulse-core";
+import type {
+  NormalizedEvent,
+  PaymentEvent,
+  ContractInvokedEvent,
+  ContractEmittedEvent,
+} from "@orbital-stellar/pulse-core";
 import { acquireWsConnection } from "./wsTransport.js";
 export { useStellarEventSuspense } from "./useStellarEventSuspense.js";
 
@@ -205,7 +210,6 @@ export {
 } from "./StellarConnectionStatus.js";
 export { StellarEventBoundary } from "./StellarEventBoundary.js";
 
-
 export type UseContractEventConfig<T extends NormalizedEvent = NormalizedEvent> = {
   serverUrl: string;
   contractId: string;
@@ -226,17 +230,20 @@ export function useContractEvent<
   T extends Extract<NormalizedEvent, { type: "contract.invoked" | "contract.emitted" }> = Extract<
     NormalizedEvent,
     { type: "contract.invoked" | "contract.emitted" }
-  >
->(
-  config: UseContractEventConfig<T>,
-): EventState<T> {
-  const { serverUrl, contractId, topics, token, initialEvent, filter, withCredentials, onEvent } = config;
+  >,
+>(config: UseContractEventConfig<T>): EventState<T> {
+  const { serverUrl, contractId, topics, token, initialEvent, filter, withCredentials, onEvent } =
+    config;
 
   const filterRef = useRef(filter);
-  useEffect(() => { filterRef.current = filter; }, [filter]);
+  useEffect(() => {
+    filterRef.current = filter;
+  }, [filter]);
 
   const onEventRef = useRef(onEvent);
-  useEffect(() => { onEventRef.current = onEvent; }, [onEvent]);
+  useEffect(() => {
+    onEventRef.current = onEvent;
+  }, [onEvent]);
 
   const [state, setState] = useState<EventState<T>>({
     event: initialEvent ?? null,

--- a/packages/pulse-notify/test/connectionPool.test.ts
+++ b/packages/pulse-notify/test/connectionPool.test.ts
@@ -4,6 +4,7 @@ import {
   __getConnectionPoolSizeForTests,
   __resetConnectionPoolForTests,
   acquireEventConnection,
+  acquireContractEventConnection,
 } from "../src/connectionPool.ts";
 
 type EventSourceMessageHandler = (message: { data: string }) => void;
@@ -138,3 +139,72 @@ describe("connectionPool", () => {
     assert.equal(__getConnectionPoolSizeForTests(), 2);
   });
 });
+
+describe("acquireContractEventConnection", () => {
+  test("shares a single EventSource for identical contract connection keys", () => {
+    const eventsA: string[] = [];
+    const eventsB: string[] = [];
+
+    const a = acquireContractEventConnection(
+      { serverUrl: "https://events.example.com", contractId: "C123", topics: ["transfer"], token: "secret" },
+      {
+        onOpen: () => undefined,
+        onEvent: (event) => eventsA.push(event.type),
+        onParseError: () => undefined,
+        onError: () => undefined,
+      },
+    );
+
+    const b = acquireContractEventConnection(
+      { serverUrl: "https://events.example.com", contractId: "C123", topics: ["transfer"], token: "secret" },
+      {
+        onOpen: () => undefined,
+        onEvent: (event) => eventsB.push(event.type),
+        onParseError: () => undefined,
+        onError: () => undefined,
+      },
+    );
+
+    assert.equal(MockEventSource.instances.length, 1);
+    assert.equal(__getConnectionPoolSizeForTests(), 1);
+    assert.equal(a.connected, false);
+    assert.equal(b.connected, false);
+
+    MockEventSource.instances[0]?.onopen?.();
+    assert.equal(a.connected, true);
+    assert.equal(b.connected, true);
+
+    MockEventSource.instances[0]?.onmessage?.({
+      data: JSON.stringify({ type: "contract.emitted", topics: ["transfer"], data: "test" }),
+    });
+
+    assert.deepEqual(eventsA, ["contract.emitted"]);
+    assert.deepEqual(eventsB, ["contract.emitted"]);
+  });
+
+  test("uses separate connections for different contract topics", () => {
+    acquireContractEventConnection(
+      { serverUrl: "https://events.example.com", contractId: "C123", topics: ["transfer"] },
+      {
+        onOpen: () => undefined,
+        onEvent: () => undefined,
+        onParseError: () => undefined,
+        onError: () => undefined,
+      },
+    );
+
+    acquireContractEventConnection(
+      { serverUrl: "https://events.example.com", contractId: "C123", topics: ["mint"] },
+      {
+        onOpen: () => undefined,
+        onEvent: () => undefined,
+        onParseError: () => undefined,
+        onError: () => undefined,
+      },
+    );
+
+    assert.equal(MockEventSource.instances.length, 2);
+    assert.equal(__getConnectionPoolSizeForTests(), 2);
+  });
+});
+

--- a/packages/pulse-notify/test/connectionPool.test.ts
+++ b/packages/pulse-notify/test/connectionPool.test.ts
@@ -146,7 +146,12 @@ describe("acquireContractEventConnection", () => {
     const eventsB: string[] = [];
 
     const a = acquireContractEventConnection(
-      { serverUrl: "https://events.example.com", contractId: "C123", topics: ["transfer"], token: "secret" },
+      {
+        serverUrl: "https://events.example.com",
+        contractId: "C123",
+        topics: ["transfer"],
+        token: "secret",
+      },
       {
         onOpen: () => undefined,
         onEvent: (event) => eventsA.push(event.type),
@@ -156,7 +161,12 @@ describe("acquireContractEventConnection", () => {
     );
 
     const b = acquireContractEventConnection(
-      { serverUrl: "https://events.example.com", contractId: "C123", topics: ["transfer"], token: "secret" },
+      {
+        serverUrl: "https://events.example.com",
+        contractId: "C123",
+        topics: ["transfer"],
+        token: "secret",
+      },
       {
         onOpen: () => undefined,
         onEvent: (event) => eventsB.push(event.type),
@@ -207,4 +217,3 @@ describe("acquireContractEventConnection", () => {
     assert.equal(__getConnectionPoolSizeForTests(), 2);
   });
 });
-

--- a/packages/pulse-notify/test/useContractEvent.test.tsx
+++ b/packages/pulse-notify/test/useContractEvent.test.tsx
@@ -69,7 +69,7 @@ describe("useContractEvent Hook", () => {
         onEvent={(e) => {
           receivedEvent = e;
         }}
-      />
+      />,
     );
 
     // Wait for connection to open
@@ -96,9 +96,7 @@ describe("useContractEvent Hook", () => {
   });
 
   test("filters contract.emitted events by topics", async () => {
-    const { getByTestId, findByText } = render(
-      <TestComponent topics={["transfer"]} />
-    );
+    const { getByTestId, findByText } = render(<TestComponent topics={["transfer"]} />);
 
     await findByText("true", { selector: '[data-testid="connected"]' });
 

--- a/packages/pulse-notify/test/useContractEvent.test.tsx
+++ b/packages/pulse-notify/test/useContractEvent.test.tsx
@@ -1,0 +1,133 @@
+import { StrictMode, useState } from "react";
+import { render, act, cleanup } from "@testing-library/react";
+import { afterEach, expect, test, describe } from "vitest";
+import {
+  __getConnectionPoolSizeForTests,
+  __resetConnectionPoolForTests,
+} from "../src/connectionPool.ts";
+import { useContractEvent } from "../src/index.ts";
+
+// Minimal EventSource stub that allows emitting events and tracking open/close
+class MockEventSource {
+  static instances: MockEventSource[] = [];
+
+  onopen: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+  onmessage: ((e: { data: string }) => void) | null = null;
+  closeCount = 0;
+
+  constructor(public url: string) {
+    MockEventSource.instances.push(this);
+    // Auto-open in next tick
+    setTimeout(() => this.onopen?.(), 0);
+  }
+
+  close() {
+    this.closeCount++;
+  }
+
+  emit(data: any) {
+    this.onmessage?.({ data: JSON.stringify(data) });
+  }
+}
+
+globalThis.EventSource = MockEventSource as unknown as typeof EventSource;
+
+afterEach(() => {
+  __resetConnectionPoolForTests();
+  MockEventSource.instances = [];
+  cleanup();
+});
+
+describe("useContractEvent Hook", () => {
+  function TestComponent({
+    topics,
+    onEvent,
+  }: {
+    topics?: string[];
+    onEvent?: (event: any) => void;
+  }) {
+    const { event, connected, error } = useContractEvent({
+      serverUrl: "https://events.example.com",
+      contractId: "C123",
+      topics,
+      onEvent,
+    });
+    return (
+      <div>
+        <div data-testid="connected">{connected ? "true" : "false"}</div>
+        <div data-testid="error">{error ?? "none"}</div>
+        <div data-testid="event">{event ? JSON.stringify(event) : "null"}</div>
+      </div>
+    );
+  }
+
+  test("subscribes and receives contract events", async () => {
+    let receivedEvent: any = null;
+    const { getByTestId, findByText } = render(
+      <TestComponent
+        onEvent={(e) => {
+          receivedEvent = e;
+        }}
+      />
+    );
+
+    // Wait for connection to open
+    await findByText("true", { selector: '[data-testid="connected"]' });
+
+    expect(MockEventSource.instances.length).toBe(1);
+    expect(__getConnectionPoolSizeForTests()).toBe(1);
+
+    // Emit event
+    const payload = {
+      type: "contract.invoked",
+      contractId: "C123",
+      function: "hello",
+      args: [],
+      timestamp: "2026-06-26T17:29:03Z",
+    };
+
+    act(() => {
+      MockEventSource.instances[0].emit(payload);
+    });
+
+    expect(receivedEvent).toEqual(payload);
+    expect(getByTestId("event").textContent).toContain("contract.invoked");
+  });
+
+  test("filters contract.emitted events by topics", async () => {
+    const { getByTestId, findByText } = render(
+      <TestComponent topics={["transfer"]} />
+    );
+
+    await findByText("true", { selector: '[data-testid="connected"]' });
+
+    // Emit non-matching topic event
+    act(() => {
+      MockEventSource.instances[0].emit({
+        type: "contract.emitted",
+        contractId: "C123",
+        topics: ["mint"],
+        data: "minted",
+        timestamp: "2026-06-26T17:29:03Z",
+      });
+    });
+
+    expect(getByTestId("event").textContent).toBe("null");
+
+    // Emit matching topic event
+    const matchPayload = {
+      type: "contract.emitted",
+      contractId: "C123",
+      topics: ["transfer", "owner"],
+      data: "transferred",
+      timestamp: "2026-06-26T17:29:03Z",
+    };
+
+    act(() => {
+      MockEventSource.instances[0].emit(matchPayload);
+    });
+
+    expect(getByTestId("event").textContent).toContain("transferred");
+  });
+});


### PR DESCRIPTION
this pr closes #688  This pull request adds the useContractEvent hook to the @orbital-stellar/pulse-notify package. The hook enables React components to subscribe to Soroban contract events (both function invocations and emitted events) via Server-Sent Events (SSE).