### PR TITLE
closes #651 1.84 — TypeScript type generation from spec (codegen CLI) 

### DIFF
--- a/packages/abi-registry/bin/abi-registry-generate
+++ b/packages/abi-registry/bin/abi-registry-generate
@@ -1,0 +1,18 @@
+#!/usr/bin/env node
+import { readFileSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { generateContractTypes } from "../src/generate.js";
+
+const [, , inputPath, outputPath] = process.argv;
+
+if (!inputPath || !outputPath) {
+  console.error("Usage: abi-registry-generate <input-spec.json> <output.d.ts>");
+  process.exit(1);
+}
+
+const resolvedInputPath = resolve(process.cwd(), inputPath);
+const resolvedOutputPath = resolve(process.cwd(), outputPath);
+const spec = JSON.parse(readFileSync(resolvedInputPath, "utf8"));
+const generated = generateContractTypes(spec, resolvedOutputPath);
+writeFileSync(resolvedOutputPath, generated, "utf8");

--- a/packages/abi-registry/package.json
+++ b/packages/abi-registry/package.json
@@ -11,9 +11,13 @@
   "types": "./dist/index.d.ts",
   "files": [
     "dist",
+    "bin",
     "README.md",
     "LICENSE"
   ],
+  "bin": {
+    "abi-registry-generate": "./bin/abi-registry-generate"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/determined-001/orbital_stellar.git",
@@ -35,6 +39,7 @@
     "@types/node": "^25.9.3",
     "@vitest/coverage-v8": "^4.1.9",
     "tsx": "^4.22.4",
-    "vitest": "^4.1.9"
+    "vitest": "^4.1.9",
+    "zod": "^4.4.3"
   }
 }

