### PR TITLE
feat(pulse-notify): add useContractState hook for Soroban contract reads

### DIFF
--- a/packages/pulse-notify/src/index.ts
+++ b/packages/pulse-notify/src/index.ts
@@ -206,6 +206,12 @@ export {
 export { pulseNotifyVitePlugin } from "./vitePlugin.js";
 export type { PulseNotifyVitePlugin } from "./vitePlugin.js";
 
+export {
+  useContractState,
+  type ContractStateOptions,
+  type ContractStateResult,
+} from "./useContractState.js";
+
 export type UseHistoryOptions = {
   token?: string;
   /** Maximum number of events to retain in FIFO order. Defaults to 100. */

--- a/packages/pulse-notify/src/useContractState.ts
+++ b/packages/pulse-notify/src/useContractState.ts
@@ -1,0 +1,147 @@
+import { useState, useEffect, useRef, useCallback } from "react";
+import type { ContractEmittedEvent } from "@orbital-stellar/pulse-core";
+import { acquireEventConnection } from "./connectionPool.js";
+
+export type ContractStateOptions<T = unknown> = {
+  pollIntervalMs?: number;
+  autoRefreshOn?: {
+    serverUrl: string;
+    contractId: string;
+    filter?: (event: ContractEmittedEvent) => boolean;
+    token?: string;
+  };
+  headers?: Record<string, string>;
+};
+
+export type ContractStateResult<T = unknown> = {
+  data: T | null;
+  loading: boolean;
+  error: string | null;
+  refetch: () => void;
+};
+
+async function getLedgerEntry(
+  rpcUrl: string,
+  key: string,
+  headers: Record<string, string> | undefined,
+  signal: AbortSignal,
+): Promise<unknown> {
+  const response = await fetch(rpcUrl, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      ...headers,
+    },
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "getLedgerEntry",
+      params: { key },
+    }),
+    signal,
+  });
+
+  if (!response.ok) {
+    throw new Error(`Soroban RPC request failed: ${response.status} ${response.statusText}`);
+  }
+
+  const json: { result?: unknown; error?: { message?: string } } = await response.json();
+  if (json.error) {
+    throw new Error(json.error.message ?? "Soroban RPC returned an error");
+  }
+  return json.result;
+}
+
+export function useContractState<T = unknown>(
+  rpcUrl: string,
+  contractId: string,
+  key: string,
+  options?: ContractStateOptions<T>,
+): ContractStateResult<T> {
+  const pollIntervalMs = options?.pollIntervalMs ?? 10_000;
+  const autoRefreshOn = options?.autoRefreshOn;
+  const headers = options?.headers;
+
+  const [data, setData] = useState<T | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const abortRef = useRef<AbortController | null>(null);
+
+  const headersRef = useRef(headers);
+  useEffect(() => {
+    headersRef.current = headers;
+  });
+
+  const autoRefreshFilterRef = useRef(autoRefreshOn?.filter);
+  useEffect(() => {
+    autoRefreshFilterRef.current = autoRefreshOn?.filter;
+  });
+
+  const fetchState = useCallback(async () => {
+    abortRef.current?.abort();
+    const controller = new AbortController();
+    abortRef.current = controller;
+
+    setLoading(true);
+    setError(null);
+
+    try {
+      const result = await getLedgerEntry(rpcUrl, key, headersRef.current, controller.signal);
+      if (!controller.signal.aborted) {
+        setData(result as T);
+        setLoading(false);
+      }
+    } catch (err) {
+      if (controller.signal.aborted) return;
+      setError(err instanceof Error ? err.message : String(err));
+      setLoading(false);
+    }
+  }, [rpcUrl, key]);
+
+  useEffect(() => {
+    fetchState();
+    const interval = setInterval(fetchState, pollIntervalMs);
+    return () => {
+      clearInterval(interval);
+      abortRef.current?.abort();
+    };
+  }, [fetchState, pollIntervalMs]);
+
+  const autoRefreshServerUrl = autoRefreshOn?.serverUrl;
+  const autoRefreshContractId = autoRefreshOn?.contractId;
+  const autoRefreshToken = autoRefreshOn?.token;
+
+  useEffect(() => {
+    if (!autoRefreshServerUrl || !autoRefreshContractId) return;
+
+    const connection = acquireEventConnection(
+      {
+        serverUrl: autoRefreshServerUrl,
+        address: autoRefreshContractId,
+        token: autoRefreshToken,
+      },
+      {
+        onOpen: () => {},
+        onEvent: (event) => {
+          if (event.type !== "contract.emitted") return;
+          if (
+            autoRefreshFilterRef.current &&
+            !autoRefreshFilterRef.current(event as ContractEmittedEvent)
+          ) {
+            return;
+          }
+          fetchState();
+        },
+        onParseError: () => {},
+        onError: () => {},
+      },
+    );
+
+    return () => {
+      connection.unsubscribe();
+    };
+  }, [autoRefreshServerUrl, autoRefreshContractId, autoRefreshToken, fetchState]);
+
+  return { data, loading, error, refetch: fetchState };
+}

