### PR TITLE
feat(pulse-core): LRU dedup window for Soroban events, default 1024 (#635)

### DIFF
--- a/packages/pulse-core/src/SorobanSubscriber.ts
+++ b/packages/pulse-core/src/SorobanSubscriber.ts
@@ -84,7 +84,12 @@ export interface SorobanSubscriberOptions {
   pageLimit?: number;
   /** @deprecated Alias for {@link SorobanSubscriberOptions.pageLimit}. */
   pageSize?: number;
-  /** Max distinct event IDs remembered for cross-poll de-duplication. Defaults to 10,000. */
+  /**
+   * Size of the LRU window of recent event IDs used for cross-poll
+   * de-duplication. Within this window a repeated event ID (e.g. the same page
+   * re-returned under retry) is suppressed, so downstream consumers see each
+   * event exactly once. Defaults to 1024.
+   */
   dedupCacheSize?: number;
   /** Interval for the self-driving {@link SorobanSubscriber.start} poll loop. Defaults to 2000ms. */
   pollIntervalMs?: number;
@@ -104,7 +109,7 @@ export interface SorobanSubscriberOptions {
 const MIN_PAGE_LIMIT = 1;
 const MAX_PAGE_LIMIT = 10_000;
 const DEFAULT_PAGE_LIMIT = 100;
-const DEFAULT_DEDUP_CACHE_SIZE = 10_000;
+const DEFAULT_DEDUP_CACHE_SIZE = 1024;
 
 export class SorobanSubscriber extends EventEmitter {
   private readonly rpc: SorobanRpc;
@@ -132,7 +137,12 @@ export class SorobanSubscriber extends EventEmitter {
   subscriptions: SorobanSubscription[] = [];
 
   // --- Cross-poll de-duplication state ---
-  /** Insertion-ordered set of recently-delivered event IDs (bounded FIFO window). */
+  /**
+   * LRU window of recently-delivered event IDs (insertion order = recency).
+   * Re-seeing an ID refreshes its recency; once the window exceeds
+   * `dedupCacheSize` the least-recently-used ID is evicted. Guarantee: an event
+   * ID is delivered downstream at most once while it remains in this window.
+   */
   private readonly seen = new Set<string>();
   private readonly dedupCacheSize: number;
 
@@ -437,8 +447,12 @@ export class SorobanSubscriber extends EventEmitter {
           }
         }
 
-        // Cross-poll de-duplication: suppress IDs we've already delivered.
-        if (this.seen.has(event.id)) continue;
+        // Cross-poll de-duplication: suppress IDs we've already delivered, and
+        // refresh their recency so a repeated ID stays alive in the LRU window.
+        if (this.seen.has(event.id)) {
+          this.touchSeen(event.id);
+          continue;
+        }
 
         // Deliver before recording so a throwing handler leaves the ID
         // un-recorded (and therefore re-deliverable on a later poll).
@@ -529,14 +543,24 @@ export class SorobanSubscriber extends EventEmitter {
     });
   }
 
-  /** Records a delivered event ID, evicting the oldest entries past the cap. */
+  /**
+   * Records a delivered event ID at the most-recently-used end of the LRU
+   * window, evicting the least-recently-used IDs once the cap is exceeded.
+   */
   private recordSeen(id: string): void {
+    // Re-insert so the ID moves to the MRU position even if already present.
+    this.seen.delete(id);
     this.seen.add(id);
     while (this.seen.size > this.dedupCacheSize) {
-      const oldest = this.seen.values().next().value;
-      if (oldest === undefined) break;
-      this.seen.delete(oldest);
+      const lru = this.seen.values().next().value;
+      if (lru === undefined) break;
+      this.seen.delete(lru);
     }
+  }
+
+  /** Marks an already-seen ID as most-recently-used (LRU touch on a dedup hit). */
+  private touchSeen(id: string): void {
+    if (this.seen.delete(id)) this.seen.add(id);
   }
 
   /** Schedules a single deferred re-poll using the injectable timer. */

--- a/packages/pulse-core/test/SorobanSubscriber.dedup.test.ts
+++ b/packages/pulse-core/test/SorobanSubscriber.dedup.test.ts
@@ -228,4 +228,46 @@ describe("SorobanSubscriber – deduplication", () => {
     expect(emitted).toHaveLength(10);
     expect(emitted.map((e) => e.id)).toEqual(page.map((e) => e.id));
   });
+
+  // ── 8. True LRU semantics ───────────────────────────────────────────────
+
+  it("refreshes recency on a repeat so a re-seen ID survives eviction (LRU, not FIFO)", async () => {
+    // cap=3, fill with a,b,c (a is least-recently-used).
+    const sub = makeSubscriber(3);
+
+    stub.page = [makeEvent("a"), makeEvent("b"), makeEvent("c")];
+    await sub.pollOnce(); // window: a(lru) b c(mru)
+
+    stub.page = [makeEvent("a")];
+    await sub.pollOnce(); // dedup hit on "a" refreshes it → b becomes the LRU
+
+    stub.page = [makeEvent("d")];
+    await sub.pollOnce(); // "d" added → evicts the LRU ("b"), "a" survives
+
+    stub.page = [makeEvent("a")]; // still in the window → suppressed
+    await sub.pollOnce();
+
+    stub.page = [makeEvent("b")]; // was evicted → emitted again
+    await sub.pollOnce();
+
+    // Under FIFO "a" would have been evicted by "d" and re-emitted; under LRU the
+    // refresh keeps "a" and evicts "b" instead.
+    expect(emitted.map((e) => e.id)).toEqual(["a", "b", "c", "d", "b"]);
+  });
+
+  it("uses a default dedup window of 1024", async () => {
+    const sub = makeSubscriber(); // default cap
+
+    // 1025 distinct events — adding the 1025th evicts the first.
+    stub.page = Array.from({ length: 1025 }, (_, i) => makeEvent(`d-${i}`));
+    await sub.pollOnce();
+    expect(emitted).toHaveLength(1025);
+
+    // The first ID fell out of the window (re-emittable); the last is still in it.
+    stub.page = [makeEvent("d-0"), makeEvent("d-1024")];
+    await sub.pollOnce();
+
+    expect(emitted.filter((e) => e.id === "d-0")).toHaveLength(2); // evicted → re-emitted
+    expect(emitted.filter((e) => e.id === "d-1024")).toHaveLength(1); // suppressed
+  });
 });