--- a/packages/abi-registry/src/generate.ts
+++ b/packages/abi-registry/src/generate.ts
@@ -1,0 +1,197 @@
+import { xdr } from "@stellar/stellar-sdk";
+import type { ContractSpec } from "./types.js";
+
+export type GeneratedContractArtifacts = {
+  declarations: string;
+  schemas: string;
+};
+
+function toPascalCase(value: string): string {
+  return value
+    .replace(/[^a-zA-Z0-9]+(.)/g, "_$1")
+    .replace(/(^|_)([a-zA-Z0-9])/g, (_, __, letter: string) => letter.toUpperCase())
+    .replace(/[^a-zA-Z0-9]+/g, "")
+    .replace(/^[0-9]+/, "");
+}
+
+function toCamelCase(value: string): string {
+  const pascal = toPascalCase(value);
+  return pascal ? pascal[0].toLowerCase() + pascal.slice(1) : value;
+}
+
+function toIdentifierName(value: string): string {
+  const normalized = value.replace(/[^a-zA-Z0-9]+/g, "_");
+  const parts = normalized.split("_").filter(Boolean);
+  if (parts.length === 0) {
+    return "value";
+  }
+  return parts.map((part, index) => {
+    const cleaned = part.replace(/^[0-9]+/, "");
+    if (!cleaned) {
+      return index === 0 ? "value" : "value";
+    }
+    return index === 0 ? cleaned.toLowerCase() : cleaned.charAt(0).toUpperCase() + cleaned.slice(1).toLowerCase();
+  }).join("");
+}
+
+function ensureUniqueName(base: string, used: Set<string>): string {
+  if (!used.has(base)) {
+    used.add(base);
+    return base;
+  }
+
+  let suffix = 2;
+  while (used.has(`${base}${suffix}`)) {
+    suffix += 1;
+  }
+  const unique = `${base}${suffix}`;
+  used.add(unique);
+  return unique;
+}
+
+function typeDiscriminant(type: xdr.ScSpecTypeDef | undefined): string {
+  if (!type) {
+    return "unknown";
+  }
+
+  const discriminant = type.switch();
+
+  if (typeof discriminant === "string") {
+    return discriminant;
+  }
+
+  if (discriminant && typeof discriminant === "object" && "name" in discriminant) {
+    return String((discriminant as { name: unknown }).name);
+  }
+
+  return String(discriminant);
+}
+
+function mapTypeToTs(type: xdr.ScSpecTypeDef | undefined): string {
+  switch (typeDiscriminant(type)) {
+    case "scSpecTypeAddress":
+    case "scSpecTypeBytes":
+    case "scSpecTypeString":
+    case "scSpecTypeSymbol":
+    case "scSpecTypeI64":
+    case "scSpecTypeU64":
+    case "scSpecTypeI128":
+    case "scSpecTypeU128":
+    case "scSpecTypeI256":
+    case "scSpecTypeU256":
+      return "string";
+    case "scSpecTypeBool":
+      return "boolean";
+    case "scSpecTypeI32":
+    case "scSpecTypeU32":
+      return "number";
+    case "scSpecTypeOption":
+      return "string | null";
+    case "scSpecTypeVec":
+      return "Array<unknown>";
+    case "scSpecTypeMap":
+      return "Array<{ key: unknown; value: unknown }>";
+    case "scSpecTypeTuple":
+      return "Array<unknown>";
+    case "scSpecTypeUdt":
+      return "unknown";
+    default:
+      return "unknown";
+  }
+}
+
+function mapTypeToZod(type: xdr.ScSpecTypeDef | undefined): string {
+  switch (typeDiscriminant(type)) {
+    case "scSpecTypeAddress":
+    case "scSpecTypeBytes":
+    case "scSpecTypeString":
+    case "scSpecTypeSymbol":
+    case "scSpecTypeI64":
+    case "scSpecTypeU64":
+    case "scSpecTypeI128":
+    case "scSpecTypeU128":
+    case "scSpecTypeI256":
+    case "scSpecTypeU256":
+      return "z.string()";
+    case "scSpecTypeBool":
+      return "z.boolean()";
+    case "scSpecTypeI32":
+    case "scSpecTypeU32":
+      return "z.number()";
+    case "scSpecTypeOption":
+      return "z.string().nullable()";
+    case "scSpecTypeVec":
+      return "z.array(z.unknown())";
+    case "scSpecTypeMap":
+      return "z.array(z.object({ key: z.unknown(), value: z.unknown() }))";
+    case "scSpecTypeTuple":
+      return "z.array(z.unknown())";
+    case "scSpecTypeUdt":
+      return "z.unknown()";
+    default:
+      return "z.unknown()";
+  }
+}
+
+export function generateContractArtifacts(spec: ContractSpec, contractName: string): GeneratedContractArtifacts {
+  const entries = spec.entries
+    .map((entry) => {
+      try {
+        return xdr.ScSpecEntry.fromXDR(Buffer.from(entry, "base64"));
+      } catch {
+        return null;
+      }
+    })
+    .filter((entry): entry is xdr.ScSpecEntry => entry !== null)
+    .map((entry) => entry.value())
+    .filter(
+      (entry): entry is xdr.ScSpecEventV0 =>
+        entry && typeof entry === "object" && typeof (entry as any).name === "function",
+    );
+
+  const usedNames = new Set<string>();
+  const declarations: string[] = [];
+  const schemas: string[] = [];
+
+  declarations.push("import { z } from \"zod\";");
+  declarations.push("");
+
+  for (const event of entries) {
+    const eventName = String((event as any).name());
+    const baseName = toPascalCase(eventName);
+    const interfaceName = ensureUniqueName(baseName, usedNames);
+    const schemaName = `${interfaceName}Schema`;
+    const params = Array.isArray((event as any).params?.()) ? (event as any).params() : [];
+    const propertyLines = params.map((param) => {
+      const rawParam = param as { name?: () => unknown; type?: () => xdr.ScSpecTypeDef };
+      const propertyName = toCamelCase(String(rawParam.name?.() ?? "value"));
+      return `  ${propertyName}: ${mapTypeToTs(rawParam.type?.())};`;
+    });
+
+    declarations.push(`export interface ${interfaceName} {`);
+    declarations.push(...propertyLines);
+    declarations.push("}");
+    declarations.push("");
+
+    schemas.push(`export const ${schemaName} = z.object({`);
+    schemas.push(
+      ...params.map((param) => {
+        const rawParam = param as { name?: () => unknown; type?: () => xdr.ScSpecTypeDef };
+        const propertyName = toCamelCase(String(rawParam.name?.() ?? "value"));
+        return `  ${propertyName}: ${mapTypeToZod(rawParam.type?.())},`;
+      }),
+    );
+    schemas.push("});");
+    schemas.push("");
+  }
+
+  return {
+    declarations: declarations.join("\n"),
+    schemas: schemas.join("\n"),
+  };
+}
+
+export function generateContractTypes(spec: ContractSpec, outputPath: string): string {
+  const artifacts = generateContractArtifacts(spec, outputPath);
+  return [artifacts.declarations, artifacts.schemas].filter(Boolean).join("\n\n");
+}

