### PR TITLE
Add replay‑attack protection to webhook verification (maxAgeMs, clock…

### DIFF
--- a/packages/pulse-webhooks/src/edge.ts
+++ b/packages/pulse-webhooks/src/edge.ts
@@ -1,7 +1,7 @@
 import type { NormalizedEvent } from "@orbital-stellar/pulse-core";
 
 import type { VerifyWebhookOptions } from "./types.js";
-import { DEFAULT_CLOCK_SKEW_MS } from "./types.js";
+import { DEFAULT_CLOCK_SKEW_MS, DEFAULT_MAX_AGE_MS } from "./types.js";
 
 /**
  * Verifies webhook signatures using Web Crypto API (compatible with Cloudflare Workers, Deno, and browsers)
@@ -67,11 +67,9 @@ export async function verifyWebhookEdgeRaw(
   // Reject timestamps from the future (beyond clock skew allowance).
   if (timestampMs > nowMs + clockSkewMs) return false;
 
-  // Only enforce the replay window when maxAgeMs is explicitly configured.
-  // Omitting it preserves pre-existing behaviour (no age rejection).
-  if (options.maxAgeMs !== undefined) {
-    if (timestampMs < nowMs - options.maxAgeMs - clockSkewMs) return false;
-  }
+  // Enforce replay window: reject timestamps older than maxAgeMs (default 5 min) plus allowed clock skew.
+  const maxAgeMs = options.maxAgeMs ?? DEFAULT_MAX_AGE_MS;
+  if (timestampMs < nowMs - maxAgeMs - clockSkewMs) return false;
 
   try {
     const keyData = new TextEncoder().encode(secret);


### PR DESCRIPTION
this pr closes #675 Enforces signature age verification on edge/receiver webhooks to protect against replay attacks, aligning with the recommendations in SECURITY.md.

Changes
Updated packages/pulse-webhooks/src/edge.ts to:
Import DEFAULT_MAX_AGE_MS from types.ts.
Calculate maxAgeMs (defaulting to 5 minutes) when not explicitly provided.
Enforce checking signature timestamp against the combined window (maxAgeMs + clockSkewMs), rejecting signatures outside the allowed skew and maximum age boundary.