### PR DESCRIPTION
## Summary

Implements **#635 (1.68 — duplicate event dedup via LRU)**.

The SorobanSubscriber already de-duplicated events across polls, but with a **FIFO** `Set` (default 10,000). Under retry the same event ID can reappear far apart; a FIFO window can evict an ID that is still actively being re-seen. This converts it to a **true LRU**.

## What changed (`SorobanSubscriber.ts`)
- **LRU window** — re-seeing an ID now **refreshes its recency** (`touchSeen`, on a dedup hit), and `recordSeen` evicts the **least-recently-used** ID when the cap is exceeded. A frequently-repeated ID therefore stays de-duplicated instead of aging out by insertion order.
- **Default 1024** — `DEFAULT_DEDUP_CACHE_SIZE` is now 1024 (was 10,000), per the issue. Still overridable via `dedupCacheSize`.
- **Docs** — the `dedupCacheSize` option, the `seen` field, and `recordSeen`/`touchSeen` now document the cap and the dedup-window guarantee: *an event ID is delivered downstream at most once while it remains in the window.*

## Done when ✓
- Replaying the same page twice produces each event exactly once downstream (existing + new tests).

## Tests (`SorobanSubscriber.dedup.test.ts`)
Kept the existing coverage and added two LRU-specific cases:
- **Refresh-on-repeat (LRU, not FIFO)** — re-seeing an ID keeps it and evicts a different, less-recently-used ID; the assertion fails under the old FIFO behaviour.
- **Default window is 1024** — 1025 distinct IDs evict the first (re-emittable) while the newest stays suppressed.

## Verification
- `tsc -p` build + `test:types` — clean.
- `vitest` dedup file — 11/11; full `pulse-core` suite green: **480 passed / 7 skipped**.
- Prettier + ESLint clean.

Closes #635
