### PR TITLE
perf(pulse-core): coalesce duplicate filters into the minimum getEvents calls (#634)

### DIFF
--- a/packages/pulse-core/src/SorobanSubscriber.ts
+++ b/packages/pulse-core/src/SorobanSubscriber.ts
@@ -315,11 +315,17 @@ export class SorobanSubscriber {
         flatFilters.push(...sub.filters);
       }
 
-      if (flatFilters.length === 0) {
+      // Coalesce identical filters (order-preserving) so duplicate subscriptions
+      // share a single filter slot. This minimises the number of getEvents calls
+      // under the 5-filter cap — e.g. 6 subscriptions on the same contract collapse
+      // to one filter, hence one call instead of two.
+      const uniqueFilters = this.coalesceFilters(flatFilters);
+
+      if (uniqueFilters.length === 0) {
         rpcCalls = [[]];
       } else {
-        for (let i = 0; i < flatFilters.length; i += 5) {
-          rpcCalls.push(flatFilters.slice(i, i + 5));
+        for (let i = 0; i < uniqueFilters.length; i += 5) {
+          rpcCalls.push(uniqueFilters.slice(i, i + 5));
         }
       }
     }
@@ -466,6 +472,32 @@ export class SorobanSubscriber {
     }
     // No contractId constraint → matches.
     return true;
+  }
+
+  /**
+   * Collapses identical filters into a single entry, preserving first-seen order.
+   * Two filters are identical when they target the same event `type`, the same set
+   * of contract IDs (order-independent), and the same positional topic filters.
+   * This is what lets N subscriptions sharing a filter coalesce into one RPC slot,
+   * so the poll issues the minimum number of getEvents calls.
+   */
+  private coalesceFilters(filters: ContractSubscriptionFilter[]): ContractSubscriptionFilter[] {
+    const byKey = new Map<string, ContractSubscriptionFilter>();
+    for (const filter of filters) {
+      const key = this.filterKey(filter);
+      if (!byKey.has(key)) byKey.set(key, filter);
+    }
+    return [...byKey.values()];
+  }
+
+  /** Stable identity key for a filter; contract IDs are sorted so order doesn't matter. */
+  private filterKey(filter: ContractSubscriptionFilter): string {
+    const contractIds = filter.contractIds ? [...filter.contractIds].sort() : undefined;
+    return JSON.stringify({
+      type: filter.type,
+      contractIds,
+      topicFilters: filter.topicFilters,
+    });
   }
 
   /** Records a delivered event ID, evicting the oldest entries past the cap. */

--- a/packages/pulse-core/test/SorobanSubscriber.coalesce.test.ts
+++ b/packages/pulse-core/test/SorobanSubscriber.coalesce.test.ts
@@ -169,6 +169,86 @@ describe("SorobanSubscriber — coalescing and parallel filters", () => {
     expect(await cursorStore.getCursor()).toBe("0000000002");
   });
 
+  it("coalesces duplicate filters so identical subscriptions cost one filter slot", async () => {
+    const subscriber = new SorobanSubscriber({ rpc, cursorStore });
+
+    // 8 subscriptions, but only two distinct contracts between them.
+    subscriber.subscriptions = Array.from({ length: 8 }, (_, i) => ({
+      id: `sub-${i}`,
+      filters: [{ contractIds: [i % 2 === 0 ? "C1" : "C2"] }],
+    }));
+
+    await subscriber.pollOnce();
+
+    // Two unique filters → a single RPC call, not ceil(8 / 5) = 2.
+    expect(rpc.calls).toHaveLength(1);
+    expect(rpc.calls[0].filters).toEqual([{ contractIds: ["C1"] }, { contractIds: ["C2"] }]);
+  });
+
+  it("treats contractId order as identical when coalescing", async () => {
+    const subscriber = new SorobanSubscriber({ rpc, cursorStore });
+
+    subscriber.subscriptions = [
+      { id: "a", filters: [{ contractIds: ["C1", "C2"] }] },
+      { id: "b", filters: [{ contractIds: ["C2", "C1"] }] },
+    ];
+
+    await subscriber.pollOnce();
+
+    expect(rpc.calls).toHaveLength(1);
+    expect(rpc.calls[0].filters).toHaveLength(1);
+  });
+
+  it("uses the minimum number of calls when unique filters exceed the 5-filter cap", async () => {
+    const subscriber = new SorobanSubscriber({ rpc, cursorStore });
+
+    // 12 subscriptions across 6 distinct contracts (each watched twice).
+    subscriber.subscriptions = Array.from({ length: 12 }, (_, i) => ({
+      id: `sub-${i}`,
+      filters: [{ contractIds: [`C${i % 6}`] }],
+    }));
+
+    await subscriber.pollOnce();
+
+    // 6 unique filters → ceil(6 / 5) = 2 calls, not ceil(12 / 5) = 3.
+    expect(rpc.calls).toHaveLength(2);
+    expect(rpc.calls[0].filters).toHaveLength(5);
+    expect(rpc.calls[1].filters).toHaveLength(1);
+  });
+
+  it("delivers a coalesced event to every subscription that matches it", async () => {
+    const subscriber = new SorobanSubscriber({ rpc, cursorStore });
+
+    const received: Record<string, string[]> = { a: [], b: [] };
+    subscriber.subscriptions = [
+      {
+        id: "a",
+        filters: [{ contractIds: ["C1"] }],
+        onEvent: async (evt) => {
+          received.a.push(evt.id);
+        },
+      },
+      {
+        id: "b",
+        filters: [{ contractIds: ["C1"] }],
+        onEvent: async (evt) => {
+          received.b.push(evt.id);
+        },
+      },
+    ];
+
+    rpc.responseMap.set(JSON.stringify({ contractIds: ["C1"] }), [
+      makeEvent("evt-1", "0000000001", "C1"),
+    ]);
+
+    await subscriber.pollOnce();
+
+    // One coalesced filter → one call, but both subscriptions receive the event.
+    expect(rpc.calls).toHaveLength(1);
+    expect(received.a).toEqual(["evt-1"]);
+    expect(received.b).toEqual(["evt-1"]);
+  });
+
   it("maintains backward compatibility with constructor onEvent option", async () => {
     const emitted: SorobanEvent[] = [];
     const subscriber = new SorobanSubscriber({


### PR DESCRIPTION
## Summary

Implements **#634 (1.67 — Soroban subscriber: coalesce active filters across subscriptions)**.

`SorobanSubscriber._doPoll` already flattened all subscription filters and chunked them under the 5-filter-per-call cap. The remaining gap for *minimum* RPC calls: **duplicate filters across subscriptions each consumed a filter slot**, so N subscriptions watching the same contract cost `ceil(N / 5)` calls instead of one.

## What changed
- Added `coalesceFilters()` — collapses identical filters (order-preserving) before chunking. Two filters are identical when they share the same `type`, the same **set** of contract IDs (order-independent, via a sorted key), and the same positional `topicFilters`.
- `_doPoll` now chunks the **deduplicated** filters under the 5-filter cap.
- Routing is unchanged: returned events are still dispatched to **every** subscription whose filters match (per-subscription matching), so coalescing never drops a delivery.

## Done when ✓
- **N ≤ 5 → one RPC call per poll**, and **N > 5 → minimum number of calls** (duplicates no longer inflate the count).
  - 8 subscriptions across 2 contracts → **1** call (was 2).
  - 12 subscriptions across 6 distinct contracts → **2** calls (`ceil(6/5)`, was 3).

## Tests (`SorobanSubscriber.coalesce.test.ts`)
Added 4 cases: duplicate-filter coalescing to one slot, contract-id-order treated as identical, minimum-calls when unique filters exceed the cap, and a coalesced event delivered to every matching subscription. All 9 coalesce tests pass; full `pulse-core` suite green (**444 passed, 6 skipped**); `tsc -p` build, `test:types`, ESLint, and Prettier all clean.

Closes #634
