### PR TITLE
feat(pulse-webhooks): add MemoryRetryQueue and durable retry-queue wiring (#668)

### DIFF
--- a/packages/pulse-webhooks/src/MemoryRetryQueue.ts
+++ b/packages/pulse-webhooks/src/MemoryRetryQueue.ts
@@ -1,0 +1,131 @@
+import type { RetryQueue, RetryRecord } from "./RetryQueue.js";
+
+export type MemoryRetryQueueOptions = {
+  /** Clock source, injectable for testing. Defaults to `Date.now`. */
+  now?: () => number;
+  /**
+   * How long a dequeued record stays "in-flight" before it is automatically
+   * reclaimed (re-queued) on the next dequeue. Mirrors the Redis queue so a
+   * consumer crash between dequeue and ack does not lose the retry. Defaults to
+   * 30,000ms.
+   */
+  visibilityTimeoutMs?: number;
+};
+
+const DEFAULT_VISIBILITY_TIMEOUT_MS = 30_000;
+
+type Entry = { record: RetryRecord; seq: number };
+
+/**
+ * In-memory reference implementation of {@link RetryQueue}.
+ *
+ * It is a drop-in, dependency-free queue with the same observable semantics as
+ * {@link RedisRetryQueue}: records are ordered by `nextRetryAt`, `dequeue` only
+ * returns due records (moving them to an in-flight set guarded by a visibility
+ * timeout), `evictNewest` sheds the furthest-future record under backpressure,
+ * and `size` counts only queued (not in-flight) records.
+ *
+ * Being in-memory it is **not durable** across process restarts — it exists as
+ * the canonical contract reference and for tests; use {@link RedisRetryQueue}
+ * (or another backing store) for real durability.
+ */
+export class MemoryRetryQueue implements RetryQueue {
+  private readonly queued = new Map<string, Entry>();
+  private readonly inFlight = new Map<string, { record: RetryRecord; expiresAt: number }>();
+  private readonly now: () => number;
+  private readonly visibilityTimeoutMs: number;
+  private seq = 0;
+
+  constructor(options: MemoryRetryQueueOptions = {}) {
+    this.now = options.now ?? Date.now;
+    this.visibilityTimeoutMs = Math.max(
+      1,
+      Math.floor(options.visibilityTimeoutMs ?? DEFAULT_VISIBILITY_TIMEOUT_MS),
+    );
+  }
+
+  async enqueue(record: RetryRecord): Promise<void> {
+    this.assertRecord(record);
+    // Store a copy so later external mutation can't corrupt queue state (this
+    // mirrors the JSON round-trip the Redis queue performs).
+    this.queued.set(record.id, { record: { ...record }, seq: this.seq++ });
+  }
+
+  async dequeue(nowMs: number = this.now()): Promise<RetryRecord | null> {
+    this.reclaimExpiredInFlight(nowMs);
+
+    // Earliest-due record; ties broken by insertion order (FIFO).
+    let best: Entry | undefined;
+    for (const entry of this.queued.values()) {
+      if (entry.record.nextRetryAt > nowMs) continue;
+      if (
+        best === undefined ||
+        entry.record.nextRetryAt < best.record.nextRetryAt ||
+        (entry.record.nextRetryAt === best.record.nextRetryAt && entry.seq < best.seq)
+      ) {
+        best = entry;
+      }
+    }
+    if (best === undefined) return null;
+
+    this.queued.delete(best.record.id);
+    this.inFlight.set(best.record.id, {
+      record: best.record,
+      expiresAt: nowMs + this.visibilityTimeoutMs,
+    });
+    return { ...best.record };
+  }
+
+  async ack(recordId: string): Promise<void> {
+    this.inFlight.delete(recordId);
+  }
+
+  async nack(recordId: string, requeueDelayMs: number): Promise<void> {
+    const inFlight = this.inFlight.get(recordId);
+    if (inFlight === undefined) return;
+
+    this.inFlight.delete(recordId);
+    const delayMs = Number.isFinite(requeueDelayMs) ? Math.max(0, Math.floor(requeueDelayMs)) : 0;
+    await this.enqueue({ ...inFlight.record, nextRetryAt: this.now() + delayMs });
+  }
+
+  async evictNewest(): Promise<RetryRecord | null> {
+    // Newest = furthest-future schedule; ties broken by most-recent insertion.
+    let newest: Entry | undefined;
+    for (const entry of this.queued.values()) {
+      if (
+        newest === undefined ||
+        entry.record.nextRetryAt > newest.record.nextRetryAt ||
+        (entry.record.nextRetryAt === newest.record.nextRetryAt && entry.seq > newest.seq)
+      ) {
+        newest = entry;
+      }
+    }
+    if (newest === undefined) return null;
+
+    this.queued.delete(newest.record.id);
+    return { ...newest.record };
+  }
+
+  async size(): Promise<number> {
+    return this.queued.size;
+  }
+
+  private reclaimExpiredInFlight(nowMs: number): void {
+    for (const [id, entry] of this.inFlight) {
+      if (entry.expiresAt <= nowMs) {
+        this.inFlight.delete(id);
+        this.queued.set(id, { record: { ...entry.record, nextRetryAt: nowMs }, seq: this.seq++ });
+      }
+    }
+  }
+
+  private assertRecord(record: RetryRecord): void {
+    if (!record.id) {
+      throw new Error("RetryRecord.id is required");
+    }
+    if (!Number.isFinite(record.nextRetryAt)) {
+      throw new Error("RetryRecord.nextRetryAt must be a finite timestamp");
+    }
+  }
+}

--- a/packages/pulse-webhooks/src/index.ts
+++ b/packages/pulse-webhooks/src/index.ts
@@ -4,6 +4,7 @@ import { createHmac, timingSafeEqual } from "crypto";
 import { DeadLetterStore } from "./MemoryDeadLetterStore.js";
 import { exponentialJittered } from "./backoff.js";
 import type { BackoffStrategy } from "./backoff.js";
+import type { RetryQueue, RetryRecord } from "./RetryQueue.js";
 import type { Tracer, VerifyWebhookOptions, WebhookConfig } from "./types.js";
 import { DEFAULT_MAX_AGE_MS, DEFAULT_CLOCK_SKEW_MS } from "./types.js";
 export { DeadLetterStore } from "./MemoryDeadLetterStore.js";
@@ -13,6 +14,7 @@ export { exponentialJittered, linear, cappedExponential, constant } from "./back
 export type { BackoffStrategy } from "./backoff.js";
 export { PostgresDeadLetterStore } from "./PostgresDeadLetterStore.js";
 export { RedisRetryQueue } from "./RedisRetryQueue.js";
+export { MemoryRetryQueue } from "./MemoryRetryQueue.js";
 export { verifyWebhookEdge, verifyWebhookEdgeRaw } from "./edge.js";
 export type {
   DeadLetterEntry,
@@ -26,6 +28,7 @@ export type {
   PgLike,
 } from "./PostgresDeadLetterStore.js";
 export type { RedisLike, RedisRetryQueueOptions } from "./RedisRetryQueue.js";
+export type { MemoryRetryQueueOptions } from "./MemoryRetryQueue.js";
 export type { RetryQueue, RetryRecord } from "./RetryQueue.js";
 export type {
   Span,
@@ -67,13 +70,14 @@ export type WebhookDroppedRaw = {
 
 type ResolvedWebhookConfig = Omit<
   Required<WebhookConfig>,
-  "url" | "tracer" | "urlValidator" | "metrics" | "backoff"
+  "url" | "tracer" | "urlValidator" | "metrics" | "backoff" | "retryQueue"
 > & {
   urls: string[];
   backoff: BackoffStrategy;
   tracer?: Tracer;
   urlValidator?: WebhookConfig["urlValidator"];
   metrics?: WebhookConfig["metrics"];
+  retryQueue?: RetryQueue;
 };
 
 export class WebhookDelivery {
@@ -83,6 +87,11 @@ export class WebhookDelivery {
   // Map of timer -> event so we can evict the newest entry when the cap is hit.
   private retryTimers: Map<ReturnType<typeof setTimeout>, { event: NormalizedEvent; url: string }> =
     new Map();
+  // Timers that fire a durable-queue drain at each record's due time (only used
+  // when `config.retryQueue` is set).
+  private queueDrainTimers = new Set<ReturnType<typeof setTimeout>>();
+  // Monotonic counter for durable RetryRecord ids.
+  private retrySeq = 0;
 
   constructor(watcher: Watcher, config: WebhookConfig, dlq?: DeadLetterStore) {
     this.watcher = watcher;
@@ -187,32 +196,29 @@ export class WebhookDelivery {
       this.dlq.recordFailure(url);
 
       if (attempt < this.config.retries) {
-        // Enforce the retry cap — evict the newest pending retry when at limit.
-        if (this.retryTimers.size >= this.config.maxConcurrentRetries) {
-          // Evict the newest (last-inserted) retry — it has waited the least, so dropping it wastes the least elapsed time.
-          const newestTimer = [...this.retryTimers.keys()].at(-1)!;
-          const newest = this.retryTimers.get(newestTimer)!;
-          clearTimeout(newestTimer);
-          this.retryTimers.delete(newestTimer);
-          this.config.metrics?.recordTerminal(newest.url, "dropped");
-          this.dlq.add(newest.url, newest.event, "retry_cap_exceeded", 0);
-          this.watcher.emit("webhook.dropped", {
-            ...newest.event,
-            raw: {
-              reason: "retry_cap_exceeded",
-              url: newest.url,
-              maxConcurrentRetries: this.config.maxConcurrentRetries,
-              originalEvent: newest.event,
-            } satisfies WebhookDroppedRaw,
-          } as unknown as NormalizedEvent);
-        }
+        if (this.config.retryQueue) {
+          // Durable path: persist the pending retry to the queue so it survives a
+          // process restart. A drain timer fires the redelivery at its due time.
+          await this.persistRetry(this.config.retryQueue, event, url, attempt + 1, errorMessage);
+        } else {
+          // In-process path: enforce the retry cap by evicting the newest pending
+          // retry when at limit.
+          if (this.retryTimers.size >= this.config.maxConcurrentRetries) {
+            // Evict the newest (last-inserted) retry — it has waited the least, so dropping it wastes the least elapsed time.
+            const newestTimer = [...this.retryTimers.keys()].at(-1)!;
+            const newest = this.retryTimers.get(newestTimer)!;
+            clearTimeout(newestTimer);
+            this.retryTimers.delete(newestTimer);
+            this.emitDropped(newest.event, newest.url);
+          }
 
-        const delay = this.config.backoff(attempt, this.config.random);
-        const retryTimer = setTimeout(() => {
-          this.retryTimers.delete(retryTimer);
-          void this.deliverToUrl(event, url, attempt + 1);
-        }, delay);
-        this.retryTimers.set(retryTimer, { event, url });
+          const delay = this.config.backoff(attempt, this.config.random);
+          const retryTimer = setTimeout(() => {
+            this.retryTimers.delete(retryTimer);
+            void this.deliverToUrl(event, url, attempt + 1);
+          }, delay);
+          this.retryTimers.set(retryTimer, { event, url });
+        }
       } else {
         this.emitFailure(event, url, errorMessage, attempt);
       }
@@ -262,6 +268,84 @@ export class WebhookDelivery {
       clearTimeout(timer);
     }
     this.retryTimers.clear();
+    for (const timer of this.queueDrainTimers) {
+      clearTimeout(timer);
+    }
+    this.queueDrainTimers.clear();
+  }
+
+  /** Emits `webhook.dropped` and dead-letters an event shed by the retry cap. */
+  private emitDropped(event: NormalizedEvent, url: string): void {
+    this.config.metrics?.recordTerminal(url, "dropped");
+    this.dlq.add(url, event, "retry_cap_exceeded", 0);
+    this.watcher.emit("webhook.dropped", {
+      ...event,
+      raw: {
+        reason: "retry_cap_exceeded",
+        url,
+        maxConcurrentRetries: this.config.maxConcurrentRetries,
+        originalEvent: event,
+      } satisfies WebhookDroppedRaw,
+    } as unknown as NormalizedEvent);
+  }
+
+  /**
+   * Persists a pending retry to the durable queue and schedules a drain at its
+   * due time. The retry cap is enforced against the queue's `size()`, shedding
+   * the newest (furthest-future) record via `evictNewest()` when at the limit.
+   */
+  private async persistRetry(
+    queue: RetryQueue,
+    event: NormalizedEvent,
+    url: string,
+    attempt: number,
+    lastError: string,
+  ): Promise<void> {
+    if ((await queue.size()) >= this.config.maxConcurrentRetries) {
+      const evicted = await queue.evictNewest();
+      if (evicted) {
+        this.emitDropped(evicted.event as NormalizedEvent, evicted.url);
+      }
+    }
+
+    const delay = this.config.backoff(attempt - 1, this.config.random);
+    const record: RetryRecord<NormalizedEvent> = {
+      id: `retry-${Date.now()}-${this.retrySeq++}`,
+      event,
+      url,
+      attempt,
+      nextRetryAt: Date.now() + delay,
+      lastError,
+      createdAt: Date.now(),
+    };
+    await queue.enqueue(record);
+
+    // Auto-drive the redelivery without requiring an external scheduler.
+    const timer = setTimeout(() => {
+      this.queueDrainTimers.delete(timer);
+      void this.drainDueRetries();
+    }, delay);
+    this.queueDrainTimers.add(timer);
+  }
+
+  /**
+   * Drains all currently-due records from the configured retry queue, redelivering
+   * each and acknowledging it. A redelivery that fails again re-persists itself
+   * (with the next backoff) via {@link deliverToUrl}, so this loop terminates once
+   * no record is due. Safe to call from a scheduler or on process startup to
+   * resume retries persisted before a restart.
+   */
+  async drainDueRetries(nowMs: number = Date.now()): Promise<void> {
+    const queue = this.config.retryQueue;
+    if (!queue) return;
+
+    for (;;) {
+      if (this.watcher.stopped) return;
+      const record = await queue.dequeue(nowMs);
+      if (!record) return;
+      await this.deliverToUrl(record.event as NormalizedEvent, record.url, record.attempt);
+      await queue.ack(record.id);
+    }
   }
 
   private getErrorMessage(err: unknown): string {

--- a/packages/pulse-webhooks/src/types.ts
+++ b/packages/pulse-webhooks/src/types.ts
@@ -40,6 +40,13 @@ export type WebhookConfig = {
   urlValidator?: (url: string) => Promise<string | null>;
   /** Optional metrics recorder for per-URL delivery observability. */
   metrics?: WebhookMetrics;
+  /**
+   * Optional durable retry queue. When provided, retryable delivery failures are
+   * persisted to it (instead of the in-process timer set) so pending retries can
+   * survive a process restart. See {@link import("./RetryQueue.js").RetryQueue}
+   * and {@link import("./MemoryRetryQueue.js").MemoryRetryQueue}.
+   */
+  retryQueue?: import("./RetryQueue.js").RetryQueue;
 };
 
 export const DEFAULT_MAX_AGE_MS = 300_000;

--- a/packages/pulse-webhooks/test/MemoryRetryQueue.test.ts
+++ b/packages/pulse-webhooks/test/MemoryRetryQueue.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it } from "vitest";
+
+import { MemoryRetryQueue, type RetryRecord } from "../src/index.js";
+
+function makeRecord(
+  id: string,
+  nextRetryAt: number,
+  overrides: Partial<RetryRecord> = {},
+): RetryRecord {
+  return {
+    id,
+    event: { id },
+    url: "https://example.com/hook",
+    attempt: 1,
+    nextRetryAt,
+    ...overrides,
+  };
+}
+
+describe("MemoryRetryQueue", () => {
+  describe("round-trip", () => {
+    it("enqueues and dequeues an identical record", async () => {
+      const queue = new MemoryRetryQueue({ now: () => 1000 });
+      const record = makeRecord("a", 500, { lastError: "HTTP 500", attempt: 2 });
+
+      await queue.enqueue(record);
+      expect(await queue.size()).toBe(1);
+
+      const out = await queue.dequeue(1000);
+      expect(out).toEqual(record);
+      expect(await queue.size()).toBe(0);
+    });
+
+    it("does not alias the caller's record (stores a copy)", async () => {
+      const queue = new MemoryRetryQueue({ now: () => 1000 });
+      const record = makeRecord("a", 500);
+      await queue.enqueue(record);
+
+      record.attempt = 99; // mutate after enqueue
+
+      const out = await queue.dequeue(1000);
+      expect(out?.attempt).toBe(1);
+    });
+
+    it("returns the earliest-due record first", async () => {
+      const queue = new MemoryRetryQueue();
+      await queue.enqueue(makeRecord("late", 300));
+      await queue.enqueue(makeRecord("early", 100));
+
+      expect((await queue.dequeue(1000))?.id).toBe("early");
+      expect((await queue.dequeue(1000))?.id).toBe("late");
+    });
+
+    it("returns null and leaves the record queued when nothing is due", async () => {
+      const queue = new MemoryRetryQueue();
+      await queue.enqueue(makeRecord("future", 5000));
+
+      expect(await queue.dequeue(1000)).toBeNull();
+      expect(await queue.size()).toBe(1);
+    });
+  });
+
+  describe("eviction", () => {
+    it("evictNewest removes and returns the furthest-future record", async () => {
+      const queue = new MemoryRetryQueue();
+      await queue.enqueue(makeRecord("a", 100));
+      await queue.enqueue(makeRecord("c", 300));
+      await queue.enqueue(makeRecord("b", 200));
+
+      const evicted = await queue.evictNewest();
+      expect(evicted?.id).toBe("c");
+      expect(await queue.size()).toBe(2);
+
+      // The remaining records are untouched and still dequeue in due order.
+      expect((await queue.dequeue(1000))?.id).toBe("a");
+      expect((await queue.dequeue(1000))?.id).toBe("b");
+    });
+
+    it("evictNewest returns null on an empty queue", async () => {
+      const queue = new MemoryRetryQueue();
+      expect(await queue.evictNewest()).toBeNull();
+    });
+  });
+
+  describe("in-flight visibility (ack / nack / reclaim)", () => {
+    it("ack removes an in-flight record so it is not reclaimed", async () => {
+      let clock = 1000;
+      const queue = new MemoryRetryQueue({ now: () => clock, visibilityTimeoutMs: 100 });
+      await queue.enqueue(makeRecord("a", 500));
+
+      const taken = await queue.dequeue(clock);
+      expect(taken?.id).toBe("a");
+      await queue.ack("a");
+
+      clock = 999_999; // well past the visibility window
+      expect(await queue.dequeue(clock)).toBeNull();
+      expect(await queue.size()).toBe(0);
+    });
+
+    it("reclaims an un-acked record once its visibility timeout lapses", async () => {
+      const queue = new MemoryRetryQueue({ visibilityTimeoutMs: 100 });
+      await queue.enqueue(makeRecord("a", 500));
+
+      expect((await queue.dequeue(1000))?.id).toBe("a"); // in-flight, expires at 1100
+      expect(await queue.dequeue(1050)).toBeNull(); // still in-flight
+      expect((await queue.dequeue(1200))?.id).toBe("a"); // reclaimed and re-delivered
+    });
+
+    it("nack re-enqueues the record with a delay", async () => {
+      const queue = new MemoryRetryQueue({ now: () => 1000 });
+      await queue.enqueue(makeRecord("a", 500));
+      await queue.dequeue(1000);
+
+      await queue.nack("a", 200); // re-schedule for now (1000) + 200
+      expect(await queue.size()).toBe(1);
+      expect(await queue.dequeue(1100)).toBeNull(); // not due yet
+
+      const out = await queue.dequeue(1300);
+      expect(out?.id).toBe("a");
+      expect(out?.nextRetryAt).toBe(1200);
+    });
+
+    it("ack and nack are no-ops for an unknown record id", async () => {
+      const queue = new MemoryRetryQueue();
+      await expect(queue.ack("missing")).resolves.toBeUndefined();
+      await expect(queue.nack("missing", 100)).resolves.toBeUndefined();
+      expect(await queue.size()).toBe(0);
+    });
+  });
+
+  describe("validation", () => {
+    it("rejects a record without an id", async () => {
+      const queue = new MemoryRetryQueue();
+      await expect(queue.enqueue(makeRecord("", 100))).rejects.toThrow(
+        "RetryRecord.id is required",
+      );
+    });
+
+    it("rejects a record with a non-finite nextRetryAt", async () => {
+      const queue = new MemoryRetryQueue();
+      await expect(queue.enqueue(makeRecord("a", Number.NaN))).rejects.toThrow(
+        "RetryRecord.nextRetryAt must be a finite timestamp",
+      );
+    });
+  });
+});

--- a/packages/pulse-webhooks/test/pulse-webhooks.test.ts
+++ b/packages/pulse-webhooks/test/pulse-webhooks.test.ts
@@ -5,6 +5,7 @@ import { Watcher } from "@orbital-stellar/pulse-core";
 import type { WebhookMetrics } from "../src/index.js";
 import {
   DeadLetterStore,
+  MemoryRetryQueue,
   verifyWebhook,
   verifyWebhookRaw,
   verifyWebhookEdge,
@@ -174,6 +175,40 @@ describe("pulse-webhooks WebhookDelivery", () => {
       "https://prod.example.com/webhooks/stellar",
       "failure",
     );
+  });
+
+  it("persists retryable failures through a configured retry queue and drains them", async () => {
+    vi.setSystemTime(new Date("2026-04-27T00:00:00.000Z"));
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: false, status: 500 })
+      .mockResolvedValue({ ok: true, status: 200 });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const queue = new MemoryRetryQueue();
+    const watcher = new Watcher("GABC");
+    const delivery = new WebhookDelivery(watcher, {
+      url: "https://prod.example.com/webhooks/stellar",
+      secret: "top-secret",
+      retries: 3,
+      random: () => 0,
+      retryQueue: queue,
+    });
+
+    watcher.emit("*", deliveryEvent);
+    await flushAsyncWork();
+    await flushAsyncWork();
+
+    // The failed attempt is persisted to the durable queue (not just an in-process
+    // timer), so a process restart could resume it.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(await queue.size()).toBe(1);
+
+    // Draining redelivers the persisted retry and acknowledges it on success.
+    await delivery.drainDueRetries(Date.now() + 3_600_000);
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(await queue.size()).toBe(0);
   });
 
   it("rejects URL when custom urlValidator blocks an otherwise allowed URL without retrying", async () => {


### PR DESCRIPTION
## Summary

Implements **#668 (2.31 — RetryQueue interface for durable retries)**.

The `RetryQueue` interface and `RedisRetryQueue` already existed, but there was no in-memory reference implementation and `WebhookDelivery` never consumed a queue — so retries lived only in in-process `setTimeout`s and a restart lost every pending one.

## What changed
- **`src/MemoryRetryQueue.ts`** (new) — a dependency-free reference `RetryQueue` with the same observable semantics as `RedisRetryQueue`:
  - `enqueue` / `dequeue` are ordered by `nextRetryAt`; `dequeue` only returns **due** records and moves them to an in-flight set guarded by a visibility timeout (un-acked records are reclaimed after it lapses).
  - `evictNewest` sheds the furthest-future record (backpressure); `size` counts only queued records; `ack` / `nack` complete or requeue in-flight records.
- **`types.ts`** — adds `WebhookConfig.retryQueue?: RetryQueue`.
- **`index.ts`** — exports `MemoryRetryQueue`; when a `retryQueue` is configured, `WebhookDelivery` persists retryable failures to it (retry cap enforced via `evictNewest`) instead of an in-process timer, and `drainDueRetries()` redelivers + acks due records (callable from a scheduler or on startup). **Without a `retryQueue`, behaviour is unchanged** (the new code is fully gated).

## Done when ✓
- **MemoryRetryQueue passes round-trip and eviction tests** — `test/MemoryRetryQueue.test.ts` covers round-trip, earliest-due ordering, `evictNewest`, ack/nack, visibility-timeout reclaim, and validation.
- **A delivery configured with a custom queue persists retries through it** — integration test in `pulse-webhooks.test.ts`: a failing delivery is persisted (`queue.size() === 1`), then `drainDueRetries()` redelivers and acks it (`size() === 0`).

## Verification
Full `pulse-webhooks` suite green (**86 passed**); `tsc -p` typecheck, ESLint, and Prettier all clean.

Closes #668