--- a/packages/pulse-notify/test/useContractState.test.tsx
+++ b/packages/pulse-notify/test/useContractState.test.tsx
@@ -1,0 +1,406 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { useContractState } from "../src/index.ts";
+import {
+  __resetConnectionPoolForTests,
+  __getConnectionPoolSizeForTests,
+} from "../src/connectionPool.ts";
+
+class MockEventSource {
+  static instances: MockEventSource[] = [];
+  onopen: (() => void) | null = null;
+  onmessage: ((e: { data: string }) => void) | null = null;
+  onerror: (() => void) | null = null;
+  closeCount = 0;
+  constructor(readonly url: string) {
+    MockEventSource.instances.push(this);
+  }
+  close() {
+    this.closeCount += 1;
+  }
+}
+
+const RPC_URL = "https://soroban-rpc.example.com";
+const CONTRACT_ID = "CA3D5R2WQ2VKJ3X5QYG4Z6J7K8L9M0N1P2Q3R4S5";
+const KEY = "AAAAAQAAAAU=";
+
+function mockFetchOnce(data: unknown) {
+  return vi.fn().mockResolvedValueOnce({
+    ok: true,
+    json: () => Promise.resolve({ result: data }),
+  });
+}
+
+function mockFetchErrorOnce(status: number, statusText: string) {
+  return vi.fn().mockResolvedValueOnce({
+    ok: false,
+    status,
+    statusText,
+    json: () => Promise.resolve({}),
+  });
+}
+
+let originalEventSource: typeof globalThis.EventSource;
+let originalFetch: typeof globalThis.fetch;
+
+beforeEach(() => {
+  originalEventSource = globalThis.EventSource;
+  originalFetch = globalThis.fetch;
+  globalThis.EventSource = MockEventSource as unknown as typeof EventSource;
+  MockEventSource.instances = [];
+});
+
+afterEach(() => {
+  globalThis.EventSource = originalEventSource;
+  globalThis.fetch = originalFetch;
+  __resetConnectionPoolForTests();
+  vi.restoreAllMocks();
+});
+
+describe("useContractState", () => {
+  it("fetches ledger entry on mount and returns data", async () => {
+    const ledgerData = { xdr: "AAAAAA==", lastModifiedLedgerSeq: 123 };
+    globalThis.fetch = mockFetchOnce(ledgerData);
+
+    const { result } = renderHook(() => useContractState(RPC_URL, CONTRACT_ID, KEY));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.data).toEqual(ledgerData);
+    expect(result.current.error).toBeNull();
+    expect(typeof result.current.refetch).toBe("function");
+  });
+
+  it("sets loading to true on mount and switches to false after fetch", async () => {
+    const ledgerData = { xdr: "AAAAAA==", lastModifiedLedgerSeq: 123 };
+
+    let resolvePromise: (value: unknown) => void;
+    const fetchPromise = new Promise((resolve) => {
+      resolvePromise = resolve;
+    });
+
+    globalThis.fetch = vi.fn().mockReturnValueOnce({
+      ok: true,
+      json: () => fetchPromise.then(() => ({ result: ledgerData })),
+    });
+
+    const { result } = renderHook(() => useContractState(RPC_URL, CONTRACT_ID, KEY));
+
+    expect(result.current.loading).toBe(true);
+
+    await act(async () => {
+      resolvePromise!(undefined);
+    });
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.data).toEqual(ledgerData);
+  });
+
+  it("sets error when fetch fails with HTTP error", async () => {
+    globalThis.fetch = mockFetchErrorOnce(400, "Bad Request");
+
+    const { result } = renderHook(() => useContractState(RPC_URL, CONTRACT_ID, KEY));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.error).toContain("400");
+    expect(result.current.error).toContain("Bad Request");
+    expect(result.current.data).toBeNull();
+  });
+
+  it("sets error when RPC returns an error", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ error: { message: "Invalid key" } }),
+    });
+
+    const { result } = renderHook(() => useContractState(RPC_URL, CONTRACT_ID, KEY));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.error).toBe("Invalid key");
+  });
+
+  it("returns data null and loading true initially", () => {
+    globalThis.fetch = vi.fn().mockReturnValue(new Promise(() => {}));
+
+    const { result } = renderHook(() => useContractState(RPC_URL, CONTRACT_ID, KEY));
+
+    expect(result.current.data).toBeNull();
+    expect(result.current.loading).toBe(true);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("refetch re-fetches data and updates state", async () => {
+    globalThis.fetch = mockFetchOnce({ xdr: "AAAAAA==", seq: 1 });
+
+    const { result } = renderHook(() => useContractState(RPC_URL, CONTRACT_ID, KEY));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect((result.current.data as any)?.seq).toBe(1);
+
+    globalThis.fetch = mockFetchOnce({ xdr: "BBBBBB==", seq: 2 });
+
+    await act(async () => {
+      result.current.refetch();
+    });
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect((result.current.data as any)?.seq).toBe(2);
+  });
+
+  it("polls at configured interval", async () => {
+    vi.useFakeTimers();
+
+    const fetchFn = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ result: { xdr: "AAAAAA==", seq: 1 } }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ result: { xdr: "BBBBBB==", seq: 2 } }),
+      });
+
+    globalThis.fetch = fetchFn;
+
+    renderHook(() => useContractState(RPC_URL, CONTRACT_ID, KEY, { pollIntervalMs: 5000 }));
+
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      vi.advanceTimersByTime(5000);
+    });
+
+    expect(fetchFn).toHaveBeenCalledTimes(2);
+
+    vi.useRealTimers();
+  });
+
+  it("passes custom headers to the fetch request", async () => {
+    const ledgerData = { xdr: "AAAAAA==" };
+    globalThis.fetch = mockFetchOnce(ledgerData);
+
+    const headers = { Authorization: "Bearer test-token" };
+
+    renderHook(() => useContractState(RPC_URL, CONTRACT_ID, KEY, { headers }));
+
+    await waitFor(() => {
+      const call = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(call[1].headers["Authorization"]).toBe("Bearer test-token");
+    });
+  });
+
+  it("sends correct JSON-RPC body", async () => {
+    const ledgerData = { xdr: "AAAAAA==" };
+    globalThis.fetch = mockFetchOnce(ledgerData);
+
+    renderHook(() => useContractState(RPC_URL, CONTRACT_ID, KEY));
+
+    await waitFor(() => {
+      const call = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(call[0]).toBe(RPC_URL);
+      const body = JSON.parse(call[1].body);
+      expect(body.jsonrpc).toBe("2.0");
+      expect(body.method).toBe("getLedgerEntry");
+      expect(body.params.key).toBe(KEY);
+    });
+  });
+
+  describe("autoRefreshOn", () => {
+    const EVENT_SERVER = "https://events.example.com";
+
+    it("connects to event stream when autoRefreshOn is configured", async () => {
+      globalThis.fetch = mockFetchOnce({ xdr: "AAAAAA==" });
+
+      renderHook(() =>
+        useContractState(RPC_URL, CONTRACT_ID, KEY, {
+          autoRefreshOn: {
+            serverUrl: EVENT_SERVER,
+            contractId: CONTRACT_ID,
+          },
+        }),
+      );
+
+      await waitFor(() => {
+        expect(MockEventSource.instances.length).toBe(1);
+        expect(MockEventSource.instances[0]!.url).toContain(CONTRACT_ID);
+      });
+    });
+
+    it("does not connect to event stream when autoRefreshOn is not set", async () => {
+      globalThis.fetch = mockFetchOnce({ xdr: "AAAAAA==" });
+
+      renderHook(() => useContractState(RPC_URL, CONTRACT_ID, KEY));
+
+      await waitFor(() => expect(fetch).toHaveBeenCalled());
+
+      expect(MockEventSource.instances.length).toBe(0);
+    });
+
+    it("refetches on matching contract.emitted event", async () => {
+      const fetchFn = vi
+        .fn()
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve({ result: { xdr: "AAAAAA==", seq: 1 } }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve({ result: { xdr: "BBBBBB==", seq: 2 } }),
+        });
+
+      globalThis.fetch = fetchFn;
+
+      const { result } = renderHook(() =>
+        useContractState(RPC_URL, CONTRACT_ID, KEY, {
+          autoRefreshOn: {
+            serverUrl: EVENT_SERVER,
+            contractId: CONTRACT_ID,
+          },
+        }),
+      );
+
+      await waitFor(() => {
+        expect(fetchFn).toHaveBeenCalledTimes(1);
+        expect((result.current.data as any)?.seq).toBe(1);
+      });
+
+      const source = MockEventSource.instances[0]!;
+      source.onopen?.();
+
+      act(() => {
+        source.onmessage?.({
+          data: JSON.stringify({
+            type: "contract.emitted",
+            contractId: CONTRACT_ID,
+            topics: [],
+            data: "hello",
+            timestamp: "2026-01-01T00:00:00Z",
+          }),
+        });
+      });
+
+      await waitFor(() => {
+        expect(fetchFn).toHaveBeenCalledTimes(2);
+        expect((result.current.data as any)?.seq).toBe(2);
+      });
+    });
+
+    it("does not refetch on non-contract.emitted events", async () => {
+      const fetchFn = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ result: { xdr: "AAAAAA==" } }),
+      });
+
+      globalThis.fetch = fetchFn;
+
+      renderHook(() =>
+        useContractState(RPC_URL, CONTRACT_ID, KEY, {
+          autoRefreshOn: {
+            serverUrl: EVENT_SERVER,
+            contractId: CONTRACT_ID,
+          },
+        }),
+      );
+
+      await waitFor(() => {
+        expect(fetchFn).toHaveBeenCalledTimes(1);
+      });
+
+      const source = MockEventSource.instances[0]!;
+      source.onopen?.();
+
+      act(() => {
+        source.onmessage?.({
+          data: JSON.stringify({
+            type: "payment.received",
+            timestamp: "2026-01-01T00:00:00Z",
+          }),
+        });
+      });
+
+      expect(fetchFn).toHaveBeenCalledTimes(1);
+
+      act(() => {
+        source.onmessage?.({
+          data: JSON.stringify({
+            type: "contract.invoked",
+            contractId: CONTRACT_ID,
+            timestamp: "2026-01-01T00:00:00Z",
+          }),
+        });
+      });
+
+      expect(fetchFn).toHaveBeenCalledTimes(1);
+    });
+
+    it("uses filter to determine which events trigger refetch", async () => {
+      const fetchFn = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ result: { xdr: "AAAAAA==" } }),
+      });
+
+      globalThis.fetch = fetchFn;
+
+      const filter = vi.fn().mockReturnValue(false);
+
+      renderHook(() =>
+        useContractState(RPC_URL, CONTRACT_ID, KEY, {
+          autoRefreshOn: {
+            serverUrl: EVENT_SERVER,
+            contractId: CONTRACT_ID,
+            filter,
+          },
+        }),
+      );
+
+      await waitFor(() => {
+        expect(fetchFn).toHaveBeenCalledTimes(1);
+      });
+
+      const source = MockEventSource.instances[0]!;
+      source.onopen?.();
+
+      act(() => {
+        source.onmessage?.({
+          data: JSON.stringify({
+            type: "contract.emitted",
+            contractId: CONTRACT_ID,
+            topics: ["balance"],
+            timestamp: "2026-01-01T00:00:00Z",
+          }),
+        });
+      });
+
+      expect(fetchFn).toHaveBeenCalledTimes(1);
+      expect(filter).toHaveBeenCalledTimes(1);
+    });
+
+    it("unsubscribes from event stream on unmount", async () => {
+      globalThis.fetch = mockFetchOnce({ xdr: "AAAAAA==" });
+
+      const { unmount } = renderHook(() =>
+        useContractState(RPC_URL, CONTRACT_ID, KEY, {
+          autoRefreshOn: {
+            serverUrl: EVENT_SERVER,
+            contractId: CONTRACT_ID,
+          },
+        }),
+      );
+
+      await waitFor(() => {
+        expect(MockEventSource.instances.length).toBe(1);
+      });
+
+      unmount();
+
+      await waitFor(() => {
+        expect(MockEventSource.instances[0]?.closeCount).toBe(1);
+      });
+
+      expect(__getConnectionPoolSizeForTests()).toBe(0);
+    });
+  });
+});


