### PR TITLE
Fix/#653

### DIFF
--- a/packages/pulse-core/src/EventEngine.ts
+++ b/packages/pulse-core/src/EventEngine.ts
@@ -45,6 +45,7 @@ import type {
   WatcherNotificationType,
   Logger,
   CursorStore,
+  DecodeFailedNotification,
   RawHorizonPayment,
   RawHorizonSetOptions,
   RawHorizonCreateAccount,
@@ -1501,9 +1502,19 @@ export class EventEngine {
       data: r.data ?? null,
       decodedData: r.decodedData,
       ...(typeof r.ledger === "number" ? { ledger: r.ledger } : {}),
-      ...(typeof r.eventId === "string" ? { eventId: r.eventId } : {}),
-      ...(typeof r.txHash === "string" ? { txHash: r.txHash } : {}),
-      inSuccessfulContractCall: Boolean(r.inSuccessfulContractCall),
+      ...(typeof r.eventId === "string"
+        ? { eventId: r.eventId }
+        : typeof r.event_id === "string"
+          ? { eventId: r.event_id }
+          : {}),
+      ...(typeof r.txHash === "string"
+        ? { txHash: r.txHash }
+        : typeof r.tx_hash === "string"
+          ? { txHash: r.tx_hash }
+          : {}),
+      inSuccessfulContractCall: Boolean(
+        r.inSuccessfulContractCall ?? r.in_successful_contract_call,
+      ),
       timestamp: r.created_at,
       raw: raw as RawSorobanEvent,
     };
@@ -1561,6 +1572,24 @@ export class EventEngine {
       if (this.matchesContractFilters(event, filters) && this.passesFilter(id, event)) {
         watcher.emit(event.type, event);
         watcher.emit("*", event);
+      }
+    }
+  }
+
+  private emitDecodeFailedNotification(
+    event: Timestamped<ContractEmittedEvent>,
+    error: string,
+  ): void {
+    const notification: DecodeFailedNotification = {
+      type: "event.decode_failed",
+      contractId: event.contractId,
+      eventId: event.eventId,
+      error,
+    };
+
+    for (const [id, { watcher, filters }] of this.contractRegistry.entries()) {
+      if (this.matchesContractFilters(event, filters) && this.passesFilter(id, event)) {
+        watcher.emit("event.decode_failed", notification);
       }
     }
   }
@@ -1745,13 +1774,22 @@ export class EventEngine {
             if (spec !== null && spec !== undefined) {
               (event as ContractEmittedEvent).decodedData =
                 (spec as { entries?: unknown }).entries ?? spec;
+            } else {
+              (event as ContractEmittedEvent).decodedData = undefined;
+              this.emitDecodeFailedNotification(
+                event,
+                `No ABI spec found for contract ${contractId}`,
+              );
             }
             this.dispatchContractEvent(event);
           },
           (err: unknown) => {
+            (event as ContractEmittedEvent).decodedData = undefined;
+            const errorMessage = err instanceof Error ? err.message : String(err);
+            this.emitDecodeFailedNotification(event, errorMessage);
             this.log.warn("ABI registry lookup failed for contract.emitted event", {
               contractId,
-              error: err instanceof Error ? err.message : String(err),
+              error: errorMessage,
             });
             this.dispatchContractEvent(event);
           },

--- a/packages/pulse-core/src/Watcher.ts
+++ b/packages/pulse-core/src/Watcher.ts
@@ -1,7 +1,7 @@
 import { EventEmitter } from "events";
-import type { NormalizedEvent, WatcherNotification } from "./index.js";
+import type { DecodeFailedNotification, NormalizedEvent, WatcherNotification } from "./index.js";
 
-type WatcherEvent = NormalizedEvent | WatcherNotification;
+type WatcherEvent = NormalizedEvent | WatcherNotification | DecodeFailedNotification;
 
 type WatcherLogger = Pick<Console, "warn">;
 

