### PR TITLE
[codex] Configure Soroban poll page limit

### DIFF
--- a/packages/pulse-core/src/EventEngine.ts
+++ b/packages/pulse-core/src/EventEngine.ts
@@ -1,7 +1,7 @@
 import { Horizon } from "@stellar/stellar-sdk";
 import { Watcher } from "./Watcher.js";
 import { EngineAlreadyStartedError, NetworkMismatchError } from "./errors.js";
-import { SorobanSubscriber } from "./SorobanSubscriber.js";
+import { resolveSorobanPageLimit, SorobanSubscriber } from "./SorobanSubscriber.js";
 import { SorobanRpcClient } from "./SorobanRpcClient.js";
 import type { SorobanRpcLike, SorobanEvent } from "./SorobanSubscriber.js";
 import { toAccountAddress, toContractAddress } from "./address.js";
@@ -176,6 +176,7 @@ export class EventEngine {
   private log: Logger;
   private cursorStore?: CursorStoreLike;
   private readonly network: Network;
+  private readonly sorobanPageLimit: number;
   private streamKey: string;
   private streamEpoch = 0;
   private cursorFailureThreshold: number;
@@ -205,6 +206,8 @@ export class EventEngine {
       };
     },
   ) {
+    this.sorobanPageLimit = resolveSorobanPageLimit(config.soroban?.pageLimit);
+
     let horizonUrl: string;
     if (config.horizonUrl !== undefined) {
       try {
@@ -526,7 +529,7 @@ export class EventEngine {
       onEvent: options.onEvent,
       endLedger: options.endLedger,
       onDone: options.onDone,
-      pageSize: options.pageSize,
+      pageLimit: options.pageSize ?? this.sorobanPageLimit,
     });
 
     return subscriber;

--- a/packages/pulse-core/src/SorobanSubscriber.ts
+++ b/packages/pulse-core/src/SorobanSubscriber.ts
@@ -111,6 +111,17 @@ const MAX_PAGE_LIMIT = 10_000;
 const DEFAULT_PAGE_LIMIT = 100;
 const DEFAULT_DEDUP_CACHE_SIZE = 1024;
 
+/** @internal Resolve and validate the pagination limit used by Soroban polls. */
+export function resolveSorobanPageLimit(pageLimit?: number): number {
+  const resolved = pageLimit ?? DEFAULT_PAGE_LIMIT;
+  if (!Number.isInteger(resolved) || resolved < MIN_PAGE_LIMIT || resolved > MAX_PAGE_LIMIT) {
+    throw new RangeError(
+      `soroban.pageLimit must be an integer between 1 and 10,000 (received ${resolved})`,
+    );
+  }
+  return resolved;
+}
+
 export class SorobanSubscriber extends EventEmitter {
   private readonly rpc: SorobanRpc;
   private readonly cursorStore: CursorStore;
@@ -173,10 +184,7 @@ export class SorobanSubscriber extends EventEmitter {
 
   constructor(options: SorobanSubscriberOptions) {
     super();
-    const pageLimit = options.pageLimit ?? options.pageSize ?? DEFAULT_PAGE_LIMIT;
-    if (!Number.isFinite(pageLimit) || pageLimit < MIN_PAGE_LIMIT || pageLimit > MAX_PAGE_LIMIT) {
-      throw new RangeError(`pageLimit must be between 1 and 10,000 (received ${pageLimit})`);
-    }
+    const pageLimit = resolveSorobanPageLimit(options.pageLimit ?? options.pageSize);
 
     this.rpc = options.rpc;
     this.cursorStore = options.cursorStore;
@@ -376,7 +384,7 @@ export class SorobanSubscriber extends EventEmitter {
           this.emit("engine.cursor_expired", { source: "soroban", lostCursor });
 
           try {
-            const fallbackPage = await this.rpc.getEvents(undefined, 1, signal);
+            const fallbackPage = await this.rpc.getEvents(undefined, this.pageLimit, signal);
             const latestLedger = fallbackPage.latestLedger;
             if (latestLedger !== undefined) {
               console.warn(

--- a/packages/pulse-core/src/index.ts
+++ b/packages/pulse-core/src/index.ts
@@ -453,6 +453,14 @@ export interface AbiRegistryClientLike {
   getSpec(contractId: string): Promise<unknown>;
 }
 
+export type SorobanConfig = {
+  /**
+   * Pagination limit for each Soroban RPC `getEvents` call.
+   * Must be an integer from 1 through 10,000. Defaults to 100.
+   */
+  pageLimit?: number;
+};
+
 export type CoreConfig = {
   /** The Stellar network to connect to. */
   network: Network;
@@ -470,10 +478,7 @@ export type CoreConfig = {
   /** Optional ABI registry client used to enrich `contract.emitted` events with `decodedData`. */
   abiRegistry?: AbiRegistryClientLike;
   /** Soroban RPC configuration. */
-  soroban?: {
-    /** Pagination limit for RPC `getEvents` calls. Must be 1–10,000. Defaults to 100. */
-    pageLimit?: number;
-  };
+  soroban?: SorobanConfig;
 };
 
 // Error class for invalid network validation

--- a/packages/pulse-core/test/SorobanSubscriber.cursorExpired.test.ts
+++ b/packages/pulse-core/test/SorobanSubscriber.cursorExpired.test.ts
@@ -15,9 +15,11 @@ class MemoryCursorStore {
 describe("SorobanSubscriber — cursor expiration", () => {
   it("catches out-of-range cursor, emits engine.cursor_expired, and sets startLedger", async () => {
     let calls = 0;
+    const limits: number[] = [];
     const rpc = {
-      getEvents: async (startCursor: string | undefined) => {
+      getEvents: async (startCursor: string | undefined, limit: number) => {
         calls++;
+        limits.push(limit);
         if (calls === 1 && startCursor === "old-cursor") {
           throw new SorobanRpcError("startCursor is before oldest ledger", {
             code: "invalid_request",
@@ -32,6 +34,7 @@ describe("SorobanSubscriber — cursor expiration", () => {
     const subscriber = new SorobanSubscriber({
       rpc: rpc as any,
       cursorStore,
+      pageLimit: 250,
       setTimeoutFn: (cb: any) => {
         cb();
         return {} as any;
@@ -55,6 +58,7 @@ describe("SorobanSubscriber — cursor expiration", () => {
       expect(emitted[0]).toEqual({ source: "soroban", lostCursor: "old-cursor" });
       expect(cursorStore.cursor).toBe("999999");
       expect(calls).toBe(2); // Initial poll + fallback poll for latestLedger
+      expect(limits).toEqual([250, 250]);
     } finally {
       console.warn = originalWarn;
     }

--- a/packages/pulse-core/test/SorobanSubscriber.pageLimit.test.ts
+++ b/packages/pulse-core/test/SorobanSubscriber.pageLimit.test.ts
@@ -15,6 +15,7 @@ import {
   type SorobanRpcLike,
   type CursorStoreLike,
 } from "../src/SorobanSubscriber.js";
+import { EventEngine } from "../src/EventEngine.js";
 
 // ---------------------------------------------------------------------------
 // Test helpers
@@ -204,7 +205,18 @@ describe("SorobanSubscriber – pagination limit", () => {
         onEvent: async () => {},
         pageLimit: 50000,
       });
-    }).toThrow(/pageLimit must be between 1 and 10,000/);
+    }).toThrow(/soroban\.pageLimit must be an integer between 1 and 10,000/);
+  });
+
+  it("rejects a non-integer pageLimit", () => {
+    expect(
+      () =>
+        new SorobanSubscriber({
+          rpc: stub,
+          cursorStore,
+          pageLimit: 1.5,
+        }),
+    ).toThrow(/soroban\.pageLimit must be an integer between 1 and 10,000/);
   });
 
   // ── 9. pageLimit works with multiple events ─────────────────────────────
@@ -228,5 +240,36 @@ describe("SorobanSubscriber – pagination limit", () => {
 
     expect(stub.recordedLimits).toEqual([7500]);
     expect(emitted).toHaveLength(3);
+  });
+
+  it("validates CoreConfig.soroban.pageLimit at EventEngine construction", () => {
+    expect(
+      () =>
+        new EventEngine({
+          network: "testnet",
+          soroban: { rpcUrl: "https://soroban-rpc.example.com", pageLimit: 0 },
+        }),
+    ).toThrow(/soroban\.pageLimit must be an integer between 1 and 10,000/);
+  });
+
+  it("passes CoreConfig.soroban.pageLimit through to Soroban replay polls", async () => {
+    const engine = new EventEngine({
+      network: "testnet",
+      soroban: { rpcUrl: "https://soroban-rpc.example.com", pageLimit: 4321 },
+    });
+    const subscriber = engine.replayContracts({
+      rpc: stub,
+      startLedger: 1,
+      endLedger: 100,
+      onEvent: async () => {},
+      onDone: () => {},
+    });
+
+    stub.page = [makeEvent("evt-1", "tok-1")];
+    await subscriber.pollOnce();
+    stub.page = [makeEvent("evt-2", "tok-2")];
+    await subscriber.pollOnce();
+
+    expect(stub.recordedLimits).toEqual([4321, 4321]);
   });
 });


### PR DESCRIPTION
## What changed

- validates `CoreConfig.soroban.pageLimit` as an integer from 1 to 10,000 during engine construction
- passes the configured limit into Soroban subscribers and every `getEvents` request, including cursor-expiry recovery
- adds regression coverage for repeated polls, CoreConfig pass-through, invalid values, and recovery polling

## Why

Soroban polling previously exposed a page-limit type but did not wire the CoreConfig value through at runtime, and recovery silently used a hardcoded limit.

## Validation

- Prettier check: passed
- `git diff --check`: passed
- Focused Vitest/typecheck: blocked locally because pnpm populated the virtual store but did not complete dependency linking (`rollup`, `@stellar/stellar-sdk`, and Node types remain unresolved)

Closes #628