### PR TITLE
test(pulse-core): real testnet Soroban integration test (#633)

### DIFF
--- a/packages/pulse-core/test/integration/soroban.test.ts
+++ b/packages/pulse-core/test/integration/soroban.test.ts
@@ -1,68 +1,146 @@
-import { expect, describe, it } from "vitest";
-import * as fs from "fs";
-import * as path from "path";
-import { fileURLToPath } from "url";
+import { describe, it, expect, afterEach } from "vitest";
+import {
+  Contract,
+  Keypair,
+  TransactionBuilder,
+  BASE_FEE,
+  Networks,
+  rpc as SorobanRpc,
+} from "@stellar/stellar-sdk";
+import { EventEngine } from "../../src/EventEngine.js";
+import type { ContractEmittedEvent } from "../../src/index.js";
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-
-// Gate the integration execution suite behind the environment variables
+// ── Gating ────────────────────────────────────────────────────────────────────
+// The whole suite is gated behind INTEGRATION_TESTS=true. The live test
+// additionally needs a deployed testnet contract and a funded invoker account
+// (the fixture the maintainer provisions) supplied via env — without them the
+// live case skips with a clear message instead of failing.
 const shouldRun = process.env.INTEGRATION_TESTS === "true";
 
-describe.runIf(shouldRun)("Soroban Testnet Subscriber Integration Suite", () => {
-  it("should deploy or target a testnet contract, invoke it, and receive an event within 2 ledgers", async () => {
-    // Verify fixture file readability
-    const wasmPath = path.join(__dirname, "fixtures", "test-contract.wasm");
-    expect(fs.existsSync(wasmPath)).toBe(true);
+const RPC_URL = process.env.SOROBAN_RPC_URL ?? "https://soroban-testnet.stellar.org";
+const CONTRACT_ID = process.env.SOROBAN_CONTRACT_ID ?? "";
+const INVOKER_SECRET = process.env.SOROBAN_INVOKER_SECRET ?? "";
+// Contract function to invoke; it must emit at least one contract event.
+const CONTRACT_FN = process.env.SOROBAN_CONTRACT_FN ?? "increment";
 
-    const testContractId = "CCJKLMNOPQRSTUVWXYZ1234567890TESTNETCONTRACTIDID";
+const hasConfig = Boolean(CONTRACT_ID && INVOKER_SECRET);
 
-    // Simulate an SDK contract invocation that emits a known contract event
-    const invokeContractAndEmit = async () => {
-      return {
-        txHash: "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f61234",
-        ledger: 10005,
-      };
-    };
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
-    const txResult = await invokeContractAndEmit();
-    expect(txResult.txHash).toBeDefined();
+/**
+ * Invoke a contract function on testnet and return the tx hash + inclusion ledger.
+ */
+async function invokeContract(): Promise<{ txHash: string; ledger: number }> {
+  const server = new SorobanRpc.Server(RPC_URL);
+  const keypair = Keypair.fromSecret(INVOKER_SECRET);
+  const source = await server.getAccount(keypair.publicKey());
+  const contract = new Contract(CONTRACT_ID);
 
-    const receivedEvents: any[] = [];
-    const simulatedLiveSubscriber = {
-      pollOnce: async () => {
-        receivedEvents.push({
-          type: "contract_emitted",
-          id: `${txResult.ledger}-00001`,
-          pagingToken: `${txResult.ledger}-00001`,
-          contractId: testContractId,
-          txHash: txResult.txHash,
-          ledger: txResult.ledger,
-          ledgerClosedAt: new Date().toISOString(),
-          topics: ["transfer"],
-          value: "AAAAEAAAAA5VbW91bnQAAAAAAA==",
-          inSuccessfulContractCall: true,
-          raw: {},
-        });
-      },
-    };
+  const tx = new TransactionBuilder(source, {
+    fee: BASE_FEE,
+    networkPassphrase: Networks.TESTNET,
+  })
+    .addOperation(contract.call(CONTRACT_FN))
+    .setTimeout(60)
+    .build();
 
-    await simulatedLiveSubscriber.pollOnce();
+  const prepared = await server.prepareTransaction(tx);
+  prepared.sign(keypair);
 
-    // Invariant Assertions: Verify an event was emitted and captured within 2 ledgers
-    expect(receivedEvents.length).toBeGreaterThan(0);
+  const sent = await server.sendTransaction(prepared);
+  if (sent.status === "ERROR") {
+    throw new Error(`sendTransaction failed: ${JSON.stringify(sent.errorResult)}`);
+  }
 
-    // Read the first event out of the array accurately
-    const firstEvent = receivedEvents[0];
-    expect(firstEvent.type).toBe("contract_emitted");
-    expect(firstEvent.contractId).toBe(testContractId);
-    expect(firstEvent.txHash).toBe(txResult.txHash);
-    expect(firstEvent.ledger).toBeLessThanOrEqual(txResult.ledger + 2);
+  // Poll until the transaction is confirmed.
+  for (let i = 0; i < 30; i++) {
+    const result = await server.getTransaction(sent.hash);
+    if (result.status !== SorobanRpc.Api.GetTransactionStatus.NOT_FOUND) {
+      if (result.status !== SorobanRpc.Api.GetTransactionStatus.SUCCESS) {
+        throw new Error(`transaction failed with status ${result.status}`);
+      }
+      return { txHash: sent.hash, ledger: result.ledger };
+    }
+    await sleep(1000);
+  }
+  throw new Error("transaction not confirmed within 30s");
+}
+
+/** Resolve once `predicate` returns a value, polling up to `timeoutMs`. */
+async function waitFor<T>(predicate: () => T | undefined, timeoutMs: number): Promise<T> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const value = predicate();
+    if (value !== undefined) return value;
+    await sleep(500);
+  }
+  throw new Error(`waitFor: timed out after ${timeoutMs}ms`);
+}
+
+describe.runIf(shouldRun)("Soroban testnet subscriber — integration", () => {
+  let engine: EventEngine | undefined;
+
+  afterEach(async () => {
+    await engine?.stop();
+    engine = undefined;
   });
+
+  it.runIf(hasConfig)(
+    "delivers a typed contract.emitted event within 2 ledgers of an invocation",
+    async () => {
+      const received: ContractEmittedEvent[] = [];
+
+      engine = new EventEngine({ network: "testnet", soroban: { rpcUrl: RPC_URL } });
+      const watcher = engine.subscribeContract(CONTRACT_ID, {
+        filters: [{ contractIds: [CONTRACT_ID] }],
+      });
+      watcher.on("contract.emitted", (event) => {
+        const e = event as ContractEmittedEvent;
+        if (e.contractId === CONTRACT_ID) received.push(e);
+      });
+
+      engine.start();
+      // Make sure the subscriber is actually polling the contract before invoking.
+      await engine
+        .awaitContractSubscriptionActive({ contractId: CONTRACT_ID }, { timeoutMs: 20_000 })
+        .catch(() => {
+          /* best-effort — fall through to the event wait below */
+        });
+
+      const { txHash, ledger } = await invokeContract();
+
+      // The subscriber must surface the emitted event from our invocation. Match
+      // on tx hash when the RPC provides it, otherwise accept any event from the
+      // contract emitted at/after the invocation ledger.
+      const event = await waitFor(
+        () => received.find((e) => (e.txHash ? e.txHash === txHash : (e.ledger ?? 0) >= ledger)),
+        90_000,
+      );
+
+      expect(event.type).toBe("contract.emitted");
+      expect(event.contractId).toBe(CONTRACT_ID);
+      expect(Array.isArray(event.topics)).toBe(true);
+      // Delivered within 2 ledgers of the invocation.
+      expect(event.ledger).toBeDefined();
+      expect(event.ledger!).toBeLessThanOrEqual(ledger + 2);
+    },
+    120_000,
+  );
+
+  it.skipIf(hasConfig)(
+    "skips the live invocation when SOROBAN_CONTRACT_ID / SOROBAN_INVOKER_SECRET are unset",
+    () => {
+      console.warn(
+        "[soroban integration] live test skipped — set SOROBAN_CONTRACT_ID and " +
+          "SOROBAN_INVOKER_SECRET (a funded testnet account) to run it against a deployed contract.",
+      );
+      expect(hasConfig).toBe(false);
+    },
+  );
 });
 
-describe.skipIf(shouldRun)("Soroban Testnet Subscriber Integration Suite (Skipped)", () => {
-  it("skips test when INTEGRATION_TESTS environment variable is not explicitly active", () => {
-    expect(true).toBe(true);
+describe.skipIf(shouldRun)("Soroban testnet subscriber — integration (gated)", () => {
+  it("skips unless INTEGRATION_TESTS=true", () => {
+    expect(shouldRun).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

Implements **#633 (1.66 — Integration test: subscribe to a deployed testnet contract)**.

The existing `test/integration/soroban.test.ts` was a **placeholder stub** — it simulated the contract id, the invocation, and the "subscriber" (pushing a hardcoded event into an array), so it passed without touching testnet. This replaces it with a **real, env-driven integration test**.

## What it does (under `INTEGRATION_TESTS=true`)
When a deployed contract and a funded invoker are supplied via env, the test:
1. Creates an `EventEngine({ network: "testnet", soroban: { rpcUrl } })` and `subscribeContract` for the contract id (filtered).
2. Waits for the subscription to be polling (`awaitContractSubscriptionActive`), then **invokes the contract** on testnet via `@stellar/stellar-sdk` (build → prepare → sign → send → poll).
3. Asserts a **typed `contract.emitted`** event for that contract is delivered, with `event.ledger ≤ invocationLedger + 2` (within 2 ledgers).

**Env:** `SOROBAN_CONTRACT_ID`, `SOROBAN_INVOKER_SECRET` (funded testnet account), optional `SOROBAN_RPC_URL` (default testnet), `SOROBAN_CONTRACT_FN` (default `increment`).

When those env vars are **absent, the live case skips with a clear message** — so the existing `integration.yml` (runs `test:integration` with `INTEGRATION_TESTS=true` but no Soroban creds) and normal unit runs stay green.

## Done when ✓
- Gated behind `INTEGRATION_TESTS=true`; asserts a typed `contract.emitted` within 2 ledgers of the invocation when a contract + invoker are configured.

## ⚠️ Needs maintainer input to run live
The issue says to "reuse the testnet contract fixture deployed by the maintainer (see `MAINTAINER.md`)" — but **there is no `MAINTAINER.md` in the repo**, and `fixtures/test-contract.wasm` is a **33‑byte placeholder** (`mock-soroban-wasm-payload-bytes`), not a real WASM. So to actually run the live assertion, the maintainer needs to provide a deployed contract id + a funded testnet secret (ideally as CI secrets wired into `integration.yml`). The test is structured to run for real the moment those are set.

## Verification
- `test:types` (tsc) — clean.
- `vitest run` (default) — suite skips (gated): 1 passed, 2 skipped.
- `INTEGRATION_TESTS=true vitest run` (no creds) — live case skips with a clear message: 1 passed, 2 skipped (CI stays green).
- Prettier clean.

Closes #633
