### PR TITLE
feat(pulse-notify): implement useStellarAddresses hook for multi-acco…

### DIFF
--- a/packages/pulse-notify/src/index.ts
+++ b/packages/pulse-notify/src/index.ts
@@ -4,7 +4,6 @@ import { acquireEventConnection, acquireContractEventConnection } from "./connec
 import type {
   NormalizedEvent,
   PaymentEvent,
-  ContractInvokedEvent,
   ContractEmittedEvent,
 } from "@orbital-stellar/pulse-core";
 import { acquireWsConnection } from "./wsTransport.js";
@@ -318,6 +317,151 @@ export type UseHistoryOptions = {
 export type HistoryState<T extends NormalizedEvent = NormalizedEvent> = EventState<T> & {
   history: T[];
 };
+
+// ─── useStellarAddresses ─────────────────────────────────────────────────────
+
+export type UseAddressesOptions = {
+  event?: string | string[];
+  token?: string;
+  /** Client-side predicate; events that return false are suppressed before state update */
+  filter?: (event: NormalizedEvent) => boolean;
+  /** Enable cookie-based auth for same-origin or CORS-credentialed SSE */
+  withCredentials?: boolean;
+  /** Side-effect callback fired for every incoming event (per address), before filter is applied */
+  onEvent?: (address: string, event: NormalizedEvent) => void;
+};
+
+/**
+ * Watches multiple Stellar addresses with a single hook call.
+ *
+ * Connections are acquired from the shared pool (see connectionPool.ts), so
+ * duplicate addresses across the same `serverUrl`/`token` combination always
+ * reuse one underlying EventSource rather than opening a new one.
+ *
+ * @param serverUrl - Base URL of the pulse-notify server.
+ * @param addresses - Array of Stellar account addresses to watch.
+ * @param options   - Optional shared configuration (token, filter, …).
+ * @returns A `Record<address, EventState<T>>` that is updated independently
+ *          for each address as events arrive.
+ *
+ * @example
+ * const states = useStellarAddresses(serverUrl, [addrA, addrB, addrC]);
+ * // states[addrA].event, states[addrB].connected, …
+ */
+export function useStellarAddresses<T extends NormalizedEvent = NormalizedEvent>(
+  serverUrl: string,
+  addresses: string[],
+  options?: UseAddressesOptions,
+): Record<string, EventState<T>> {
+  const { event: eventType, token, filter, withCredentials, onEvent } = options ?? {};
+
+  // Serialise the addresses array once per render so we can use it as a stable
+  // effect dependency even when the caller passes an inline literal.
+  const addressKey = [...addresses].sort().join(",");
+  const eventKey = Array.isArray(eventType) ? [...eventType].sort().join(",") : (eventType ?? "*");
+
+  // Initialise state lazily — one EventState entry per address.
+  const [states, setStates] = useState<Record<string, EventState<T>>>(() => {
+    const initial: Record<string, EventState<T>> = {};
+    for (const addr of addresses) {
+      initial[addr] = { event: null, connected: false, error: null, lastEventAt: null };
+    }
+    return initial;
+  });
+
+  // Keep callbacks in refs so that effect deps stay stable across renders.
+  const filterRef = useRef(filter);
+  useEffect(() => {
+    filterRef.current = filter;
+  });
+
+  const onEventRef = useRef(onEvent);
+  useEffect(() => {
+    onEventRef.current = onEvent;
+  });
+
+  useEffect(() => {
+    if (addresses.length === 0) return;
+
+    // Normalise the event-type list once for all subscriptions.
+    const resolvedEventType: string | string[] = eventKey === "*" ? "*" : (eventType ?? "*");
+
+    const connections = addresses.map((addr) => {
+      const connection = acquireEventConnection(
+        { serverUrl, address: addr, token, withCredentials },
+        {
+          onOpen: () => {
+            setStates((prev) => ({
+              ...prev,
+              [addr]: { ...prev[addr]!, connected: true, error: null },
+            }));
+          },
+          onEvent: (incoming) => {
+            onEventRef.current?.(addr, incoming);
+
+            // Apply event-type filter.
+            const allowed =
+              resolvedEventType === "*" ||
+              (Array.isArray(resolvedEventType)
+                ? resolvedEventType.includes(incoming.type)
+                : incoming.type === resolvedEventType);
+            if (!allowed) return;
+
+            // Apply user predicate.
+            if (filterRef.current && !filterRef.current(incoming)) return;
+
+            setStates((prev) => ({
+              ...prev,
+              [addr]: {
+                ...prev[addr]!,
+                event: incoming as T,
+                lastEventAt: incoming.timestamp ?? null,
+              },
+            }));
+          },
+          onParseError: () => {
+            setStates((prev) => ({
+              ...prev,
+              [addr]: { ...prev[addr]!, error: "Failed to parse event" },
+            }));
+          },
+          onError: () => {
+            setStates((prev) => ({
+              ...prev,
+              [addr]: {
+                ...prev[addr]!,
+                connected: false,
+                error: "Connection lost — retrying...",
+              },
+            }));
+          },
+        },
+      );
+
+      // If the pool already had an open connection, reflect that immediately.
+      if (connection.connected) {
+        setStates((prev) => ({
+          ...prev,
+          [addr]: { ...prev[addr]!, connected: true, error: null },
+        }));
+      }
+
+      return connection;
+    });
+
+    return () => {
+      for (const connection of connections) {
+        connection.unsubscribe();
+      }
+    };
+    // ✅ addressKey and eventKey are stable serialised strings — safe as deps
+    // even when the caller passes inline array literals.
+  }, [serverUrl, addressKey, eventKey, token, withCredentials]);
+
+  return states;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
 
 export function useStellarHistory<T extends NormalizedEvent = NormalizedEvent>(
   serverUrl: string,

--- a/packages/pulse-notify/test/useStellarAddresses.test.tsx
+++ b/packages/pulse-notify/test/useStellarAddresses.test.tsx
@@ -1,0 +1,182 @@
+import { render, act, cleanup } from "@testing-library/react";
+import { afterEach, expect, test, describe } from "vitest";
+import {
+  __getConnectionPoolSizeForTests,
+  __resetConnectionPoolForTests,
+} from "../src/connectionPool.ts";
+import { useStellarAddresses } from "../src/index.ts";
+
+// ── Minimal EventSource stub ──────────────────────────────────────────────────
+
+class MockEventSource {
+  static instances: MockEventSource[] = [];
+
+  onopen: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+  onmessage: ((e: { data: string }) => void) | null = null;
+  closeCount = 0;
+
+  constructor(public url: string) {
+    MockEventSource.instances.push(this);
+    // Auto-open on next tick (mirrors other hook tests in this package).
+    setTimeout(() => this.onopen?.(), 0);
+  }
+
+  close() {
+    this.closeCount++;
+  }
+
+  emit(data: unknown) {
+    this.onmessage?.({ data: JSON.stringify(data) });
+  }
+}
+
+globalThis.EventSource = MockEventSource as unknown as typeof EventSource;
+
+afterEach(() => {
+  __resetConnectionPoolForTests();
+  MockEventSource.instances = [];
+  cleanup();
+});
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+const SERVER = "https://events.example.com";
+
+function makeAddresses(n: number): string[] {
+  return Array.from({ length: n }, (_, i) => `GADDR${i + 1}`);
+}
+
+// Simple component that renders the connection count and each address state.
+function WatcherComponent({
+  addresses,
+  onEvent,
+}: {
+  addresses: string[];
+  onEvent?: (addr: string, ev: unknown) => void;
+}) {
+  const states = useStellarAddresses(SERVER, addresses, { onEvent });
+  return (
+    <div>
+      {addresses.map((addr, i) => (
+        <div key={`${addr}-${i}`} data-testid={addr}>
+          {states[addr]?.connected ? "connected" : "disconnected"}|
+          {states[addr]?.event ? JSON.stringify(states[addr]!.event) : "null"}|
+          {states[addr]?.error ?? "none"}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("useStellarAddresses", () => {
+  test("opens one EventSource per unique address", async () => {
+    const addresses = makeAddresses(5);
+    const { unmount } = render(<WatcherComponent addresses={addresses} />);
+
+    // Wait for all five EventSources to auto-open.
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 20));
+    });
+
+    // Each unique address = one connection in the pool.
+    expect(MockEventSource.instances.length).toBe(5);
+    expect(__getConnectionPoolSizeForTests()).toBe(5);
+
+    unmount();
+  });
+
+  test("duplicate addresses share one underlying EventSource", async () => {
+    // Pass the same address three times — pool must coalesce to 1 connection.
+    const addr = "GSHARED";
+    const addresses = [addr, addr, addr];
+    const { unmount } = render(<WatcherComponent addresses={addresses} />);
+
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 20));
+    });
+
+    // Three subscriptions, but the pool only opens one EventSource.
+    expect(MockEventSource.instances.length).toBe(1);
+    expect(__getConnectionPoolSizeForTests()).toBe(1);
+
+    unmount();
+  });
+
+  test("returns connected state per address after open", async () => {
+    const addresses = makeAddresses(2);
+    const { getByTestId, findByText } = render(<WatcherComponent addresses={addresses} />);
+
+    // Wait for first address to connect.
+    await findByText(/connected/, { selector: `[data-testid="${addresses[0]}"]` });
+
+    expect(getByTestId(addresses[0]!).textContent).toContain("connected");
+    expect(getByTestId(addresses[1]!).textContent).toContain("connected");
+  });
+
+  test("delivers events to the correct address slot", async () => {
+    const [addr1, addr2] = makeAddresses(2);
+    const received: { addr: string; type: string }[] = [];
+
+    const { getByTestId, findByText } = render(
+      <WatcherComponent
+        addresses={[addr1!, addr2!]}
+        onEvent={(addr, ev) => received.push({ addr, type: (ev as { type: string }).type })}
+      />,
+    );
+
+    await findByText(/connected/, { selector: `[data-testid="${addr1}"]` });
+
+    // Fire an event on the second EventSource (addr2 maps to instances[1]).
+    act(() => {
+      MockEventSource.instances[1]!.emit({
+        type: "payment.received",
+        address: addr2,
+        amount: "10.0000000",
+        asset: "XLM",
+        timestamp: "2026-06-27T10:00:00Z",
+      });
+    });
+
+    expect(getByTestId(addr2!).textContent).toContain("payment.received");
+    // addr1 slot must remain unaffected.
+    expect(getByTestId(addr1!).textContent).toContain("|null|");
+    expect(received).toHaveLength(1);
+    expect(received[0]!.addr).toBe(addr2);
+  });
+
+  test("cleans up all connections on unmount", async () => {
+    const addresses = makeAddresses(5);
+    const { unmount } = render(<WatcherComponent addresses={addresses} />);
+
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 20));
+    });
+
+    expect(__getConnectionPoolSizeForTests()).toBe(5);
+
+    unmount();
+
+    // Pool must be empty — every EventSource closed.
+    expect(__getConnectionPoolSizeForTests()).toBe(0);
+    expect(MockEventSource.instances.every((es) => es.closeCount === 1)).toBe(true);
+  });
+
+  test("five addresses use at most one EventSource when all are identical", async () => {
+    // This is the literal 'Done when' criterion from issue #693.
+    const shared = "GSHAREDWALLET";
+    const addresses = Array.from({ length: 5 }, () => shared);
+    const { unmount } = render(<WatcherComponent addresses={addresses} />);
+
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 20));
+    });
+
+    // All five 'subscriptions' must coalesce into exactly 1 EventSource.
+    expect(MockEventSource.instances.length).toBe(1);
+
+    unmount();
+  });
+});


### PR DESCRIPTION
closes #693

## Description
This pull request adds `useStellarAddresses`—a multi-address React hook that watches N Stellar addresses in a single call while coalescing into the minimum number of connections via the shared connection pool.

### Key Changes
- **Implement `useStellarAddresses` hook**: Adds the hook to [index.ts](file:///C:/Users/godzi/Documents/orbital_stellar/packages/pulse-notify/src/index.ts). It subscribes to an array of addresses, uses the shared pool (`acquireEventConnection`), and maps incoming events/statuses to independent states per address in a `Record<string, EventState<T>>` output.
- **Deduplicate EventSources**: When duplicate addresses are watched (either within the same hook or across multiple hook usages), they leverage the pool to reuse existing EventSource instances.
- **Add Tests**: Creates [useStellarAddresses.test.tsx](file:///C:/Users/godzi/Documents/orbital_stellar/packages/pulse-notify/test/useStellarAddresses.test.tsx) containing comprehensive unit tests verifying connection sharing, state isolation, correct event delivery, cleanup on unmount, and multi-address pooling behavior.
