### PR TITLE
Closes #621 1.54 — CursorStore interface for resumable streams

### DIFF
--- a/packages/pulse-core/src/CursorStore.ts
+++ b/packages/pulse-core/src/CursorStore.ts
@@ -65,3 +65,11 @@ export abstract class CursorStore {
    */
   ping?: () => Promise<unknown>;
 }
+export type CursorStoreLike = {
+  get(streamKey: string): Promise<string | null>;
+  set(streamKey: string, cursor: string): Promise<void>;
+  getMany?(keys: string[]): Promise<Record<string, string | null>>;
+  setMany?(entries: Record<string, string>): Promise<void>;
+  getAll?(): Promise<Array<{ streamKey: string; cursor: string }>>;
+  ping?(): Promise<unknown>;
+};

--- a/packages/pulse-core/src/EventEngine.ts
+++ b/packages/pulse-core/src/EventEngine.ts
@@ -45,6 +45,7 @@ import type {
   WatcherNotificationType,
   Logger,
   CursorStore,
+  CursorStoreLike,
   RawHorizonPayment,
   RawHorizonSetOptions,
   RawHorizonCreateAccount,
@@ -171,9 +172,10 @@ export class EventEngine {
   private horizonCursor?: string;
   private filters: Map<string, (event: NormalizedEvent) => boolean> = new Map();
   private log: Logger;
-  private cursorStore?: CursorStore;
+  private cursorStore?: CursorStoreLike;
   private readonly network: Network;
   private streamKey: string;
+  private streamEpoch = 0;
   private cursorFailureThreshold: number;
   private consecutiveCursorFailures = 0;
   private isCursorStoreUnhealthy = false;
@@ -712,6 +714,12 @@ export class EventEngine {
           });
         }
 
+        const cursor = this.getHorizonCursor(record);
+        if (cursor !== null) {
+          this.horizonCursor = cursor;
+          void this.persistHorizonCursor(cursor);
+        }
+
         const event = this.normalize(record);
         if (!event) {
           return;
@@ -726,7 +734,59 @@ export class EventEngine {
       },
     };
 
