### PR TITLE
feat(pulse-core): enforce filter validation at subscribeContract construction (#630)

### DIFF
--- a/packages/pulse-core/src/EventEngine.ts
+++ b/packages/pulse-core/src/EventEngine.ts
@@ -6,6 +6,7 @@ import { SorobanRpcClient } from "./SorobanRpcClient.js";
 import type { SorobanRpcLike, SorobanEvent } from "./SorobanSubscriber.js";
 import { toAccountAddress, toContractAddress } from "./address.js";
 import { toStellarAmount } from "./amount.js";
+import { validateContractFilters } from "./contractFilters.js";
 import type {
   AccountCreatedEvent,
   AccountMergeEvent,
@@ -392,7 +393,9 @@ export class EventEngine {
    * Subscribes to Soroban contract events using an RPC-shaped filter config.
    * Deduplicates by a stable key over the filter shape — repeated calls with
    * semantically equal configs return the same Watcher instance.
-   * Throws synchronously when filters.length > 5 or any filter's contractIds.length > 5.
+   * Throws synchronously when the filter shape is invalid — more than 5 filters,
+   * a filter with more than 5 contractIds, or a malformed topic segment array
+   * (each segment must be '*', '**', or a base64-encoded XDR scval).
    * @param config - Filter configuration mirroring the RPC getEvents filter shape.
    */
   subscribeContract(config: ContractSubscriptionConfig): Watcher;
@@ -403,18 +406,11 @@ export class EventEngine {
     // New config-object overload
     if (typeof idOrConfig === "object") {
       const config = idOrConfig;
-      if (config.filters.length > 5) {
-        throw new Error(
-          `ContractSubscriptionConfig.filters must have ≤ 5 entries, got ${config.filters.length}`,
-        );
-      }
-      for (let i = 0; i < config.filters.length; i++) {
-        const f = config.filters[i]!;
-        if (f.contractIds !== undefined && f.contractIds.length > 5) {
-          throw new Error(
-            `ContractSubscriptionConfig.filters[${i}].contractIds must have ≤ 5 entries, got ${f.contractIds.length}`,
-          );
-        }
+      // Validate the whole filter shape up front so callers get a clear, synchronous
+      // error instead of a 4xx from the RPC (5-filter / 5-contractId / topic limits).
+      const validationErrors = validateContractFilters(config.filters);
+      if (validationErrors) {
+        throw new Error(`Invalid ContractSubscriptionConfig: ${validationErrors.join("; ")}`);
       }
 
       const key = stableFilterKey(config.filters);

--- a/packages/pulse-core/src/contractFilters.ts
+++ b/packages/pulse-core/src/contractFilters.ts
@@ -1,8 +1,24 @@
 /**
- * Validates a list of contract subscription filters according to Stellar RPC constraints:
+ * Accepted filter `type` values: the legacy ContractEventType union plus the
+ * RPC-shaped event classes used by ContractFilter (subscribeContract(config)).
+ */
+const VALID_FILTER_TYPES = [
+  "contract.invoked",
+  "contract.emitted",
+  "system",
+  "contract",
+  "diagnostic",
+];
+
+/**
+ * Validates a list of contract subscription filters against Stellar RPC constraints:
  * - filters.length ≤ 5
  * - filter.contractIds.length ≤ 5
- * - Topic patterns must be string arrays where each segment is either '*', '**', or a base64-encoded XDR scval
+ * - filter.topics (RPC segment arrays): an array of topic patterns, where each
+ *   pattern is a segment array and every segment is '*', '**', or a
+ *   base64-encoded XDR scval
+ * - filter.topicFilters (legacy positional form): an array whose entries are
+ *   null, '*', '**', or a base64-encoded XDR scval
  *
  * @param filters - The filters to validate
  * @returns null if valid, or an array of validation error messages if invalid
@@ -32,13 +48,10 @@ export function validateContractFilters(filters: unknown): string[] | null {
 
     const filterObj = filter as Record<string, unknown>;
 
-    // Validate type field (optional, must be string if present)
+    // Validate type field (optional, must be a known type if present)
     if ("type" in filterObj && filterObj.type !== undefined) {
-      if (
-        typeof filterObj.type !== "string" ||
-        !["contract.invoked", "contract.emitted"].includes(filterObj.type)
-      ) {
-        errors.push(`Filter[${i}].type must be "contract.invoked" or "contract.emitted"`);
+      if (typeof filterObj.type !== "string" || !VALID_FILTER_TYPES.includes(filterObj.type)) {
+        errors.push(`Filter[${i}].type must be one of: ${VALID_FILTER_TYPES.join(", ")}`);
       }
     }
 
@@ -86,6 +99,35 @@ export function validateContractFilters(filters: unknown): string[] | null {
                   `Filter[${i}].topicFilters[${j}] must be '*', '**', or a base64-encoded XDR scval, but got '${topic}'`,
                 );
               }
+            }
+          }
+        }
+      }
+    }
+
+    // Validate topics (RPC segment arrays): an array of topic patterns, where
+    // each pattern is a segment array and every segment must be '*', '**', or a
+    // base64-encoded XDR scval.
+    if ("topics" in filterObj && filterObj.topics !== undefined) {
+      if (!Array.isArray(filterObj.topics)) {
+        errors.push(`Filter[${i}].topics must be an array of segment arrays`);
+      } else {
+        for (let j = 0; j < filterObj.topics.length; j++) {
+          const pattern = filterObj.topics[j];
+          if (!Array.isArray(pattern)) {
+            errors.push(`Filter[${i}].topics[${j}] must be a segment array`);
+            continue;
+          }
+          for (let k = 0; k < pattern.length; k++) {
+            const segment = pattern[k];
+            if (typeof segment !== "string") {
+              errors.push(`Filter[${i}].topics[${j}][${k}] must be a string segment`);
+              continue;
+            }
+            if (segment !== "*" && segment !== "**" && !isValidBase64XdrScval(segment)) {
+              errors.push(
+                `Filter[${i}].topics[${j}][${k}] must be '*', '**', or a base64-encoded XDR scval, but got '${segment}'`,
+              );
             }
           }
         }

--- a/packages/pulse-core/test/EventEngine.subscribeContract.test.ts
+++ b/packages/pulse-core/test/EventEngine.subscribeContract.test.ts
@@ -288,6 +288,20 @@ describe("engine.subscribeContract(config)", () => {
     expect(() => engine.subscribeContract({ filters: [{ type: "diagnostic" }] })).not.toThrow();
   });
 
+  it("accepts '*' and '**' topic wildcards", () => {
+    const engine = makeEngine();
+    expect(() =>
+      engine.subscribeContract({ filters: [{ topics: [["*"], ["**"]] }] }),
+    ).not.toThrow();
+  });
+
+  it("throws synchronously for a malformed topic segment", () => {
+    const engine = makeEngine();
+    expect(() =>
+      engine.subscribeContract({ filters: [{ topics: [["not valid base64!"]] }] }),
+    ).toThrow(/topics|base64|scval/i);
+  });
+
   it("does not interfere with the legacy string-id subscribeContract", () => {
     const engine = makeEngine();
     const legacyWatcher = engine.subscribeContract("my-sub");

--- a/packages/pulse-core/test/contractFilters.test.ts
+++ b/packages/pulse-core/test/contractFilters.test.ts
@@ -55,16 +55,32 @@ describe("validateContractFilters", () => {
       expect(result).toBeNull();
     });
 
+    it("accepts RPC type 'contract'", () => {
+      expect(validateContractFilters([{ type: "contract" }])).toBeNull();
+    });
+
+    it("accepts RPC type 'system'", () => {
+      expect(validateContractFilters([{ type: "system" }])).toBeNull();
+    });
+
+    it("accepts RPC type 'diagnostic'", () => {
+      expect(validateContractFilters([{ type: "diagnostic" }])).toBeNull();
+    });
+
     it("rejects invalid type", () => {
       const filters = [{ type: "invalid.type" }];
       const result = validateContractFilters(filters);
-      expect(result).toContain('Filter[0].type must be "contract.invoked" or "contract.emitted"');
+      expect(result).toContain(
+        "Filter[0].type must be one of: contract.invoked, contract.emitted, system, contract, diagnostic",
+      );
     });
 
     it("rejects non-string type", () => {
       const filters = [{ type: 123 }];
       const result = validateContractFilters(filters);
-      expect(result).toContain('Filter[0].type must be "contract.invoked" or "contract.emitted"');
+      expect(result).toContain(
+        "Filter[0].type must be one of: contract.invoked, contract.emitted, system, contract, diagnostic",
+      );
     });
   });
 
@@ -250,6 +266,62 @@ describe("validateContractFilters", () => {
       const filters = [{ topicFilters: ["YWJjK2QvZQ=="] }];
       const result = validateContractFilters(filters);
       expect(result).toBeNull();
+    });
+  });
+
+  describe("topics segment-array validation", () => {
+    it("returns null when topics is omitted", () => {
+      expect(validateContractFilters([{ contractIds: ["C1"] }])).toBeNull();
+    });
+
+    it("returns error when topics is not an array", () => {
+      const result = validateContractFilters([{ topics: "nope" }]);
+      expect(result).toContain("Filter[0].topics must be an array of segment arrays");
+    });
+
+    it("returns null for an empty topics array", () => {
+      expect(validateContractFilters([{ topics: [] }])).toBeNull();
+    });
+
+    it("accepts a '*' single-segment wildcard pattern", () => {
+      expect(validateContractFilters([{ topics: [["*"]] }])).toBeNull();
+    });
+
+    it("accepts a '**' multi-segment wildcard pattern", () => {
+      expect(validateContractFilters([{ topics: [["**"]] }])).toBeNull();
+    });
+
+    it("accepts a base64 XDR scval segment", () => {
+      expect(validateContractFilters([{ topics: [["AAAADwAAAAV0cmFuc2Zlcg=="]] }])).toBeNull();
+    });
+
+    it("accepts multiple patterns mixing wildcards and scvals", () => {
+      const filters = [{ topics: [["*", "**"], ["AAAADwAAAAV0cmFuc2Zlcg=="]] }];
+      expect(validateContractFilters(filters)).toBeNull();
+    });
+
+    it("rejects a pattern that is not a segment array", () => {
+      const result = validateContractFilters([{ topics: ["*"] }]);
+      expect(result).toContain("Filter[0].topics[0] must be a segment array");
+    });
+
+    it("rejects a non-string segment", () => {
+      const result = validateContractFilters([{ topics: [[123]] }]);
+      expect(result).toContain("Filter[0].topics[0][0] must be a string segment");
+    });
+
+    it("rejects an invalid segment (not *, **, or base64)", () => {
+      const result = validateContractFilters([{ topics: [["not valid!"]] }]);
+      expect(result).toContain(
+        "Filter[0].topics[0][0] must be '*', '**', or a base64-encoded XDR scval, but got 'not valid!'",
+      );
+    });
+
+    it("reports the position of an invalid segment within a pattern", () => {
+      const result = validateContractFilters([{ topics: [["*", "bad seg!"]] }]);
+      expect(result).toContain(
+        "Filter[0].topics[0][1] must be '*', '**', or a base64-encoded XDR scval, but got 'bad seg!'",
+      );
     });
   });
 


### PR DESCRIPTION
## Summary

Implements **#630 (1.63 — Filter validation: 5-filter / 5-contractId / topic wildcards)**.

`validateContractFilters` already existed (from #499) but was **never wired into the engine**, so invalid filters only surfaced as a 4xx from the RPC. This PR runs validation at `subscribeContract(config)` construction and extends it to cover RPC topic segment arrays.

## What changed
- **`EventEngine.subscribeContract(config)`** now calls `validateContractFilters(config.filters)` and throws synchronously with a clear, aggregated message on any error — replacing the partial inline length checks. Throw messages still satisfy the existing `/filters.*≤ 5/i` and `/contractIds.*≤ 5/i` expectations.
- **`validateContractFilters`** extended:
  - Validates `topics` as **RPC segment arrays** — `topics` is an array of patterns, each pattern a segment array, and every segment must be `*`, `**`, or a base64-encoded XDR scval (reports `Filter[i].topics[j][k]` positions).
  - Accepts the RPC-shaped filter `type` values (`system` / `contract` / `diagnostic`) alongside the legacy `contract.invoked` / `contract.emitted`, so valid configs aren't falsely rejected.
  - The legacy positional `topicFilters` validation is unchanged (backwards compatible).

## Done when ✓
- Construction throws synchronously for invalid filter shapes with a clear message — covered by new `subscribeContract(config)` tests (malformed topic segment throws; `*`/`**` wildcards accepted).

## Tests
- New `topics` segment-array suite + config-`type` acceptance tests in `contractFilters.test.ts`.
- Two wiring tests in `EventEngine.subscribeContract.test.ts`.
- Full `pulse-core` suite green locally: **456 passed, 6 skipped**; `tsc -p` build, `test:types`, ESLint, and Prettier all clean.

Closes #630