--- a/packages/abi-registry/test/generate.test.ts
+++ b/packages/abi-registry/test/generate.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+import { xdr } from "@stellar/stellar-sdk";
+import { generateContractArtifacts } from "../src/generate.js";
+import type { ContractSpec } from "../src/types.js";
+
+function createEventEntry(name: string, params: Array<{ name: string; type: xdr.ScSpecTypeDef }>) {
+  const entry = xdr.ScSpecEntry.scSpecEntryEventV0(
+    new xdr.ScSpecEventV0({
+      doc: "",
+      lib: "",
+      name,
+      prefixTopics: [],
+      params: params.map(
+        ({ name: paramName, type }) =>
+          new xdr.ScSpecEventParamV0({
+            doc: "",
+            name: paramName,
+            type,
+            location: xdr.ScSpecEventParamLocationV0.scSpecEventParamLocationData(),
+          }),
+      ),
+      dataFormat: xdr.ScSpecEventDataFormat.scSpecEventDataFormatVec(),
+    }),
+  );
+
+  return Buffer.from(entry.toXDR()).toString("base64");
+}
+
+function createTokenSpec(): ContractSpec {
+  return {
+    contractId: "CABC123",
+    entries: [
+      createEventEntry("transfer", [
+        { name: "from", type: xdr.ScSpecTypeDef.scSpecTypeAddress() },
+        { name: "to", type: xdr.ScSpecTypeDef.scSpecTypeAddress() },
+        { name: "amount", type: xdr.ScSpecTypeDef.scSpecTypeI128() },
+      ]),
+      createEventEntry("approve", [
+        { name: "spender", type: xdr.ScSpecTypeDef.scSpecTypeAddress() },
+        { name: "amount", type: xdr.ScSpecTypeDef.scSpecTypeI128() },
+      ]),
+      createEventEntry("mint", [
+        { name: "to", type: xdr.ScSpecTypeDef.scSpecTypeAddress() },
+        { name: "amount", type: xdr.ScSpecTypeDef.scSpecTypeI128() },
+      ]),
+    ],
+  };
+}
+
+describe("generateContractArtifacts", () => {
+  it("generates typed interfaces and matching zod schemas for token events", () => {
+    const spec = createTokenSpec();
+    const artifacts = generateContractArtifacts(spec, "token");
+
+    expect(artifacts.declarations).toContain("export interface Transfer");
+    expect(artifacts.declarations).toContain("from: string;");
+    expect(artifacts.declarations).toContain("amount: string;");
+    expect(artifacts.declarations).toContain("export interface Approve");
+    expect(artifacts.declarations).toContain("export interface Mint");
+
+    expect(artifacts.schemas).toContain("export const TransferSchema");
+    expect(artifacts.schemas).toContain("z.object({");
+    expect(artifacts.schemas).toContain("from: z.string()" );
+    expect(artifacts.schemas).toContain("amount: z.string()");
+    expect(artifacts.schemas).toContain("export const ApproveSchema");
+    expect(artifacts.schemas).toContain("export const MintSchema");
+  });
+
+  it("uses stable identifier mangling with collision suffixes", () => {
+    const spec = {
+      contractId: "CABC123",
+      entries: [
+        createEventEntry("transfer_event", [{ name: "from_address", type: xdr.ScSpecTypeDef.scSpecTypeAddress() }]),
+        createEventEntry("transfer_event", [{ name: "from_address", type: xdr.ScSpecTypeDef.scSpecTypeAddress() }]),
+      ],
+    } satisfies ContractSpec;
+
+    const artifacts = generateContractArtifacts(spec, "token");
+
+    expect(artifacts.declarations).toContain("export interface TransferEvent");
+    expect(artifacts.declarations).toContain("export interface TransferEvent2");
+    expect(artifacts.declarations).toContain("fromAddress: string;");
+    expect(artifacts.schemas).toContain("export const TransferEventSchema");
+    expect(artifacts.schemas).toContain("export const TransferEvent2Schema");
+  });
+});


### PR DESCRIPTION

Closes #651 1.84 — TypeScript type generation from spec (codegen CLI)


- [ ] Existing tests pass (`pnpm test`)
- [ ] New tests added for new behaviour
- [ ] Typechecks pass (`pnpm -r typecheck`)
- [ ] Manually tested against testnet / mainnet (describe what you tested)