### PR TITLE
perf(pulse-notify): pause connections when tab is hidden after hideAf…

### DIFF
--- a/packages/pulse-notify/src/index.ts
+++ b/packages/pulse-notify/src/index.ts
@@ -26,6 +26,8 @@ export type UseEventConfig<T extends NormalizedEvent = NormalizedEvent> = {
   onEvent?: (event: NormalizedEvent) => void;
   /** Transport to use. Defaults to 'sse'. */
   transport?: "sse" | "websocket";
+  /** Wait time before pausing active connection when document becomes hidden (ms). Defaults to 30000. */
+  hideAfterMs?: number;
 };
 
 export type EventState<T extends NormalizedEvent = NormalizedEvent> = {
@@ -35,6 +37,45 @@ export type EventState<T extends NormalizedEvent = NormalizedEvent> = {
   lastEventAt: string | null;
 };
 
+function useVisibilityState(hideAfterMs = 30000): boolean {
+  const [isActive, setIsActive] = useState(true);
+
+  useEffect(() => {
+    if (typeof document === "undefined") return;
+
+    let timer: any = null;
+
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === "hidden") {
+        timer = setTimeout(() => {
+          setIsActive(false);
+        }, hideAfterMs);
+      } else {
+        if (timer) {
+          clearTimeout(timer);
+          timer = null;
+        }
+        setIsActive(true);
+      }
+    };
+
+    if (document.visibilityState === "hidden") {
+      timer = setTimeout(() => {
+        setIsActive(false);
+      }, hideAfterMs);
+    }
+
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+
+    return () => {
+      if (timer) clearTimeout(timer);
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+    };
+  }, [hideAfterMs]);
+
+  return isActive;
+}
+
 export function useStellarEvent<T extends NormalizedEvent = NormalizedEvent>(
   config: UseEventConfig<T>,
 ): EventState<T>;
@@ -43,7 +84,7 @@ export function useStellarEvent<T extends NormalizedEvent = NormalizedEvent>(
   address: string,
   options?: Pick<
     UseEventConfig<T>,
-    "event" | "token" | "initialEvent" | "filter" | "withCredentials" | "onEvent"
+    "event" | "token" | "initialEvent" | "filter" | "withCredentials" | "onEvent" | "hideAfterMs"
   >,
 ): EventState<T>;
 export function useStellarEvent<T extends NormalizedEvent = NormalizedEvent>(
@@ -51,7 +92,7 @@ export function useStellarEvent<T extends NormalizedEvent = NormalizedEvent>(
   address?: string,
   options?: Pick<
     UseEventConfig<T>,
-    "event" | "token" | "initialEvent" | "filter" | "withCredentials" | "onEvent"
+    "event" | "token" | "initialEvent" | "filter" | "withCredentials" | "onEvent" | "hideAfterMs"
   >,
 ): EventState<T> {
   const serverUrl = typeof configOrUrl === "string" ? configOrUrl : configOrUrl.serverUrl;
@@ -66,6 +107,8 @@ export function useStellarEvent<T extends NormalizedEvent = NormalizedEvent>(
     typeof configOrUrl === "string" ? options?.withCredentials : configOrUrl.withCredentials;
   const onEvent = typeof configOrUrl === "string" ? options?.onEvent : configOrUrl.onEvent;
   const transport = typeof configOrUrl === "string" ? "sse" : (configOrUrl.transport ?? "sse");
+  const hideAfterMs =
+    typeof configOrUrl === "string" ? options?.hideAfterMs : configOrUrl.hideAfterMs;
 
   const eventKey = Array.isArray(eventType) ? [...eventType].sort().join(",") : eventType;
 
@@ -86,7 +129,14 @@ export function useStellarEvent<T extends NormalizedEvent = NormalizedEvent>(
     lastEventAt: null,
   });
 
+  const isActive = useVisibilityState(hideAfterMs ?? 30000);
+
   useEffect(() => {
+    if (!isActive) {
+      setState((prev) => ({ ...prev, connected: false }));
+      return;
+    }
+
     const acquire = transport === "websocket" ? acquireWsConnection : acquireEventConnection;
     const connection = acquire(
       { serverUrl, address: addr, token, ...(transport === "sse" ? { withCredentials } : {}) },
@@ -134,7 +184,7 @@ export function useStellarEvent<T extends NormalizedEvent = NormalizedEvent>(
     };
     // ✅ eventKey is a serialised string — stable even when the caller passes
     // an array literal, which would otherwise be a new reference every render.
-  }, [serverUrl, addr, eventKey, token, withCredentials, transport]);
+  }, [serverUrl, addr, eventKey, token, withCredentials, transport, isActive]);
 
   return state;
 }
