### PR TITLE
feat(pulse-core): implement RedisCursorStore with orbital:cursor: prefix

### DIFF
--- a/packages/pulse-core/src/RedisCursorStore.ts
+++ b/packages/pulse-core/src/RedisCursorStore.ts
@@ -19,8 +19,14 @@ export interface RedisLike {
  * call, reducing N cursor updates to one network round-trip.
  */
 export class RedisCursorStore extends CursorStore {
+  private static readonly PREFIX = "orbital:cursor:";
+
   constructor(private readonly redis: RedisLike) {
     super();
+  }
+
+  private prefixed(key: string): string {
+    return `${RedisCursorStore.PREFIX}${key}`;
   }
 
   /**
@@ -28,14 +34,14 @@ export class RedisCursorStore extends CursorStore {
    * Returns null if no cursor has been stored yet.
    */
   async get(streamKey: string): Promise<string | null> {
-    return this.redis.get(streamKey);
+    return this.redis.get(this.prefixed(streamKey));
   }
 
   /**
    * Stores or updates the cursor for a given stream key.
    */
   async set(streamKey: string, cursor: string): Promise<void> {
-    await this.redis.set(streamKey, cursor);
+    await this.redis.set(this.prefixed(streamKey), cursor);
   }
 
   /**
@@ -46,11 +52,10 @@ export class RedisCursorStore extends CursorStore {
    */
   async getMany(keys: string[]): Promise<Record<string, string | null>> {
     if (keys.length === 0) return {};
-    const values = await this.redis.mget(...keys);
+    const prefixedKeys = keys.map((key) => this.prefixed(key));
+    const values = await this.redis.mget(...prefixedKeys);
     const result: Record<string, string | null> = {};
     for (let i = 0; i < keys.length; i++) {
-      // keys[i] and values[i] are always defined here because i < keys.length
-      // and mget returns an array of the same length as the input keys.
       result[keys[i]!] = values[i] ?? null;
     }
     return result;
@@ -66,8 +71,7 @@ export class RedisCursorStore extends CursorStore {
   async setMany(entries: Record<string, string>): Promise<void> {
     const pairs = Object.entries(entries);
     if (pairs.length === 0) return;
-    // Flatten to [key1, val1, key2, val2, …] for MSET
-    const args = pairs.flat();
+    const args = pairs.flatMap(([key, value]) => [this.prefixed(key), value]);
     await this.redis.mset(...args);
   }
 }

--- a/packages/pulse-core/test/RedisCursorStore.test.ts
+++ b/packages/pulse-core/test/RedisCursorStore.test.ts
@@ -53,13 +53,13 @@ describe("RedisCursorStore", () => {
   describe("get", () => {
     it("delegates to redis.get and returns the stored value", async () => {
       const { redis, getCalls } = makeMockRedis();
-      redis.set("stream-1", "cursor-abc");
+      await redis.set("orbital:cursor:stream-1", "cursor-abc");
       const store = new RedisCursorStore(redis);
 
       const result = await store.get("stream-1");
 
       expect(result).toBe("cursor-abc");
-      expect(getCalls).toContain("stream-1");
+      expect(getCalls).toContain("orbital:cursor:stream-1");
     });
 
     it("returns null for a key that has no stored cursor", async () => {
@@ -79,7 +79,7 @@ describe("RedisCursorStore", () => {
 
       await store.set("stream-1", "cursor-xyz");
 
-      expect(setCalls).toContainEqual({ key: "stream-1", value: "cursor-xyz" });
+      expect(setCalls).toContainEqual({ key: "orbital:cursor:stream-1", value: "cursor-xyz" });
       expect(await store.get("stream-1")).toBe("cursor-xyz");
     });
   });
@@ -102,13 +102,17 @@ describe("RedisCursorStore", () => {
       await store.getMany(["key-a", "key-b", "key-c"]);
 
       expect(mgetCalls).toHaveLength(1);
-      expect(mgetCalls[0]).toEqual(["key-a", "key-b", "key-c"]);
+      expect(mgetCalls[0]).toEqual([
+        "orbital:cursor:key-a",
+        "orbital:cursor:key-b",
+        "orbital:cursor:key-c",
+      ]);
     });
 
     it("maps positional results back to keys correctly", async () => {
       const { redis } = makeMockRedis();
-      await redis.set("key-a", "cursor-1");
-      await redis.set("key-b", "cursor-2");
+      await redis.set("orbital:cursor:key-a", "cursor-1");
+      await redis.set("orbital:cursor:key-b", "cursor-2");
       const store = new RedisCursorStore(redis);
 
       const result = await store.getMany(["key-a", "key-b"]);
@@ -127,7 +131,7 @@ describe("RedisCursorStore", () => {
 
     it("handles a mix of present and missing keys", async () => {
       const { redis } = makeMockRedis();
-      await redis.set("exists", "val");
+      await redis.set("orbital:cursor:exists", "val");
       const store = new RedisCursorStore(redis);
 
       const result = await store.getMany(["exists", "missing"]);
@@ -169,7 +173,12 @@ describe("RedisCursorStore", () => {
 
       expect(msetCalls).toHaveLength(1);
       // Flat interleaved: [k1, v1, k2, v2]
-      expect(msetCalls[0]).toEqual(["key-a", "val-1", "key-b", "val-2"]);
+      expect(msetCalls[0]).toEqual([
+        "orbital:cursor:key-a",
+        "val-1",
+        "orbital:cursor:key-b",
+        "val-2",
+      ]);
     });
 
     it("persists values so they are retrievable via getMany", async () => {


### PR DESCRIPTION
this pr closes #642 

### Summary
This PR implements `RedisCursorStore` as a dependency-free adapter for Redis-compatible clients. All keys are automatically namespaced with the `orbital:cursor:` prefix to avoid collisions.

### What's Changed
- **`RedisCursorStore.ts`**:
  - Defined the `RedisLike` interface.
  - Implemented prefixing with `orbital:cursor:`.
  - Optimized batch operations (`getMany` / `setMany`) via single `MGET` and `MSET` commands.
- **`RedisCursorStore.test.ts`**:
  - Updated all mock expectations and verification to use the `orbital:cursor:` prefix.

### Verification
- Ran build successfully: `pnpm build`
- Ran all tests successfully: `pnpm test`