--- a/packages/pulse-core/src/index.ts
+++ b/packages/pulse-core/src/index.ts
@@ -16,6 +16,7 @@ export type {
 
 export { validateContractFilters } from "./contractFilters.js";
 export { Watcher } from "./Watcher.js";
+export { toStellarAmount, toBigInt } from "./amount.js";
 export type { StellarAmount } from "./amount.js";
 export type { AccountAddress, MuxedAddress, ContractAddress } from "./address.js";
 export { EngineAlreadyStartedError, HorizonStreamError } from "./errors.js";

--- a/packages/pulse-core/src/index.ts
+++ b/packages/pulse-core/src/index.ts
@@ -535,6 +535,13 @@ export type ContractEmittedEvent = {
 
 export type ContractEvent = ContractInvokedEvent | ContractEmittedEvent;
 
+export type DecodeFailedNotification = {
+  type: "event.decode_failed";
+  contractId: ContractAddress;
+  eventId?: string;
+  error: string;
+};
+
 /**
  * Filter criteria for a contract subscription.
  * All specified fields must match (AND semantics).

--- a/packages/pulse-core/test/EventEngine.abiRegistry.test.ts
+++ b/packages/pulse-core/test/EventEngine.abiRegistry.test.ts
@@ -82,25 +82,44 @@ describe("EventEngine — ABI registry integration", () => {
     expect(received[0]!.decodedData).toEqual(spec.entries);
   });
 
-  it("leaves decodedData undefined on a registry miss (null spec)", async () => {
+  it("emits event.decode_failed and leaves decodedData undefined on a registry miss", async () => {
     const abiRegistry: AbiRegistryClientLike = {
       getSpec: vi.fn().mockResolvedValue(null),
     };
 
     const { engine, simulateRecord } = buildEngine(abiRegistry);
     const received: ContractEmittedEvent[] = [];
+    const notifications: Array<{
+      type: string;
+      contractId: string;
+      eventId?: string;
+      error: string;
+    }> = [];
 
     const watcher = engine.subscribeContract("sub1");
     watcher.on("contract.emitted", (e) => received.push(e as ContractEmittedEvent));
+    watcher.on("event.decode_failed", (e) => {
+      notifications.push(
+        e as { type: string; contractId: string; eventId?: string; error: string },
+      );
+    });
 
-    simulateRecord(makeEmittedRecord());
+    simulateRecord(makeEmittedRecord({ event_id: "evt-miss" }));
 
     await vi.waitFor(() => expect(received).toHaveLength(1));
 
     expect(received[0]!.decodedData).toBeUndefined();
+    expect(notifications).toEqual([
+      {
+        type: "event.decode_failed",
+        contractId: "CABC1234",
+        eventId: "evt-miss",
+        error: "No ABI spec found for contract CABC1234",
+      },
+    ]);
   });
 
-  it("routes the event without decodedData and logs a warning when getSpec rejects", async () => {
+  it("routes the event without decodedData and emits event.decode_failed when getSpec rejects", async () => {
     const warnSpy = vi.fn();
     const abiRegistry: AbiRegistryClientLike = {
       getSpec: vi.fn().mockRejectedValue(new Error("network timeout")),
@@ -124,14 +143,33 @@ describe("EventEngine — ABI registry integration", () => {
     engine.start();
 
     const received: ContractEmittedEvent[] = [];
+    const notifications: Array<{
+      type: string;
+      contractId: string;
+      eventId?: string;
+      error: string;
+    }> = [];
     const watcher = engine.subscribeContract("sub1");
     watcher.on("contract.emitted", (e) => received.push(e as ContractEmittedEvent));
+    watcher.on("event.decode_failed", (e) => {
+      notifications.push(
+        e as { type: string; contractId: string; eventId?: string; error: string },
+      );
+    });
 
-    capturedOnMessage!(makeEmittedRecord());
+    capturedOnMessage!(makeEmittedRecord({ event_id: "evt-reject" }));
 
     await vi.waitFor(() => expect(received).toHaveLength(1));
 
     expect(received[0]!.decodedData).toBeUndefined();
+    expect(notifications).toEqual([
+      {
+        type: "event.decode_failed",
+        contractId: "CABC1234",
+        eventId: "evt-reject",
+        error: "network timeout",
+      },
+    ]);
     expect(warnSpy).toHaveBeenCalledWith(
       expect.stringContaining("ABI registry lookup failed"),
       expect.objectContaining({ contractId: "CABC1234" }),

--- a/packages/pulse-core/test/amount.test.ts
+++ b/packages/pulse-core/test/amount.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { toBigInt } from "../src/amount.js";
+import type { StellarAmount } from "../src/amount.js";
 
 describe("amount.toBigInt", () => {
   it("converts simple decimals to stroops", () => {
@@ -7,6 +8,9 @@ describe("amount.toBigInt", () => {
     expect(toBigInt("0.0000001" as any)).toBe(1n);
     expect(toBigInt("2" as any)).toBe(20000000n);
     expect(toBigInt("-2.5" as any)).toBe(-25000000n);
+
+    const amount = "1.2345678" as StellarAmount;
+    expect(toBigInt(amount)).toBe(12345678n);
   });
 
   it("truncates extra fractional precision", () => {

--- a/packages/pulse-webhooks/src/RedisRetryQueue.ts
+++ b/packages/pulse-webhooks/src/RedisRetryQueue.ts
@@ -1,3 +1,4 @@
+//redis-retry-queue.ts
 import type { RetryQueue, RetryRecord } from "./RetryQueue.js";
 
 type RedisValue = number | string;

--- a/packages/pulse-webhooks/src/index.ts
+++ b/packages/pulse-webhooks/src/index.ts
@@ -1,4 +1,9 @@
-import type { NormalizedEvent, Watcher, WatcherNotification } from "@orbital-stellar/pulse-core";
+import type {
+  DecodeFailedNotification,
+  NormalizedEvent,
+  Watcher,
+  WatcherNotification,
+} from "@orbital-stellar/pulse-core";
 import { createHmac, timingSafeEqual } from "crypto";
 
 import { DeadLetterStore } from "./MemoryDeadLetterStore.js";
@@ -112,13 +117,16 @@ export class WebhookDelivery {
       this.clearRetryTimers();
     });
 
-    this.watcher.on("*", (event: NormalizedEvent | WatcherNotification) => {
-      if ("raw" in event) {
-        for (const url of this.config.urls) {
-          void this.deliverToUrl(event, url);
+    this.watcher.on(
+      "*",
+      (event: NormalizedEvent | WatcherNotification | DecodeFailedNotification) => {
+        if ("raw" in event) {
+          for (const url of this.config.urls) {
+            void this.deliverToUrl(event, url);
+          }
         }
-      }
-    });
+      },
+    );
   }
 
   getDeadLetterStore(): DeadLetterStore {


### PR DESCRIPTION
## Linked issue

Closes #653 


Brief summary of changes made:

Added ABI-registry-based decoding for contract-emitted events in the pulse-core event engine.
When decoding succeeds, events now receive decodedData; when decoding fails or no ABI spec is found, the engine emits an event.decode_failed notification while still forwarding the original event.
Expanded watcher typing and public exports to support the new decode-failed notification and related amount helpers.
Added/updated regression tests covering successful decoding, missing ABI specs, and decode failures.