### PR DESCRIPTION
Closes #702

## Summary

Adds `useContractState(rpcUrl, contractId, key, options)` — a React hook that polls Soroban RPC `getLedgerEntry` at a configurable interval and returns current on-chain contract state.

## Key changes

- **New** `packages/pulse-notify/src/useContractState.ts`: The hook implementation with full TypeScript types
- **Modified** `packages/pulse-notify/src/index.ts`: Exports `useContractState`, `ContractStateOptions`, and `ContractStateResult`
- **New** `packages/pulse-notify/test/useContractState.test.tsx`: 15 tests covering all states

## API

```ts
const { data, loading, error, refetch } = useContractState(
  rpcUrl,      // Soroban RPC endpoint URL
  contractId,  // Contract ID (C... address)  
  key,         // Base64-encoded LedgerKey XDR
  {
    pollIntervalMs: 10_000,          // Optional polling interval (default 10s)
    headers: { Authorization },      // Optional HTTP headers for the RPC call
    autoRefreshOn: {                 // Optional auto-refresh on matching events
      serverUrl,                     //   Event stream server URL
      contractId,                    //   Contract to listen for events on
      filter,                        //   Optional event filter function
      token,                         //   Optional event stream auth token
    },
  },
);
```

## Features

- **Polling**: Fetches `getLedgerEntry` via JSON-RPC on mount and at the configured interval (default 10s)
- **Auto-refresh**: When `autoRefreshOn` is configured, subscribes to the SSE event stream and refetches on each matching `contract.emitted` event
- **Cancellation**: In-flight requests are aborted via `AbortController` on unmount, refetch, or dependency change
- **Error handling**: HTTP errors and JSON-RPC error envelopes are surfaced via the `error` field
- **Test coverage**: 15 tests covering mount fetch, loading/error states, polling interval, custom headers, JSON-RPC body shape, autoRefreshOn connection, event-triggered refetch, event type filtering, custom filter, and unsubscribe cleanup

## Verification

- `pnpm run build` — compiles cleanly
- `pnpm test` — 27 tests pass (15 new + 12 existing)