-    this.stopStream = this.server.operations().cursor("now").stream(callbacks);
+    const streamEpoch = ++this.streamEpoch;
+    if (!this.cursorStore) {
+      this.stopStream = this.server.operations().cursor("now").stream(callbacks);
+      return;
+    }
+
+    void this.resolveStreamCursor().then((streamCursor) => {
+      if (streamEpoch !== this.streamEpoch || !this.isRunning) {
+        return;
+      }
+
+      this.horizonCursor = streamCursor;
+      this.stopStream = this.server.operations().cursor(streamCursor).stream(callbacks);
+    });
+  }
+
+  private getHorizonCursor(record: unknown): string | null {
+    if (!this.isRecord(record)) {
+      return null;
+    }
+
+    const cursor = this.getStringField(record, "paging_token");
+    return cursor ?? this.getStringField(record, "pagingToken");
+  }
+
+  private async resolveStreamCursor(): Promise<string> {
+    if (!this.cursorStore) {
+      return "now";
+    }
+
+    try {
+      const cursor = await this.cursorStore.get(this.streamKey);
+      return cursor ?? "now";
+    } catch (err) {
+      this.log.warn("[pulse-core] cursorStore.get() failed during stream startup.", {
+        key: this.streamKey,
+        error: err instanceof Error ? err.message : String(err),
+      });
+      return "now";
+    }
+  }
+
+  private async persistHorizonCursor(cursor: string): Promise<void> {
+    if (!this.cursorStore) {
+      return;
+    }
+
+    try {
+      await this.cursorStore.set(this.streamKey, cursor);
+      this.consecutiveCursorFailures = 0;
+    } catch (err) {
+      this.handleCursorFailure(err);
+    }
   }
 
   private handleStreamError(error?: unknown): void {

--- a/packages/pulse-core/src/index.ts
+++ b/packages/pulse-core/src/index.ts
@@ -21,6 +21,7 @@ export type { AccountAddress, MuxedAddress, ContractAddress } from "./address.js
 export { EngineAlreadyStartedError, HorizonStreamError } from "./errors.js";
 export { StrKey } from "@stellar/stellar-sdk";
 export { CursorStore } from "./CursorStore.js";
+export type { CursorStoreLike } from "./CursorStore.js";
 export { MemoryCursorStore } from "./MemoryCursorStore.js";
 export { FileCursorStore } from "./FileCursorStore.js";
 export { PostgresCursorStore } from "./PostgresCursorStore.js";
@@ -437,7 +438,7 @@ export type CoreConfig = {
   reconnect?: ReconnectConfig;
   logger?: Logger;
   /** Optional cursor store for resumable streams. */
-  cursorStore?: CursorStore;
+  cursorStore?: CursorStoreLike;
   /** Key to use for cursor storage. Defaults to "pulse-core-cursor". */
   streamKey?: string;
   /** Number of consecutive cursor store failures before marking it unhealthy. Defaults to 5. */

--- a/packages/pulse-core/src/index.ts
+++ b/packages/pulse-core/src/index.ts
@@ -45,6 +45,7 @@ export { EngineAlreadyStartedError, HorizonStreamError } from "./errors.js";
 export { StrKey } from "@stellar/stellar-sdk";
 export { CursorStore } from "./CursorStore.js";
 export type { CursorStoreLike } from "./CursorStore.js";
+import type { CursorStoreLike } from "./CursorStore.js";
 export { MemoryCursorStore } from "./MemoryCursorStore.js";
 export { FileCursorStore } from "./FileCursorStore.js";
 export { PostgresCursorStore } from "./PostgresCursorStore.js";

--- a/packages/pulse-core/test/EventEngine.healthCheck.test.ts
+++ b/packages/pulse-core/test/EventEngine.healthCheck.test.ts
@@ -11,12 +11,14 @@ type MockStreamInstance = {
 };
 
 const streamInstances: MockStreamInstance[] = [];
+const cursorCalls: string[] = [];
 
 vi.mock("@stellar/stellar-sdk", () => {
   class MockServer {
     operations() {
       return {
-        cursor() {
+        cursor(value: string) {
+          cursorCalls.push(value);
           return {
             stream(handlers: StreamHandlers) {
               const close = vi.fn();
@@ -35,12 +37,18 @@ import { EventEngine } from "../src/EventEngine.js";
 
 beforeEach(() => {
   streamInstances.length = 0;
+  cursorCalls.length = 0;
   vi.useFakeTimers();
 });
 
 afterEach(() => {
   vi.useRealTimers();
 });
+
+async function flushAsyncWork() {
+  await Promise.resolve();
+  await Promise.resolve();
+}
 
 describe("engine.healthCheck()", () => {
   it("returns ok=false with reason when engine is not running", async () => {
@@ -126,6 +134,36 @@ describe("engine.healthCheck()", () => {
     expect((await engine.healthCheck(60_000)).ok).toBe(true);
   });
 
+  it("uses a persisted cursor on startup and writes the latest cursor after messages", async () => {
+    const setSpy = vi.fn(async () => {});
+    const cursorStore = {
+      get: vi.fn(async () => "saved-cursor"),
+      set: setSpy,
+    };
+    const engine = new EventEngine({ network: "testnet", cursorStore, streamKey: "stream-a" });
+    engine.start();
+    await flushAsyncWork();
+
+    expect(cursorStore.get).toHaveBeenCalledWith("stream-a");
+    expect(cursorCalls[0]).toBe("saved-cursor");
+
+    streamInstances[0]!.handlers.onmessage({
+      type: "payment",
+      id: "1",
+      paging_token: "fresh-cursor",
+      created_at: new Date().toISOString(),
+      transaction_successful: true,
+      source_account: "GABC",
+      from: "GABC",
+      to: "GDEF",
+      amount: "10.0000000",
+      asset_type: "native",
+    });
+    await Promise.resolve();
+
+    expect(setSpy).toHaveBeenCalledWith("stream-a", "fresh-cursor");
+  });
+
   it("returns ok=false when cursorStore.ping rejects", async () => {
     const cursorStore = {
       get: async () => null,
@@ -136,6 +174,7 @@ describe("engine.healthCheck()", () => {
     };
     const engine = new EventEngine({ network: "testnet", cursorStore });
     engine.start();
+    await flushAsyncWork();
     engine.subscribe("GABC");
     streamInstances[0]!.handlers.onmessage({
       type: "payment",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -108,6 +108,9 @@ importers:
       vitest:
         specifier: ^4.1.9
         version: 4.1.9(@types/node@25.9.3)(@vitest/coverage-v8@4.1.9)(jsdom@29.1.1(@noble/hashes@1.8.0))(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
 
   packages/pulse-core:
     dependencies:
@@ -2763,6 +2766,9 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
 
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
+
 snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
@@ -5032,3 +5038,5 @@ snapshots:
       yargs-parser: 22.0.0
 
   yocto-queue@0.1.0: {}
+
+  zod@4.4.3: {}


### PR DESCRIPTION
## Linked issue

Closes #621 1.54 — CursorStore interface for resumable streams


- [ ] Existing tests pass (`pnpm test`)
- [ ] New tests added for new behaviour
- [ ] Typechecks pass (`pnpm -r typecheck`)
- [ ] Manually tested against testnet / mainnet (describe what you tested)