@@ -169,6 +219,7 @@ export function useStellarPayment(
     initialEvent?: PaymentEvent | null;
     filter?: (event: NormalizedEvent) => boolean;
     withCredentials?: boolean;
+    hideAfterMs?: number;
   },
 ) {
   const base = useStellarEvent(serverUrl, address, {
@@ -176,6 +227,7 @@ export function useStellarPayment(
     initialEvent: (options?.initialEvent ?? undefined) as NormalizedEvent | undefined,
     filter: options?.filter,
     withCredentials: options?.withCredentials,
+    hideAfterMs: options?.hideAfterMs,
   });
   // The "payment.received" stream only ever delivers PaymentEvents; narrow the
   // generic NormalizedEvent so we can read `amount`.
@@ -192,6 +244,7 @@ export function useStellarActivity<T extends NormalizedEvent = NormalizedEvent>(
     initialEvent?: T | null;
     filter?: (event: NormalizedEvent) => boolean;
     withCredentials?: boolean;
+    hideAfterMs?: number;
   },
 ): EventState<T> {
   return useStellarEvent<T>(serverUrl, address, {
@@ -199,6 +252,7 @@ export function useStellarActivity<T extends NormalizedEvent = NormalizedEvent>(
     initialEvent: options?.initialEvent,
     filter: options?.filter,
     withCredentials: options?.withCredentials,
+    hideAfterMs: options?.hideAfterMs,
   });
 }
 
@@ -223,6 +277,8 @@ export type UseContractEventConfig<T extends NormalizedEvent = NormalizedEvent> 
   withCredentials?: boolean;
   /** Side-effect callback fired for every incoming event, before filter is applied */
   onEvent?: (event: NormalizedEvent) => void;
+  /** Wait time before pausing active connection when document becomes hidden (ms). Defaults to 30000. */
+  hideAfterMs?: number;
 };
 
 /** Hook for subscribing to Soroban contract events */
@@ -232,8 +288,17 @@ export function useContractEvent<
     { type: "contract.invoked" | "contract.emitted" }
   >,
 >(config: UseContractEventConfig<T>): EventState<T> {
-  const { serverUrl, contractId, topics, token, initialEvent, filter, withCredentials, onEvent } =
-    config;
+  const {
+    serverUrl,
+    contractId,
+    topics,
+    token,
+    initialEvent,
+    filter,
+    withCredentials,
+    onEvent,
+    hideAfterMs,
+  } = config;
 
   const filterRef = useRef(filter);
   useEffect(() => {
@@ -252,7 +317,14 @@ export function useContractEvent<
     lastEventAt: null,
   });
 
+  const isActive = useVisibilityState(hideAfterMs ?? 30000);
+
   useEffect(() => {
+    if (!isActive) {
+      setState((prev) => ({ ...prev, connected: false }));
+      return;
+    }
+
     const connection = acquireContractEventConnection(
       { serverUrl, contractId, topics, token, withCredentials },
       {
@@ -296,7 +368,7 @@ export function useContractEvent<
     return () => {
       connection.unsubscribe();
     };
-  }, [serverUrl, contractId, JSON.stringify(topics ?? []), token, withCredentials]);
+  }, [serverUrl, contractId, JSON.stringify(topics ?? []), token, withCredentials, isActive]);
 
   return state;
 }
@@ -313,6 +385,7 @@ export type UseHistoryOptions = {
   token?: string;
   /** Maximum number of events to retain in FIFO order. Defaults to 100. */
   capacity?: number;
+  hideAfterMs?: number;
 };
 
 export type HistoryState<T extends NormalizedEvent = NormalizedEvent> = EventState<T> & {
@@ -326,7 +399,10 @@ export function useStellarHistory<T extends NormalizedEvent = NormalizedEvent>(
 ): HistoryState<T> {
   const [history, setHistory] = useState<T[]>([]);
   const capacity = options?.capacity ?? 100;
-  const base = useStellarActivity<T>(serverUrl, address, { initialEvent: null });
+  const base = useStellarActivity<T>(serverUrl, address, {
+    initialEvent: null,
+    hideAfterMs: options?.hideAfterMs,
+  });
 
   useEffect(() => {
     if (base.event) {

--- a/packages/pulse-notify/test/visibility.test.tsx
+++ b/packages/pulse-notify/test/visibility.test.tsx
@@ -1,0 +1,164 @@
+import { render, act, cleanup } from "@testing-library/react";
+import { afterEach, beforeEach, expect, test, describe, vi } from "vitest";
+import {
+  __getConnectionPoolSizeForTests,
+  __resetConnectionPoolForTests,
+} from "../src/connectionPool.ts";
+import { useStellarEvent } from "../src/index.ts";
+
+class MockEventSource {
+  static instances: MockEventSource[] = [];
+  onopen: (() => void) | null = null;
+  closeCount = 0;
+
+  constructor(public url: string) {
+    MockEventSource.instances.push(this);
+    setTimeout(() => this.onopen?.(), 0);
+  }
+
+  close() {
+    this.closeCount++;
+  }
+}
+
+globalThis.EventSource = MockEventSource as unknown as typeof EventSource;
+
+describe("Visibility-API integration", () => {
+  let originalVisibilityState: any;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    originalVisibilityState = document.visibilityState;
+    Object.defineProperty(document, "visibilityState", {
+      value: "visible",
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    Object.defineProperty(document, "visibilityState", {
+      value: originalVisibilityState,
+      writable: true,
+      configurable: true,
+    });
+    __resetConnectionPoolForTests();
+    MockEventSource.instances = [];
+    cleanup();
+  });
+
+  function TestComponent({ hideAfterMs }: { hideAfterMs?: number }) {
+    const state = useStellarEvent("https://events.example.com", "GABC", {
+      hideAfterMs,
+    });
+    return (
+      <div>
+        <div data-testid="connected">{state.connected ? "connected" : "disconnected"}</div>
+      </div>
+    );
+  }
+
+  test("pauses connection when tab is hidden after hideAfterMs and reconnects when visible", async () => {
+    const { getByTestId } = render(<TestComponent hideAfterMs={5000} />);
+
+    // Wait for connection to open
+    await act(async () => {
+      await vi.runOnlyPendingTimersAsync();
+    });
+
+    expect(getByTestId("connected").textContent).toBe("connected");
+    expect(__getConnectionPoolSizeForTests()).toBe(1);
+
+    // Hide the tab
+    act(() => {
+      Object.defineProperty(document, "visibilityState", {
+        value: "hidden",
+        writable: true,
+        configurable: true,
+      });
+      document.dispatchEvent(new Event("visibilitychange"));
+    });
+
+    // Advance time before hideAfterMs threshold — connection must still be open
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(4000);
+    });
+
+    expect(getByTestId("connected").textContent).toBe("connected");
+    expect(__getConnectionPoolSizeForTests()).toBe(1);
+
+    // Advance past hideAfterMs threshold — connection must close
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1500);
+    });
+
+    expect(getByTestId("connected").textContent).toBe("disconnected");
+    expect(__getConnectionPoolSizeForTests()).toBe(0);
+    expect(MockEventSource.instances[0]!.closeCount).toBe(1);
+
+    // Show the tab again — connection must restore
+    act(() => {
+      Object.defineProperty(document, "visibilityState", {
+        value: "visible",
+        writable: true,
+        configurable: true,
+      });
+      document.dispatchEvent(new Event("visibilitychange"));
+    });
+
+    // Wait for new connection to open
+    await act(async () => {
+      await vi.runOnlyPendingTimersAsync();
+    });
+
+    expect(getByTestId("connected").textContent).toBe("connected");
+    expect(__getConnectionPoolSizeForTests()).toBe(1);
+    expect(MockEventSource.instances.length).toBe(2);
+  });
+
+  test("does not pause connection if tab becomes visible before hideAfterMs expires", async () => {
+    const { getByTestId } = render(<TestComponent hideAfterMs={5000} />);
+
+    await act(async () => {
+      await vi.runOnlyPendingTimersAsync();
+    });
+
+    expect(getByTestId("connected").textContent).toBe("connected");
+
+    // Hide the tab
+    act(() => {
+      Object.defineProperty(document, "visibilityState", {
+        value: "hidden",
+        writable: true,
+        configurable: true,
+      });
+      document.dispatchEvent(new Event("visibilitychange"));
+    });
+
+    // Advance time partly
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(3000);
+    });
+
+    // Show the tab again before timeout expires
+    act(() => {
+      Object.defineProperty(document, "visibilityState", {
+        value: "visible",
+        writable: true,
+        configurable: true,
+      });
+      document.dispatchEvent(new Event("visibilitychange"));
+    });
+
+    // Advance past original timeout threshold
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(3000);
+    });
+
+    // Connection must stay open and not close
+    expect(getByTestId("connected").textContent).toBe("connected");
+    expect(__getConnectionPoolSizeForTests()).toBe(1);
+    expect(MockEventSource.instances[0]!.closeCount).toBe(0);
+  });
+});


### PR DESCRIPTION
closes #692

## Description
This pull request integrates the document Visibility API with the Stellar SSE events system to save mobile bandwidth and battery. When a tab becomes hidden, active hook connections will pause/release their subscriptions after a configurable threshold (`hideAfterMs`, default 30s) and automatically reconnect once the tab becomes visible again.

### Key Changes
- **Implement `useVisibilityState`**: Added a helper hook inside [index.ts](file:///C:/Users/godzi/Documents/orbital_stellar/packages/pulse-notify/src/index.ts) that tracks `document.visibilityState` changes and handles the `hideAfterMs` timeout when hidden.
- **Hook Integration**: Updated `useStellarEvent`, `useStellarPayment`, `useStellarActivity`, `useStellarHistory`, and `useContractEvent` to accept `hideAfterMs` in their configuration/options. If the tab stays hidden past the threshold, the hook unsubscribes and cleans up the active EventSource (releasing connection from the pool). Re-focusing/showing the tab automatically triggers re-subscription.
- **Unit Tests**: Added [visibility.test.tsx](file:///C:/Users/godzi/Documents/orbital_stellar/packages/pulse-notify/test/visibility.test.tsx) to verify visibility-based pausing, reconnecting, and timeout behavior.
