### PR TITLE
Add Soroban RPC client methods

### DIFF
--- a/packages/pulse-core/src/SorobanRpcClient.ts
+++ b/packages/pulse-core/src/SorobanRpcClient.ts
@@ -1,6 +1,8 @@
 import type { ContractSubscriptionFilter, Logger } from "./index.js";
 import { SorobanRpcError, type SorobanRpcErrorCode } from "./errors.js";
 
+const DEFAULT_TIMEOUT_MS = 10_000;
+
 export type SorobanNetworkInfo = {
   friendbotUrl?: string;
   passphrase: string;
@@ -28,18 +30,82 @@ export interface SorobanRpcClientOptions {
    */
   headers?: Record<string, string>;
   /** Injectable `fetch` implementation (for testing). Defaults to `globalThis.fetch`. */
+  fetch?: typeof fetch;
+  /** Injectable `fetch` implementation (for testing). Defaults to `globalThis.fetch`. */
   fetchImpl?: typeof fetch;
+  /** Per-call timeout in milliseconds. Defaults to 10 seconds. */
+  timeoutMs?: number;
   /** Optional logger. Per-request diagnostics go to `logger.debug` (header values redacted). */
   logger?: Logger;
 }
 
-/** Result of a `getEvents` call: the JSON-RPC `result` payload with `events` guaranteed. */
+export type SorobanEventXdrFormat = "base64" | "json";
+
+export type SorobanEventFilter = {
+  type?: "contract" | "system" | "diagnostic" | "contract.invoked" | "contract.emitted";
+  contractIds?: string[];
+  topics?: Array<Array<string | null>>;
+  topicFilters?: Array<string | null>;
+};
+
+export type SorobanGetEventsParams = {
+  startLedger?: number;
+  cursor?: string;
+  startCursor?: string;
+  filters?: SorobanEventFilter[] | ContractSubscriptionFilter[];
+  limit?: number;
+  xdrFormat?: SorobanEventXdrFormat;
+};
+
+export type SorobanRpcCallOptions = {
+  signal?: AbortSignal;
+};
+
+export type SorobanRpcEvent = {
+  type: string;
+  ledger: number;
+  ledgerClosedAt?: string;
+  contractId?: string;
+  id: string;
+  pagingToken?: string;
+  topic?: unknown[];
+  topics?: unknown[];
+  value?: unknown;
+  txHash?: string;
+  inSuccessfulContractCall?: boolean;
+  [key: string]: unknown;
+};
+
 export type SorobanGetEventsResult = {
-  events: unknown[];
+  events: SorobanRpcEvent[];
   latestLedger?: number;
   cursor?: string;
   [key: string]: unknown;
 };
+
+export type SorobanLatestLedgerResult = {
+  id?: string;
+  protocolVersion?: number;
+  sequence: number;
+};
+
+export type JsonRpcSuccess<T> = {
+  jsonrpc: "2.0";
+  id: string | number | null;
+  result: T;
+};
+
+export type JsonRpcFailure = {
+  jsonrpc: "2.0";
+  id: string | number | null;
+  error: {
+    code: number;
+    message: string;
+    data?: unknown;
+  };
+};
+
+export type JsonRpcResponse<T> = JsonRpcSuccess<T> | JsonRpcFailure;
 
 /** Maps an HTTP status code to a {@link SorobanRpcError} classification. */
 function classifyHttpStatus(status: number): {
@@ -71,9 +137,25 @@ function classifyJsonRpcCode(code: number): {
 function isAbortError(err: unknown): boolean {
   if (err instanceof Error) {
     if ((err as { name?: string }).name === "AbortError") return true;
+    if ((err as { name?: string }).name === "TimeoutError") return true;
     if ((err as NodeJS.ErrnoException).code === "ABORT_ERR") return true;
   }
   return false;
+}
+
+function createAbortError(message: string): Error {
+  if (typeof DOMException !== "undefined") {
+    return new DOMException(message, "AbortError");
+  }
+  const error = new Error(message);
+  error.name = "AbortError";
+  return error;
+}
+
+function isAbortSignal(value: unknown): value is AbortSignal {
+  return (
+    typeof value === "object" && value !== null && "aborted" in value && "addEventListener" in value
+  );
 }
 
 /**
@@ -119,16 +201,25 @@ export class SorobanRpcClient {
 
   private readonly url: string;
   private readonly headers: Record<string, string>;
-  private readonly fetchImpl?: typeof fetch;
+  private readonly fetchImpl: typeof fetch;
+  private readonly timeoutMs: number;
   private readonly logger?: Logger;
 
   /**
    * @param options - Configuration for the RPC client.
    */
   constructor(options: SorobanRpcClientOptions) {
-    this.url = (options.rpcUrl ?? options.url) as string;
+    const url = options.rpcUrl ?? options.url;
+    if (!url) {
+      throw new TypeError("SorobanRpcClient requires a url.");
+    }
+    this.url = url;
     this.headers = { ...(options.headers ?? {}) };
-    this.fetchImpl = options.fetchImpl;
+    this.fetchImpl = options.fetch ?? options.fetchImpl ?? globalThis.fetch;
+    if (typeof this.fetchImpl !== "function") {
+      throw new TypeError("SorobanRpcClient requires a fetch implementation.");
+    }
+    this.timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
     this.logger = options.logger;
   }
 
@@ -168,18 +259,30 @@ export class SorobanRpcClient {
       headers: this.getRedactedHeaders(),
     });
 
-    const fetchImpl = this.fetchImpl ?? globalThis.fetch;
+    const controller = new AbortController();
+    const timeout = setTimeout(() => {
+      controller.abort(createAbortError(`Soroban RPC request timed out after ${this.timeoutMs}ms`));
+    }, this.timeoutMs);
+    const abortFromCaller = () => {
+      controller.abort(signal?.reason ?? createAbortError("Soroban RPC request aborted"));
+    };
+
+    if (signal?.aborted) {
+      clearTimeout(timeout);
+      throw signal.reason ?? createAbortError("Soroban RPC request aborted");
+    }
+    signal?.addEventListener("abort", abortFromCaller, { once: true });
 
     let response: Response;
     try {
-      response = await fetchImpl(this.url, {
+      response = await this.fetchImpl(this.url, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
           ...this.headers,
         },
         body,
-        signal,
+        signal: controller.signal,
       });
     } catch (err) {
       if (err instanceof SorobanRpcError) throw err;
@@ -189,6 +292,9 @@ export class SorobanRpcClient {
         `Soroban RPC network error: ${err instanceof Error ? err.message : String(err)}`,
         { code: "network", retryable: true, cause: err },
       );
+    } finally {
+      clearTimeout(timeout);
+      signal?.removeEventListener("abort", abortFromCaller);
     }
 
     if (!response.ok) {
@@ -225,6 +331,21 @@ export class SorobanRpcClient {
     return parsed;
   }
 
+  private async requestResult<T>(
+    method: string,
+    params?: unknown,
+    options?: SorobanRpcCallOptions,
+  ): Promise<T> {
+    const body = (await this.request(method, params, options?.signal)) as JsonRpcResponse<T>;
+    if (!body || typeof body !== "object" || !("result" in body)) {
+      throw new SorobanRpcError("Soroban RPC response did not include a result", {
+        code: "invalid_request",
+        retryable: false,
+      });
+    }
+    return body.result;
+  }
+
   /**
    * Fetches Soroban events with optional cursor-based pagination and filters.
    *
@@ -236,28 +357,45 @@ export class SorobanRpcClient {
    * @returns The JSON-RPC `result` payload, with `events` defaulting to `[]`.
    */
   async getEvents(
+    params?: SorobanGetEventsParams,
+    options?: SorobanRpcCallOptions,
+  ): Promise<SorobanGetEventsResult>;
+  async getEvents(
     startCursor?: string,
     limit?: number,
     signalOrOptions?: AbortSignal | { xdrFormat?: "base64" | "json"; signal?: AbortSignal },
     filters?: ContractSubscriptionFilter[],
     options?: { xdrFormat?: "base64" | "json"; signal?: AbortSignal } | AbortSignal,
+  ): Promise<SorobanGetEventsResult>;
+  async getEvents(
+    first?: string | SorobanGetEventsParams,
+    limit?: number | SorobanRpcCallOptions,
+    signalOrOptions?: AbortSignal | { xdrFormat?: "base64" | "json"; signal?: AbortSignal },
+    filters?: ContractSubscriptionFilter[],
+    options?: { xdrFormat?: "base64" | "json"; signal?: AbortSignal } | AbortSignal,
   ): Promise<SorobanGetEventsResult> {
-    const params: Record<string, unknown> = {};
-    if (startCursor !== undefined) params.startCursor = startCursor;
-    if (limit !== undefined) params.limit = limit;
-    if (filters !== undefined && filters.length > 0) params.filters = filters;
+    let params: Record<string, unknown> = {};
+    let signal: AbortSignal | undefined = undefined;
+
+    if (typeof first === "object" && first !== null && !isAbortSignal(first)) {
+      params = { ...first };
+      if (typeof limit === "object" && limit !== null && "signal" in limit) {
+        signal = limit.signal;
+      }
+    } else {
+      if (first !== undefined) params.startCursor = first;
+      if (typeof limit === "number") params.limit = limit;
+      if (filters !== undefined && filters.length > 0) params.filters = filters;
+    }
 
     let xdrFormat: "base64" | "json" = "json";
-    let signal: AbortSignal | undefined = undefined;
+    if (typeof params.xdrFormat === "string") {
+      xdrFormat = params.xdrFormat as "base64" | "json";
+    }
 
     // Resolve signal or options from the third parameter
     if (signalOrOptions !== undefined) {
-      if (
-        signalOrOptions instanceof AbortSignal ||
-        (typeof signalOrOptions === "object" &&
-          signalOrOptions !== null &&
-          "addEventListener" in signalOrOptions)
-      ) {
+      if (isAbortSignal(signalOrOptions)) {
         signal = signalOrOptions as AbortSignal;
       } else if (typeof signalOrOptions === "object" && signalOrOptions !== null) {
         if ("xdrFormat" in signalOrOptions) {
@@ -271,10 +409,7 @@ export class SorobanRpcClient {
 
     // Resolve signal or options from the fifth parameter (options)
     if (options !== undefined) {
-      if (
-        options instanceof AbortSignal ||
-        (typeof options === "object" && options !== null && "addEventListener" in options)
-      ) {
+      if (isAbortSignal(options)) {
         signal = options as AbortSignal;
       } else if (typeof options === "object" && options !== null) {
         if ("xdrFormat" in options) {
@@ -288,10 +423,25 @@ export class SorobanRpcClient {
 
     params.xdrFormat = xdrFormat;
 
-    const body = (await this.request("getEvents", params, signal)) as {
-      result?: Partial<SorobanGetEventsResult>;
-    };
+    const result = await this.requestResult<Partial<SorobanGetEventsResult>>("getEvents", params, {
+      signal,
+    });
 
-    return { events: [], ...(body?.result ?? {}) };
+    return { events: [], ...result };
+  }
+
+  async getLatestLedger(options?: SorobanRpcCallOptions): Promise<number> {
+    const result = await this.requestResult<SorobanLatestLedgerResult>(
+      "getLatestLedger",
+      undefined,
+      options,
+    );
+    return result.sequence;
+  }
+
+  async getNetwork(options?: SorobanRpcCallOptions): Promise<SorobanNetworkInfo> {
+    const result = await this.requestResult<SorobanNetworkInfo>("getNetwork", undefined, options);
+    SorobanRpcClient.setCachedNetwork(result);
+    return result;
   }
 }

--- a/packages/pulse-core/src/index.ts
+++ b/packages/pulse-core/src/index.ts
@@ -3,7 +3,20 @@ import type { StellarAmount } from "./amount.js";
 import type { AccountAddress, MuxedAddress, ContractAddress } from "./address.js";
 
 export { SorobanRpcClient } from "./SorobanRpcClient.js";
-export type { SorobanRpcClientOptions } from "./SorobanRpcClient.js";
+export type {
+  JsonRpcFailure,
+  JsonRpcResponse,
+  JsonRpcSuccess,
+  SorobanEventFilter,
+  SorobanEventXdrFormat,
+  SorobanGetEventsParams,
+  SorobanGetEventsResult,
+  SorobanLatestLedgerResult,
+  SorobanNetworkInfo,
+  SorobanRpcCallOptions,
+  SorobanRpcClientOptions,
+  SorobanRpcEvent,
+} from "./SorobanRpcClient.js";
 export { EventEngine } from "./EventEngine.js";
 export { SorobanSubscriber } from "./SorobanSubscriber.js";
 export type {

--- a/packages/pulse-core/test/SorobanRpcClient.test.ts
+++ b/packages/pulse-core/test/SorobanRpcClient.test.ts
@@ -26,8 +26,59 @@ async function expectSorobanRpcError(
 }
 
 describe("SorobanRpcClient", () => {
+  it("returns the latest ledger sequence", async () => {
+    const fetch = vi.fn(async () =>
+      jsonResponse({
+        jsonrpc: "2.0",
+        id: 1,
+        result: {
+          id: "000001",
+          protocolVersion: 22,
+          sequence: 12345,
+        },
+      }),
+    ) as unknown as typeof globalThis.fetch;
+
+    const client = new SorobanRpcClient({ url: "https://rpc.example", fetch });
+    const sequence = await client.getLatestLedger();
+
+    expect(sequence).toBe(12345);
+    expect(fetch).toHaveBeenCalledWith(
+      "https://rpc.example",
+      expect.objectContaining({
+        method: "POST",
+        body: expect.stringContaining('"method":"getLatestLedger"'),
+        signal: expect.any(AbortSignal),
+      }),
+    );
+  });
+
+  it("returns network info and caches it", async () => {
+    const fetch = vi.fn(async () =>
+      jsonResponse({
+        jsonrpc: "2.0",
+        id: 1,
+        result: {
+          friendbotUrl: "https://friendbot.stellar.org",
+          passphrase: "Test SDF Network ; September 2015",
+          protocolVersion: 22,
+        },
+      }),
+    ) as unknown as typeof globalThis.fetch;
+
+    const client = new SorobanRpcClient({ url: "https://rpc.example", fetch });
+    const network = await client.getNetwork();
+
+    expect(network).toEqual({
+      friendbotUrl: "https://friendbot.stellar.org",
+      passphrase: "Test SDF Network ; September 2015",
+      protocolVersion: 22,
+    });
+    expect(SorobanRpcClient.getNetwork()).toEqual(network);
+  });
+
   it("returns typed getEvents responses", async () => {
-    const fetchImpl = vi.fn(async () =>
+    const fetch = vi.fn(async () =>
       jsonResponse({
         jsonrpc: "2.0",
         id: "pulse-core-getEvents",
@@ -37,9 +88,9 @@ describe("SorobanRpcClient", () => {
           cursor: "000001",
         },
       }),
-    ) as unknown as typeof fetch;
+    ) as unknown as typeof globalThis.fetch;
 
-    const client = new SorobanRpcClient({ rpcUrl: "https://rpc.example", fetchImpl });
+    const client = new SorobanRpcClient({ url: "https://rpc.example", fetch });
     const result = await client.getEvents("000000", 10);
 
     expect(result).toEqual({
@@ -47,7 +98,7 @@ describe("SorobanRpcClient", () => {
       latestLedger: 123,
       cursor: "000001",
     });
-    expect(fetchImpl).toHaveBeenCalledWith(
+    expect(fetch).toHaveBeenCalledWith(
       "https://rpc.example",
       expect.objectContaining({
         method: "POST",
@@ -65,12 +116,12 @@ describe("SorobanRpcClient", () => {
     [500, "server", true],
     [503, "server", true],
   ] as const)("maps HTTP %s to %s retryable=%s", async (status, code, retryable) => {
-    const fetchImpl = vi.fn(async () =>
+    const fetch = vi.fn(async () =>
       jsonResponse({ error: "nope" }, status),
-    ) as unknown as typeof fetch;
-    const client = new SorobanRpcClient({ rpcUrl: "https://rpc.example", fetchImpl });
+    ) as unknown as typeof globalThis.fetch;
+    const client = new SorobanRpcClient({ url: "https://rpc.example", fetch });
 
-    await expectSorobanRpcError(() => client.getEvents(), {
+    await expectSorobanRpcError(() => client.getLatestLedger(), {
       code,
       retryable,
       status,
@@ -78,22 +129,46 @@ describe("SorobanRpcClient", () => {
   });
 
   it("maps fetch failures to retryable network errors", async () => {
-    const fetchImpl = vi.fn(async () => {
+    const fetch = vi.fn(async () => {
       throw new Error("ECONNRESET");
-    }) as unknown as typeof fetch;
-    const client = new SorobanRpcClient({ rpcUrl: "https://rpc.example", fetchImpl });
+    }) as unknown as typeof globalThis.fetch;
+    const client = new SorobanRpcClient({ url: "https://rpc.example", fetch });
 
-    await expectSorobanRpcError(() => client.getEvents(), {
+    await expectSorobanRpcError(() => client.getLatestLedger(), {
       code: "network",
       retryable: true,
     });
   });
 
+  it("aborts requests on timeout", async () => {
+    vi.useFakeTimers();
+    try {
+      const fetch = vi.fn((_url, init) => {
+        return new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener("abort", () => {
+            reject(init.signal?.reason ?? new DOMException("Aborted", "AbortError"));
+          });
+        });
+      }) as unknown as typeof globalThis.fetch;
+      const client = new SorobanRpcClient({ url: "https://rpc.example", fetch, timeoutMs: 25 });
+
+      const request = expect(client.getLatestLedger()).rejects.toMatchObject({
+        name: "AbortError",
+      });
+      await vi.advanceTimersByTimeAsync(25);
+
+      await request;
+      expect(fetch).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("maps malformed JSON to terminal invalid_request", async () => {
-    const fetchImpl = vi.fn(
+    const fetch = vi.fn(
       async () => new Response("{", { status: 200 }),
-    ) as unknown as typeof fetch;
-    const client = new SorobanRpcClient({ rpcUrl: "https://rpc.example", fetchImpl });
+    ) as unknown as typeof globalThis.fetch;
+    const client = new SorobanRpcClient({ url: "https://rpc.example", fetch });
 
     await expectSorobanRpcError(() => client.getEvents(), {
       code: "invalid_request",
@@ -102,14 +177,14 @@ describe("SorobanRpcClient", () => {
   });
 
   it("maps JSON-RPC server errors to retryable server errors", async () => {
-    const fetchImpl = vi.fn(async () =>
+    const fetch = vi.fn(async () =>
       jsonResponse({
         jsonrpc: "2.0",
         id: "pulse-core-getEvents",
         error: { code: -32001, message: "temporary upstream failure" },
       }),
-    ) as unknown as typeof fetch;
-    const client = new SorobanRpcClient({ rpcUrl: "https://rpc.example", fetchImpl });
+    ) as unknown as typeof globalThis.fetch;
+    const client = new SorobanRpcClient({ url: "https://rpc.example", fetch });
 
     await expectSorobanRpcError(() => client.getEvents(), {
       code: "server",
@@ -118,14 +193,14 @@ describe("SorobanRpcClient", () => {
   });
 
   it("maps JSON-RPC request errors to terminal invalid_request errors", async () => {
-    const fetchImpl = vi.fn(async () =>
+    const fetch = vi.fn(async () =>
       jsonResponse({
         jsonrpc: "2.0",
         id: "pulse-core-getEvents",
         error: { code: -32602, message: "invalid params" },
       }),
-    ) as unknown as typeof fetch;
-    const client = new SorobanRpcClient({ rpcUrl: "https://rpc.example", fetchImpl });
+    ) as unknown as typeof globalThis.fetch;
+    const client = new SorobanRpcClient({ url: "https://rpc.example", fetch });
 
     await expectSorobanRpcError(() => client.getEvents(), {
       code: "invalid_request",

--- a/packages/pulse-core/test/SorobanRpcClient.xdrFormat.test.ts
+++ b/packages/pulse-core/test/SorobanRpcClient.xdrFormat.test.ts
@@ -86,7 +86,7 @@ describe("SorobanRpcClient xdrFormat options & Normalization", () => {
 
       expect(fetchMock).toHaveBeenCalledTimes(1);
       const [, callOptions] = fetchMock.mock.calls[0] as [string, RequestInit];
-      expect(callOptions.signal).toBe(controller.signal);
+      expect(callOptions.signal).toBeInstanceOf(AbortSignal);
       const parsedBody = JSON.parse(callOptions.body as string);
       expect(parsedBody.params.xdrFormat).toBe("json");
     });


### PR DESCRIPTION

Closes  #614 1.47 — Stellar RPC client wrapper


#614 1.47

- [ ] Existing tests pass (`pnpm test`)
- [ ] New tests added for new behaviour
- [ ] Typechecks pass (`pnpm -r typecheck`)
- [ ] Manually tested against testnet / mainnet (describe what you tested)
