### PR TITLE
test(pulse-core): pin NETWORK_PASSPHRASES source-of-truth strings (#665)

### DIFF
--- a/packages/pulse-core/test/networkPassphrases.test.ts
+++ b/packages/pulse-core/test/networkPassphrases.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from "vitest";
+import { NETWORK_PASSPHRASES } from "../src/index.js";
+
+// NETWORK_PASSPHRASES is the package's source of truth for the exact passphrase
+// strings (see README "Network passphrases and asset format"). These tests lock
+// the literal values so a stray edit can't silently break consumers — signing
+// helpers, RPC calls, and tests — that depend on byte-exact passphrases.
+describe("NETWORK_PASSPHRASES", () => {
+  it("pins the exact mainnet passphrase string", () => {
+    expect(NETWORK_PASSPHRASES.mainnet).toBe("Public Global Stellar Network ; September 2015");
+  });
+
+  it("pins the exact testnet passphrase string", () => {
+    expect(NETWORK_PASSPHRASES.testnet).toBe("Test SDF Network ; September 2015");
+  });
+
+  it("exposes exactly the supported networks", () => {
+    expect(Object.keys(NETWORK_PASSPHRASES).sort()).toEqual(["mainnet", "testnet"]);
+  });
+});


### PR DESCRIPTION
## Summary

Resolves **#665 (1.98 — NETWORK_PASSPHRASES constants and asset format docs)**.

**Heads-up for the reviewer:** the issue's two "Done when" items already shipped in **#456** ("feat(pulse-core): export NETWORK_PASSPHRASES and document asset format"):
- `NETWORK_PASSPHRASES` (`{ mainnet, testnet }`) is exported from `src/index.ts`.
- The README "Network passphrases and asset format" section cross-references the constant and documents the asset-format rule (`XLM` / `CODE:ISSUER`).

What was still missing is the thing the issue's **context** asks for — *"consumers writing tests need to know exact passphrase strings"* — there was **no test pinning those strings**.

## Change
Adds `test/networkPassphrases.test.ts` that locks the source-of-truth values:
- `NETWORK_PASSPHRASES.mainnet === "Public Global Stellar Network ; September 2015"`
- `NETWORK_PASSPHRASES.testnet === "Test SDF Network ; September 2015"`
- the export exposes exactly `{ mainnet, testnet }`

So a stray edit to the constants can't silently break consumers (signing helpers, RPC calls, tests).

## Verification
New test passes (3/3); Prettier and ESLint clean. Docs-only references already in the README, so no `README.md`/`index.ts` changes were needed.

Closes #665
