### PR TITLE
1.81 — AbiRegistryClient: contract spec fetch with local cache

### DIFF
--- a/packages/abi-registry/src/AbiRegistryClient.ts
+++ b/packages/abi-registry/src/AbiRegistryClient.ts
@@ -22,9 +22,15 @@
 export const REGISTRY_SPEC_VERSION = 1;
 
 import { LruCache } from "./LruCache.js";
-import type { AbiRegistryClientConfig, ContractSpec } from "./types.js";
+import type { AbiRegistryClientConfig, AbiRegistryClientTransport, ContractSpec } from "./types.js";
 
 const DEFAULT_MAX_CACHE_SIZE = 512;
+const DEFAULT_CACHE_TTL_MS = 5 * 60 * 1000;
+
+type CacheEntry = {
+  value: ContractSpec | null;
+  expiresAt: number;
+};
 
 /**
  * HTTP client for the Orbital ABI Registry API.
@@ -39,17 +45,44 @@ const DEFAULT_MAX_CACHE_SIZE = 512;
  */
 export class AbiRegistryClient {
   private readonly baseUrl: string;
-  private readonly cache: LruCache<string, ContractSpec | null>;
+  private readonly transport: AbiRegistryClientTransport;
+  private readonly cache: LruCache<string, CacheEntry>;
+  private readonly ttlMs: number;
 
   constructor(config: AbiRegistryClientConfig) {
     this.baseUrl = config.baseUrl.replace(/\/$/, "");
+    this.transport = config.transport ?? fetch.bind(globalThis);
+    this.ttlMs = config.cacheTtlMs ?? DEFAULT_CACHE_TTL_MS;
     this.cache = new LruCache(config.maxCacheSize ?? DEFAULT_MAX_CACHE_SIZE);
   }
 
   /** Fetch a single contract spec (cached). */
   async getSpec(contractId: string): Promise<ContractSpec | null> {
-    const results = await this.getSpecs([contractId]);
-    return results[contractId] ?? null;
+    const cached = this.getCached(contractId);
+    if (cached !== undefined) return cached;
+
+    const response = await this.transport(
+      `${this.baseUrl}/specs/${encodeURIComponent(contractId)}`,
+      {
+        method: "GET",
+        headers: {
+          Accept: `application/vnd.orbital.abi-registry+json; version=${REGISTRY_SPEC_VERSION}`,
+        },
+      },
+    );
+
+    if (response.status === 404) {
+      this.setCache(contractId, null);
+      return null;
+    }
+
+    if (!response.ok) {
+      throw new Error(`ABI registry responded with ${response.status} for contract spec fetch`);
+    }
+
+    const spec = (await response.json()) as ContractSpec;
+    this.setCache(contractId, spec);
+    return spec;
   }
 
   /**
@@ -63,8 +96,9 @@ export class AbiRegistryClient {
     const uncached: string[] = [];
 
     for (const id of contractIds) {
-      if (this.cache.has(id)) {
-        result[id] = this.cache.get(id) ?? null;
+      const cached = this.getCached(id);
+      if (cached !== undefined) {
+        result[id] = cached;
       } else {
         uncached.push(id);
       }
@@ -76,18 +110,35 @@ export class AbiRegistryClient {
 
     for (const id of uncached) {
       const spec = fetched[id] ?? null;
-      this.cache.set(id, spec);
+      this.setCache(id, spec);
       result[id] = spec;
     }
 
     return result;
   }
 
+  private getCached(contractId: string): ContractSpec | null | undefined {
+    const entry = this.cache.get(contractId);
+    if (!entry) return undefined;
+    if (Date.now() > entry.expiresAt) {
+      this.cache.delete(contractId);
+      return undefined;
+    }
+    return entry.value;
+  }
+
+  private setCache(contractId: string, value: ContractSpec | null): void {
+    this.cache.set(contractId, {
+      value,
+      expiresAt: Date.now() + this.ttlMs,
+    });
+  }
+
   /**
    * POST /specs with the full list of IDs — one round-trip regardless of batch size.
    */
   private async fetchBatch(contractIds: string[]): Promise<Record<string, ContractSpec | null>> {
-    const response = await fetch(`${this.baseUrl}/specs`, {
+    const response = await this.transport(`${this.baseUrl}/specs`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",

--- a/packages/abi-registry/src/LruCache.ts
+++ b/packages/abi-registry/src/LruCache.ts
@@ -25,6 +25,10 @@ export class LruCache<K, V> {
     }
   }
 
+  delete(key: K): boolean {
+    return this.map.delete(key);
+  }
+
   has(key: K): boolean {
     return this.map.has(key);
   }

--- a/packages/abi-registry/src/types.ts
+++ b/packages/abi-registry/src/types.ts
@@ -5,9 +5,18 @@ export type ContractSpec = {
   entries: string[];
 };
 
+export type AbiRegistryClientTransport = (
+  input: RequestInfo,
+  init?: RequestInit,
+) => Promise<Response>;
+
 export type AbiRegistryClientConfig = {
   /** Base URL of the hosted ABI registry, e.g. "https://abi.stellar.org". */
   baseUrl: string;
   /** Maximum number of specs to keep in the LRU cache. Defaults to 512. */
   maxCacheSize?: number;
+  /** Time-to-live for cached specs in milliseconds. Defaults to 5 minutes. */
+  cacheTtlMs?: number;
+  /** Optional transport for HTTP requests; falls back to the global fetch implementation. */
+  transport?: AbiRegistryClientTransport;
 };

--- a/packages/abi-registry/test/AbiRegistryClient.test.ts
+++ b/packages/abi-registry/test/AbiRegistryClient.test.ts
@@ -133,22 +133,73 @@ describe("AbiRegistryClient", () => {
   });
 
   describe("getSpec", () => {
-    it("delegates to getSpecs and returns the single result", async () => {
+    it("fetches a single spec from GET /specs/:id and returns the typed result", async () => {
       const spec = makeSpec("CONTRACT_Z");
-      mockFetch(() => new Response(JSON.stringify({ CONTRACT_Z: spec }), { status: 200 }));
+      mockFetch(() => new Response(JSON.stringify(spec), { status: 200 }));
 
       const client = new AbiRegistryClient({ baseUrl: "https://abi.example.com" });
       const result = await client.getSpec("CONTRACT_Z");
 
       expect(result).toEqual(spec);
-      expect(fetch).toHaveBeenCalledTimes(1);
+      expect(fetch).toHaveBeenCalledWith(
+        "https://abi.example.com/specs/CONTRACT_Z",
+        expect.objectContaining({ method: "GET" }),
+      );
     });
 
-    it("returns null when the contract is not found", async () => {
-      mockFetch(() => new Response(JSON.stringify({ CONTRACT_Z: null }), { status: 200 }));
+    it("returns null when the contract is not found with 404", async () => {
+      mockFetch(() => new Response(null, { status: 404 }));
 
       const client = new AbiRegistryClient({ baseUrl: "https://abi.example.com" });
       expect(await client.getSpec("CONTRACT_Z")).toBeNull();
+    });
+
+    it("uses an injected transport when provided", async () => {
+      const spec = makeSpec("CONTRACT_TRANSPORT");
+      const transport = vi
+        .fn()
+        .mockResolvedValue(new Response(JSON.stringify(spec), { status: 200 }));
+
+      const client = new AbiRegistryClient({
+        baseUrl: "https://abi.example.com",
+        transport,
+      });
+
+      const result = await client.getSpec("CONTRACT_TRANSPORT");
+
+      expect(result).toEqual(spec);
+      expect(transport).toHaveBeenCalledTimes(1);
+      expect(transport).toHaveBeenCalledWith(
+        "https://abi.example.com/specs/CONTRACT_TRANSPORT",
+        expect.anything(),
+      );
+    });
+
+    it("expires cached specs after the configured TTL", async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(0);
+
+      const spec = makeSpec("CONTRACT_TTL");
+      const transport = vi
+        .fn()
+        .mockResolvedValueOnce(new Response(JSON.stringify(spec), { status: 200 }))
+        .mockResolvedValueOnce(new Response(JSON.stringify(spec), { status: 200 }));
+
+      const client = new AbiRegistryClient({
+        baseUrl: "https://abi.example.com",
+        cacheTtlMs: 1_000,
+        transport,
+      });
+
+      expect(await client.getSpec("CONTRACT_TTL")).toEqual(spec);
+      expect(await client.getSpec("CONTRACT_TTL")).toEqual(spec);
+      expect(transport).toHaveBeenCalledTimes(1);
+
+      vi.advanceTimersByTime(1_001);
+      expect(await client.getSpec("CONTRACT_TTL")).toEqual(spec);
+      expect(transport).toHaveBeenCalledTimes(2);
+
+      vi.useRealTimers();
     });
   });
 


### PR DESCRIPTION
## Summary

Adds `AbiRegistryClient` — an HTTP client for the Orbital ABI Registry API with local caching.

## Details

- **`getSpec(contractId)`** — fetches a single spec via `GET /specs/:id`, returns typed `ContractSpec` or `null` on 404
- **`getSpecs(ids)`** — batch fetch via `POST /specs` in a single round-trip; only uncached IDs are fetched
- **Pluggable transport** — defaults to global `fetch`, injectable via config
- **LRU cache** — configurable `maxCacheSize` (default 512) and `cacheTtlMs` (default 5 min)
- **Spec version negotiation** — all requests include `Accept: application/vnd.orbital.abi-registry+json; version=1`

## Testing

12 tests covering: single fetch, 404 handling, injected transport, TTL expiry, batch fetch (100 IDs), cache hits, partial cache misses, null caching, error handling, trailing slash normalization, and LRU eviction.

Closes #648

Closes #648