### PR TITLE
Feat/webhook idempotency

### DIFF
--- a/packages/pulse-webhooks/README.md
+++ b/packages/pulse-webhooks/README.md
@@ -188,6 +188,7 @@ watcher.on("webhook.dropped", (event) => {
   - `x-orbital-signature`: hex-encoded HMAC-SHA256 of `x-orbital-timestamp + "." + raw body`
   - `x-orbital-timestamp`: Unix epoch milliseconds as a string (for example: `1714176000000`)
   - `x-orbital-attempt`: `1`, `2`, … up to `retries`
+  - `x-orbital-delivery-id`: UUID v4 identifier unique per event‑URL pair, reused across retries
 - **Success:** Any 2xx response
 - **Retry:** Any non-2xx, network error, or timeout. Backoff is exponential: `2^(attempt-1) × 1000 ms`.
 - **Failure:** After `retries` unsuccessful attempts for a given URL, the watcher emits `webhook.failed` with the original event in `raw.originalEvent` and the failed target in `raw.url`.

--- a/packages/pulse-webhooks/README.md
+++ b/packages/pulse-webhooks/README.md
@@ -188,7 +188,6 @@ watcher.on("webhook.dropped", (event) => {
   - `x-orbital-signature`: hex-encoded HMAC-SHA256 of `x-orbital-timestamp + "." + raw body`
   - `x-orbital-timestamp`: Unix epoch milliseconds as a string (for example: `1714176000000`)
   - `x-orbital-attempt`: `1`, `2`, … up to `retries`
-  - `x-orbital-delivery-id`: UUID v4 identifier unique per event‑URL pair, reused across retries
 - **Success:** Any 2xx response
 - **Retry:** Any non-2xx, network error, or timeout. Backoff is exponential: `2^(attempt-1) × 1000 ms`.
 - **Failure:** After `retries` unsuccessful attempts for a given URL, the watcher emits `webhook.failed` with the original event in `raw.originalEvent` and the failed target in `raw.url`.

--- a/packages/pulse-webhooks/src/index.ts
+++ b/packages/pulse-webhooks/src/index.ts
@@ -1,5 +1,5 @@
 import type { NormalizedEvent, Watcher, WatcherNotification } from "@orbital-stellar/pulse-core";
-import { createHmac, timingSafeEqual } from "crypto";
+import { createHmac, timingSafeEqual, randomUUID } from "crypto";
 
 import { DeadLetterStore } from "./MemoryDeadLetterStore.js";
 import { exponentialJittered } from "./backoff.js";

--- a/packages/pulse-webhooks/src/index.ts
+++ b/packages/pulse-webhooks/src/index.ts
@@ -106,15 +106,15 @@ export class WebhookDelivery {
   // Map of timer -> event so we can evict the newest entry when the cap is hit.
   private retryTimers: Map<ReturnType<typeof setTimeout>, { event: NormalizedEvent; url: string }> =
     new Map();
-// Map to store idempotency delivery IDs per event and URL
-private deliveryIds: Map<NormalizedEvent, Map<string, string>> = new Map();
+  // Map to store idempotency delivery IDs per event and URL
+  private deliveryIds: Map<NormalizedEvent, Map<string, string>> = new Map();
 
-// Timers that fire a durable-queue drain at each record's due time (only used
-// when `config.retryQueue` is set).
-private queueDrainTimers = new Set<ReturnType<typeof setTimeout>>();
+  // Timers that fire a durable-queue drain at each record's due time (only used
+  // when `config.retryQueue` is set).
+  private queueDrainTimers = new Set<ReturnType<typeof setTimeout>>();
 
-// Monotonic counter for durable RetryRecord ids.
-private retrySeq = 0;
+  // Monotonic counter for durable RetryRecord ids.
+  private retrySeq = 0;
 
   constructor(watcher: Watcher, config: WebhookConfig, dlq?: DeadLetterStore) {
     this.watcher = watcher;

--- a/packages/pulse-webhooks/src/index.ts
+++ b/packages/pulse-webhooks/src/index.ts
@@ -83,6 +83,8 @@ export class WebhookDelivery {
   // Map of timer -> event so we can evict the newest entry when the cap is hit.
   private retryTimers: Map<ReturnType<typeof setTimeout>, { event: NormalizedEvent; url: string }> =
     new Map();
+  // Map to store idempotency delivery IDs per event and URL
+  private deliveryIds: Map<NormalizedEvent, Map<string, string>> = new Map();
 
   constructor(watcher: Watcher, config: WebhookConfig, dlq?: DeadLetterStore) {
     this.watcher = watcher;
@@ -143,6 +145,19 @@ export class WebhookDelivery {
     const timeoutMs = this.config.deliveryTimeoutMs;
     const abortTimer = setTimeout(() => controller.abort(), timeoutMs);
 
+    // Idempotency header: generate or reuse UUID per event-URL pair
+    let urlDeliveryMap = this.deliveryIds.get(event);
+    if (!urlDeliveryMap) {
+      urlDeliveryMap = new Map();
+      this.deliveryIds.set(event, urlDeliveryMap);
+    }
+    let deliveryId = urlDeliveryMap.get(url);
+    if (!deliveryId) {
+      // Use crypto.randomUUID for UUID v4
+      deliveryId = randomUUID();
+      urlDeliveryMap.set(url, deliveryId);
+    }
+
     const parentTraceId = this.extractTraceId(event);
     const spanAttrs: Record<string, string | number | boolean> = {
       "webhook.url": url,
@@ -162,6 +177,7 @@ export class WebhookDelivery {
           "x-orbital-signature": signature,
           "x-orbital-timestamp": timestamp,
           "x-orbital-attempt": String(attempt),
+          "x-orbital-delivery-id": deliveryId,
         },
         body: payload,
         signal: controller.signal,

--- a/packages/pulse-webhooks/test/pulse-webhooks.test.ts
+++ b/packages/pulse-webhooks/test/pulse-webhooks.test.ts
@@ -512,6 +512,49 @@ describe("pulse-webhooks WebhookDelivery tracer", () => {
     expect(span.end).toHaveBeenCalledTimes(1);
   });
 
+  it("sends x-orbital-delivery-id (UUID v4) and re-uses the same ID across retries, but new ID for next event", async () => {
+    const fetchMock = vi.fn().mockRejectedValue(new Error("network down"));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const watcher = new Watcher("GABC");
+    new WebhookDelivery(watcher, {
+      url: "https://example.com/hook",
+      secret: "top-secret",
+      retries: 3,
+    });
+
+    watcher.emit("*", deliveryEvent);
+    await flushAsyncWork();
+
+    // attempt 1
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const headers1 = fetchMock.mock.calls[0][1].headers;
+    const deliveryId1 = headers1["x-orbital-delivery-id"];
+    expect(deliveryId1).toBeDefined();
+    expect(deliveryId1).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i); // UUID v4 pattern
+
+    // advance to trigger retry (attempt 2)
+    vi.advanceTimersByTime(2000);
+    await flushAsyncWork();
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const headers2 = fetchMock.mock.calls[1][1].headers;
+    const deliveryId2 = headers2["x-orbital-delivery-id"];
+    expect(deliveryId2).toBe(deliveryId1); // Must re-use the same ID across retries
+
+    // Emit a different event
+    const deliveryEvent2 = { ...deliveryEvent, raw: { id: "evt_2" } };
+    watcher.emit("*", deliveryEvent2);
+    await flushAsyncWork();
+
+    // attempt 1 of second event
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    const headers3 = fetchMock.mock.calls[2][1].headers;
+    const deliveryId3 = headers3["x-orbital-delivery-id"];
+    expect(deliveryId3).toBeDefined();
+    expect(deliveryId3).not.toBe(deliveryId1); // New ID for the next event
+  });
+
   it("emits a span per attempt on retry, recording error on failure", async () => {
     const fetchMock = vi.fn().mockRejectedValue(new Error("network down"));
     vi.stubGlobal("fetch", fetchMock);

--- a/packages/pulse-webhooks/test/pulse-webhooks.test.ts
+++ b/packages/pulse-webhooks/test/pulse-webhooks.test.ts
@@ -566,7 +566,9 @@ describe("pulse-webhooks WebhookDelivery tracer", () => {
     const headers1 = fetchMock.mock.calls[0][1].headers;
     const deliveryId1 = headers1["x-orbital-delivery-id"];
     expect(deliveryId1).toBeDefined();
-    expect(deliveryId1).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i); // UUID v4 pattern
+    expect(deliveryId1).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
+    ); // UUID v4 pattern
 
     // advance to trigger retry (attempt 2)
     vi.advanceTimersByTime(2000);


### PR DESCRIPTION
this pr closes #676 This PR implements webhook idempotency support by sending a unique `x-orbital-delivery-id` header (UUID v4) for every webhook event-URL pair, which is reused across all retry attempts of that specific delivery.