### PR TITLE
feat(pulse-core): unsubscribeContract(config) + config cleanup in unsubscribeAllContracts (#632)

### DIFF
--- a/packages/pulse-core/src/EventEngine.ts
+++ b/packages/pulse-core/src/EventEngine.ts
@@ -461,10 +461,24 @@ export class EventEngine {
   }
 
   /**
-   * Removes a contract subscription by its id.
+   * Removes a contract subscription created with the legacy id-based
+   * `subscribeContract(id)`, stopping its watcher.
    */
-  unsubscribeContract(id: string): void {
-    this.contractRegistry.get(id)?.watcher.stop();
+  unsubscribeContract(id: string): void;
+  /**
+   * Removes the contract subscription created with `subscribeContract(config)`,
+   * stopping the watcher registered under the same filter shape. No-op when no
+   * matching subscription exists.
+   */
+  unsubscribeContract(config: ContractSubscriptionConfig): void;
+  unsubscribeContract(idOrConfig: string | ContractSubscriptionConfig): void {
+    if (typeof idOrConfig === "object") {
+      const key = stableFilterKey(idOrConfig.filters);
+      // The watcher's stop handler removes it from contractConfigRegistry.
+      this.contractConfigRegistry.get(key)?.stop();
+      return;
+    }
+    this.contractRegistry.get(idOrConfig)?.watcher.stop();
   }
 
   /**
@@ -523,6 +537,7 @@ export class EventEngine {
    * tearing it down.
    */
   unsubscribeAllContracts(): void {
+    // Legacy id-based subscriptions.
     for (const [id, entry] of this.contractRegistry.entries()) {
       const name = this.subscriptionNames.get(id);
       const notification = {
@@ -533,6 +548,17 @@ export class EventEngine {
       };
       entry.watcher.emit("engine.stopped", notification);
       entry.watcher.stop();
+    }
+
+    // Config-based subscriptions (subscribeContract(config)). Snapshot first —
+    // each watcher's stop handler mutates contractConfigRegistry.
+    for (const watcher of [...this.contractConfigRegistry.values()]) {
+      watcher.emit("engine.stopped", {
+        type: "engine.stopped" as const,
+        attempt: 0,
+        emittedAt: new Date().toISOString(),
+      });
+      watcher.stop();
     }
   }
 

--- a/packages/pulse-core/test/EventEngine.unsubscribeContract.test.ts
+++ b/packages/pulse-core/test/EventEngine.unsubscribeContract.test.ts
@@ -1,0 +1,136 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+type StreamHandlers = {
+  onmessage: (record: unknown) => void;
+  onerror: (error: unknown) => void;
+};
+type MockStreamInstance = { handlers: StreamHandlers; close: ReturnType<typeof vi.fn> };
+
+const streamInstances: MockStreamInstance[] = [];
+
+vi.mock("@stellar/stellar-sdk", () => {
+  class MockServer {
+    operations() {
+      return {
+        cursor() {
+          return {
+            stream(handlers: StreamHandlers) {
+              const close = vi.fn();
+              streamInstances.push({ handlers, close });
+              return close;
+            },
+          };
+        },
+      };
+    }
+  }
+  return { Horizon: { Server: MockServer } };
+});
+
+import { EventEngine } from "../src/EventEngine.js";
+import type { ContractSubscriptionConfig } from "../src/index.js";
+
+function configRegistry(engine: EventEngine): Map<string, unknown> {
+  return (engine as unknown as { contractConfigRegistry: Map<string, unknown> })
+    .contractConfigRegistry;
+}
+
+beforeEach(() => {
+  streamInstances.length = 0;
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("unsubscribeContract(config)", () => {
+  it("stops the watcher matching the config and removes its registry entry", () => {
+    const engine = new EventEngine({ network: "testnet" });
+    const config: ContractSubscriptionConfig = { filters: [{ contractIds: ["CA1234"] }] };
+    const watcher = engine.subscribeContract(config);
+    expect(configRegistry(engine).size).toBe(1);
+
+    engine.unsubscribeContract(config);
+
+    expect(watcher.stopped).toBe(true);
+    expect(configRegistry(engine).size).toBe(0);
+    // A fresh subscribe returns a new watcher — the old key is gone.
+    const next = engine.subscribeContract({ filters: [{ contractIds: ["CA1234"] }] });
+    expect(next).not.toBe(watcher);
+  });
+
+  it("matches the subscription regardless of contractIds order", () => {
+    const engine = new EventEngine({ network: "testnet" });
+    const watcher = engine.subscribeContract({ filters: [{ contractIds: ["CA", "CB"] }] });
+
+    engine.unsubscribeContract({ filters: [{ contractIds: ["CB", "CA"] }] });
+
+    expect(watcher.stopped).toBe(true);
+    expect(configRegistry(engine).size).toBe(0);
+  });
+
+  it("removes only the matching config and leaves the others intact", () => {
+    const engine = new EventEngine({ network: "testnet" });
+    const a = engine.subscribeContract({ filters: [{ contractIds: ["CA"] }] });
+    const b = engine.subscribeContract({ filters: [{ contractIds: ["CB"] }] });
+
+    engine.unsubscribeContract({ filters: [{ contractIds: ["CA"] }] });
+
+    expect(a.stopped).toBe(true);
+    expect(b.stopped).toBe(false);
+    expect(configRegistry(engine).size).toBe(1);
+  });
+
+  it("is a no-op for a config that was never subscribed", () => {
+    const engine = new EventEngine({ network: "testnet" });
+    engine.subscribeContract({ filters: [{ contractIds: ["CA"] }] });
+
+    expect(() => engine.unsubscribeContract({ filters: [{ contractIds: ["CZ"] }] })).not.toThrow();
+    expect(configRegistry(engine).size).toBe(1);
+  });
+
+  it("still supports the legacy id-based overload", () => {
+    const engine = new EventEngine({ network: "testnet" });
+    engine.subscribeContract("CAAA");
+    engine.unsubscribeContract("CAAA");
+    expect(engine.status().contractWatcherCount).toBe(0);
+  });
+});
+
+describe("unsubscribeAllContracts() — config-based subscriptions", () => {
+  it("stops config-based watchers and leaves the Horizon stream running", () => {
+    const engine = new EventEngine({ network: "testnet" });
+    engine.subscribe("GABC"); // classic Horizon subscription
+    const c1 = engine.subscribeContract({ filters: [{ contractIds: ["CA"] }] });
+    const c2 = engine.subscribeContract({ filters: [{ contractIds: ["CB"] }] });
+    engine.subscribeContract("CLEGACY"); // legacy id-based contract sub
+    engine.start();
+
+    engine.unsubscribeAllContracts();
+
+    expect(c1.stopped).toBe(true);
+    expect(c2.stopped).toBe(true);
+    expect(configRegistry(engine).size).toBe(0);
+    expect(engine.status().contractWatcherCount).toBe(0); // legacy gone too
+
+    // Done when: the Horizon stream keeps running and classic subs are untouched.
+    expect(engine.status().running).toBe(true);
+    expect(engine.status().watcherCount).toBe(1);
+    expect(streamInstances).toHaveLength(1);
+  });
+
+  it("emits engine.stopped to config-based watchers before stopping them", () => {
+    const engine = new EventEngine({ network: "testnet" });
+    const watcher = engine.subscribeContract({ filters: [{ contractIds: ["CA"] }] });
+    const stopped = vi.fn();
+    watcher.on("engine.stopped", stopped);
+
+    engine.unsubscribeAllContracts();
+
+    expect(stopped).toHaveBeenCalledOnce();
+    expect(stopped).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "engine.stopped", attempt: 0 }),
+    );
+    expect(watcher.stopped).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Implements **#632 (1.65 — `engine.unsubscribeContract` / `unsubscribeAllContracts`)**.

`subscribeContract(id)` already had `unsubscribeContract(id)` + `unsubscribeAllContracts()` for the legacy id-based registry, but **`subscribeContract(config)` had no inverse** — config-based subscriptions (in `contractConfigRegistry`) couldn't be removed.

## What changed (`EventEngine.ts`)
- **`unsubscribeContract(config)` overload** — computes the same `stableFilterKey(config.filters)` used by `subscribeContract(config)` and stops the matching watcher (its stop handler removes the registry entry). No-op when nothing matches. The legacy `unsubscribeContract(id)` overload is unchanged.
- **`unsubscribeAllContracts()`** now also tears down config-based watchers (emitting `engine.stopped` to each), not just the legacy registry. The Horizon SSE stream and classic subscriptions are left running.

## Done when ✓
- `unsubscribeContract(config)` stops the matching watcher and clears its entry (covered by tests).
- `unsubscribeAllContracts()` leaves the Horizon stream running (`status().running === true`, stream still open, classic watcher registry intact) — covered by a test.

## Tests
New `EventEngine.unsubscribeContract.test.ts`: config-based unsubscribe (stop + entry removal + order-independent matching + only-the-match + no-op), the legacy overload still works, and `unsubscribeAllContracts()` stops config-based watchers while keeping the Horizon stream up.

Full `pulse-core` suite green locally: **478 passed / 6 skipped**; `tsc -p` build, `test:types`, ESLint, and Prettier all clean.

Closes #632
