### PR TITLE
[codex] Soroban start-ledger cursor polling

### DIFF
--- a/packages/pulse-core/src/EventEngine.ts
+++ b/packages/pulse-core/src/EventEngine.ts
@@ -196,16 +196,7 @@ export class EventEngine {
    * Creates a new EventEngine instance.
    * @param config - The core configuration for the engine.
    */
-  constructor(
-    config: CoreConfig & {
-      soroban?: {
-        rpcUrl: string;
-        rpcHeaders?: Record<string, string>;
-        pollIntervalMs?: number;
-        startLedgerLookback?: number;
-      };
-    },
-  ) {
+  constructor(config: CoreConfig) {
     this.sorobanPageLimit = resolveSorobanPageLimit(config.soroban?.pageLimit);
 
     let horizonUrl: string;
@@ -237,6 +228,38 @@ export class EventEngine {
     this.abiRegistry = config.abiRegistry;
     this.cursorStore = config.cursorStore;
     this.network = config.network;
+
+    if (config.soroban) {
+      const rpc = new SorobanRpcClient({
+        url: config.soroban.rpcUrl,
+        headers: config.soroban.rpcHeaders,
+        logger: this.log,
+      });
+      const sorobanCursorKey = `${this.streamKey}:soroban`;
+      let inMemoryCursor: string | undefined;
+      const cursorStore = {
+        getCursor: async (): Promise<string | undefined> => {
+          if (!this.cursorStore) return inMemoryCursor;
+          return (await this.cursorStore.get(sorobanCursorKey)) ?? undefined;
+        },
+        saveCursor: async (cursor: string): Promise<void> => {
+          if (!this.cursorStore) {
+            inMemoryCursor = cursor;
+            return;
+          }
+          await this.cursorStore.set(sorobanCursorKey, cursor);
+        },
+      };
+
+      this.sorobanSubscriber = new SorobanSubscriber({
+        rpc: rpc as unknown as SorobanRpcLike,
+        cursorStore,
+        pollIntervalMs: config.soroban.pollIntervalMs,
+        startLedgerLookback: config.soroban.startLedgerLookback,
+        pageLimit: config.soroban.pageLimit,
+        onEvent: async (event) => this.handleSorobanEvent(event),
+      });
+    }
   }
 
   /**
@@ -529,6 +552,7 @@ export class EventEngine {
       onEvent: options.onEvent,
       endLedger: options.endLedger,
       onDone: options.onDone,
+      startLedger: options.startLedger,
       pageLimit: options.pageSize ?? this.sorobanPageLimit,
     });
 
@@ -598,7 +622,7 @@ export class EventEngine {
     }
 
     this.openStream(false);
-    if (this.contractRegistry.size > 0 && this.sorobanSubscriber) {
+    if (this.sorobanSubscriber) {
       this.sorobanSubscriber.start();
     }
     return true;
@@ -1640,6 +1664,51 @@ export class EventEngine {
         error: err,
       });
       return false;
+    }
+  }
+
+  /** Converts a polled Soroban RPC event into the public normalized event shape. */
+  private handleSorobanEvent(event: SorobanEvent): void {
+    if (!event.contractId) {
+      this.log.warn("[pulse-core] Dropping Soroban event without a contractId.", {
+        eventId: event.id,
+      });
+      return;
+    }
+
+    const timestamp = event.ledgerClosedAt ?? new Date().toISOString();
+    if (event.type === "contract.invoked") {
+      this.route(
+        withTimestampDate({
+          type: "contract.invoked",
+          contractId: toContractAddress(event.contractId),
+          function: event.function ?? "",
+          args: event.args ?? [],
+          ...(event.ledger !== undefined ? { ledger: event.ledger } : {}),
+          ...(event.txHash !== undefined ? { txHash: event.txHash } : {}),
+          timestamp,
+          raw: event as RawSorobanEvent,
+        }),
+      );
+      return;
+    }
+
+    if (event.type === "contract.emitted") {
+      this.route(
+        withTimestampDate({
+          type: "contract.emitted",
+          contractId: toContractAddress(event.contractId),
+          topics: event.topic,
+          data: event.decodedData ?? event.value,
+          decodedData: event.decodedData,
+          ...(event.ledger !== undefined ? { ledger: event.ledger } : {}),
+          eventId: event.id,
+          ...(event.txHash !== undefined ? { txHash: event.txHash } : {}),
+          inSuccessfulContractCall: event.inSuccessfulContractCall ?? false,
+          timestamp,
+          raw: event as RawSorobanEvent,
+        }),
+      );
     }
   }
 

--- a/packages/pulse-core/src/SorobanRpcClient.ts
+++ b/packages/pulse-core/src/SorobanRpcClient.ts
@@ -54,6 +54,10 @@ export type SorobanGetEventsParams = {
   startCursor?: string;
   filters?: SorobanEventFilter[] | ContractSubscriptionFilter[];
   limit?: number;
+  pagination?: {
+    cursor?: string;
+    limit?: number;
+  };
   xdrFormat?: SorobanEventXdrFormat;
 };
 

--- a/packages/pulse-core/src/SorobanSubscriber.ts
+++ b/packages/pulse-core/src/SorobanSubscriber.ts
@@ -1,4 +1,9 @@
 import type { ContractSubscriptionFilter, ContractAddress } from "./index.js";
+import type {
+  SorobanGetEventsParams,
+  SorobanGetEventsResult,
+  SorobanRpcCallOptions,
+} from "./SorobanRpcClient.js";
 import { SorobanRpcError } from "./errors.js";
 import { EventEmitter } from "events";
 
@@ -34,6 +39,12 @@ export interface SorobanEvent {
   contractId?: string;
   type?: string;
   decodedData?: unknown;
+  ledger?: number;
+  ledgerClosedAt?: string;
+  txHash?: string;
+  inSuccessfulContractCall?: boolean;
+  function?: string;
+  args?: unknown[];
 }
 
 /** Minimal interface for a Soroban RPC client. */
@@ -45,6 +56,7 @@ export interface SorobanRpc {
     filters?: ContractSubscriptionFilter[],
     options?: { xdrFormat?: "base64" | "json"; signal?: AbortSignal } | AbortSignal,
   ): Promise<{ events: SorobanEvent[]; [key: string]: any }>;
+  getLatestLedger?(options?: SorobanRpcCallOptions): Promise<number>;
 }
 
 /** Alias for {@link SorobanRpc}; the name used by EventEngine's replay API. */
@@ -93,6 +105,10 @@ export interface SorobanSubscriberOptions {
   dedupCacheSize?: number;
   /** Interval for the self-driving {@link SorobanSubscriber.start} poll loop. Defaults to 2000ms. */
   pollIntervalMs?: number;
+  /** Explicit ledger for the first poll. Primarily used by bounded replay. */
+  startLedger?: number;
+  /** Ledgers subtracted from `getLatestLedger()` for the first live poll. Defaults to 0. */
+  startLedgerLookback?: number;
   /** Delay before retrying after a retryable RPC error. Defaults to 1000ms. */
   retryDelayMs?: number;
   /** Injectable timer scheduler (for testing). Defaults to `globalThis.setTimeout`. */
@@ -171,6 +187,8 @@ export class SorobanSubscriber extends EventEmitter {
   private _isRunning = false;
   private pollTimer: ReturnType<typeof setInterval> | null = null;
   private readonly pollIntervalMs: number;
+  private startLedger: number | undefined;
+  private readonly startLedgerLookback: number;
   /** ISO timestamp of the most recently delivered event, or null. */
   lastEventAt: string | null = null;
 
@@ -185,6 +203,24 @@ export class SorobanSubscriber extends EventEmitter {
   constructor(options: SorobanSubscriberOptions) {
     super();
     const pageLimit = resolveSorobanPageLimit(options.pageLimit ?? options.pageSize);
+    const pollIntervalMs = options.pollIntervalMs ?? 2000;
+    if (!Number.isFinite(pollIntervalMs) || pollIntervalMs <= 0) {
+      throw new RangeError(`pollIntervalMs must be greater than 0 (received ${pollIntervalMs})`);
+    }
+    const startLedgerLookback = options.startLedgerLookback ?? 0;
+    if (!Number.isInteger(startLedgerLookback) || startLedgerLookback < 0) {
+      throw new RangeError(
+        `startLedgerLookback must be a non-negative integer (received ${startLedgerLookback})`,
+      );
+    }
+    if (
+      options.startLedger !== undefined &&
+      (!Number.isInteger(options.startLedger) || options.startLedger < 0)
+    ) {
+      throw new RangeError(
+        `startLedger must be a non-negative integer (received ${options.startLedger})`,
+      );
+    }
 
     this.rpc = options.rpc;
     this.cursorStore = options.cursorStore;
@@ -194,7 +230,9 @@ export class SorobanSubscriber extends EventEmitter {
     this.dedupCacheSize = options.dedupCacheSize ?? DEFAULT_DEDUP_CACHE_SIZE;
     this.endLedger = options.endLedger;
     this.onDone = options.onDone;
-    this.pollIntervalMs = options.pollIntervalMs ?? 2000;
+    this.pollIntervalMs = pollIntervalMs;
+    this.startLedger = options.startLedger;
+    this.startLedgerLookback = startLedgerLookback;
     this.retryDelayMs = options.retryDelayMs ?? 1000;
     this.setTimeoutFn = options.setTimeoutFn ?? globalThis.setTimeout;
     this.clearTimeoutFn = options.clearTimeoutFn ?? globalThis.clearTimeout;
@@ -218,6 +256,7 @@ export class SorobanSubscriber extends EventEmitter {
    */
   start(): void {
     if (this._isRunning) return;
+    this.isStopped = false;
     this._isRunning = true;
     const tick = () => {
       this.inflightPoll = (this.inflightPoll ?? Promise.resolve()).then(() => this.pollOnce());
@@ -355,21 +394,18 @@ export class SorobanSubscriber extends EventEmitter {
       ? this.replayCursor
       : await this.cursorStore.getCursor();
 
-    const promises = rpcCalls.map((filters) =>
-      this.rpc.getEvents(
-        currentCursor,
-        this.pageLimit,
-        signal,
-        filters.length > 0 ? filters : undefined,
-        {
-          xdrFormat: this.xdrFormat,
-          signal,
-        },
-      ),
-    );
-
-    let results: { events: SorobanEvent[]; latestLedger?: number }[];
+    let results: { events: SorobanEvent[]; latestLedger?: number; cursor?: string }[];
     try {
+      if (
+        currentCursor === undefined &&
+        this.startLedger === undefined &&
+        this.rpc.getLatestLedger !== undefined
+      ) {
+        const latestLedger = await this.rpc.getLatestLedger({ signal });
+        this.startLedger = Math.max(0, latestLedger - this.startLedgerLookback);
+      }
+
+      const promises = rpcCalls.map((filters) => this.fetchEvents(currentCursor, filters, signal));
       results = await Promise.all(promises);
     } catch (err) {
       // An aborted request is expected during shutdown — swallow it silently.
@@ -467,12 +503,16 @@ export class SorobanSubscriber extends EventEmitter {
         await this.dispatch(event);
         this.lastEventAt = new Date().toISOString();
         this.recordSeen(event.id);
+      }
 
+      const responseCursor = results.find((result) => result.cursor !== undefined)?.cursor;
+      const fallbackCursor = uniqueEvents[uniqueEvents.length - 1]?.pagingToken;
+      const nextCursor = responseCursor ?? fallbackCursor;
+      if (nextCursor !== undefined) {
         if (this.isReplayMode) {
-          // Replay progress is ephemeral and must never touch the durable store.
-          this.replayCursor = event.pagingToken;
+          this.replayCursor = nextCursor;
         } else {
-          await this.cursorStore.saveCursor(event.pagingToken);
+          await this.cursorStore.saveCursor(nextCursor);
         }
       }
     } finally {
@@ -488,7 +528,13 @@ export class SorobanSubscriber extends EventEmitter {
    *   filters match the event, falling back to the constructor `onEvent`.
    */
   private async dispatch(event: SorobanEvent): Promise<void> {
-    const eventToEmit = { ...event };
+    const normalizedType =
+      event.type === "contract"
+        ? "contract.emitted"
+        : event.type === "system" || event.type === "diagnostic"
+          ? "contract.invoked"
+          : event.type;
+    const eventToEmit = { ...event, type: normalizedType };
     if (this.xdrFormat === "json") {
       eventToEmit.decodedData = event.value;
     }
@@ -504,6 +550,50 @@ export class SorobanSubscriber extends EventEmitter {
         if (handler) await handler(eventToEmit);
       }
     }
+  }
+
+  /** Fetch one page using modern start-ledger/cursor pagination when supported. */
+  private async fetchEvents(
+    currentCursor: string | undefined,
+    filters: ContractSubscriptionFilter[],
+    signal: AbortSignal,
+  ): Promise<{ events: SorobanEvent[]; latestLedger?: number; cursor?: string }> {
+    if (this.rpc.getLatestLedger !== undefined) {
+      const pagination: NonNullable<SorobanGetEventsParams["pagination"]> = {
+        limit: this.pageLimit,
+      };
+      const params: SorobanGetEventsParams = {
+        ...(filters.length > 0 ? { filters } : {}),
+        pagination,
+        xdrFormat: this.xdrFormat,
+      };
+
+      if (currentCursor !== undefined) {
+        pagination.cursor = currentCursor;
+      } else if (this.startLedger !== undefined) {
+        params.startLedger = this.startLedger;
+      }
+
+      const rpc = this.rpc as unknown as {
+        getEvents(
+          params: SorobanGetEventsParams,
+          options?: SorobanRpcCallOptions,
+        ): Promise<SorobanGetEventsResult>;
+      };
+      return (await rpc.getEvents(params, { signal })) as {
+        events: SorobanEvent[];
+        latestLedger?: number;
+        cursor?: string;
+      };
+    }
+
+    return this.rpc.getEvents(
+      currentCursor,
+      this.pageLimit,
+      signal,
+      filters.length > 0 ? filters : undefined,
+      { xdrFormat: this.xdrFormat, signal },
+    );
   }
 
   /** True when any of the subscription's filters matches the event. */

--- a/packages/pulse-core/src/index.ts
+++ b/packages/pulse-core/src/index.ts
@@ -454,6 +454,14 @@ export interface AbiRegistryClientLike {
 }
 
 export type SorobanConfig = {
+  /** Soroban RPC endpoint used for live contract-event polling. */
+  rpcUrl: string;
+  /** Optional headers forwarded to the Soroban RPC endpoint. */
+  rpcHeaders?: Record<string, string>;
+  /** Interval between Soroban polls in milliseconds. Defaults to 2,000. */
+  pollIntervalMs?: number;
+  /** Number of ledgers to look back from the latest ledger on the first poll. Defaults to 0. */
+  startLedgerLookback?: number;
   /**
    * Pagination limit for each Soroban RPC `getEvents` call.
    * Must be an integer from 1 through 10,000. Defaults to 100.

--- a/packages/pulse-core/test/SorobanSubscriber.test.ts
+++ b/packages/pulse-core/test/SorobanSubscriber.test.ts
@@ -1,0 +1,216 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { EventEngine } from "../src/EventEngine.js";
+import {
+  SorobanSubscriber,
+  type CursorStoreLike,
+  type SorobanEvent,
+} from "../src/SorobanSubscriber.js";
+import type {
+  SorobanGetEventsParams,
+  SorobanGetEventsResult,
+  SorobanRpcCallOptions,
+  SorobanRpcEvent,
+} from "../src/SorobanRpcClient.js";
+
+class MemoryCursorStore implements CursorStoreLike {
+  constructor(public cursor?: string) {}
+
+  async getCursor(): Promise<string | undefined> {
+    return this.cursor;
+  }
+
+  async saveCursor(cursor: string): Promise<void> {
+    this.cursor = cursor;
+  }
+}
+
+class PollingRpc {
+  readonly getLatestLedger = vi.fn(async (_options?: SorobanRpcCallOptions) => 120);
+  readonly calls: SorobanGetEventsParams[] = [];
+  private responseIndex = 0;
+
+  constructor(private readonly responses: SorobanGetEventsResult[]) {}
+
+  async getEvents(
+    params: SorobanGetEventsParams,
+    _options?: SorobanRpcCallOptions,
+  ): Promise<SorobanGetEventsResult> {
+    this.calls.push(structuredClone(params));
+    const response = this.responses[this.responseIndex];
+    this.responseIndex++;
+    return response ?? { events: [], cursor: `cursor-${this.responseIndex}` };
+  }
+}
+
+function rawEvent(id = "event-1"): SorobanRpcEvent & SorobanEvent {
+  return {
+    id,
+    pagingToken: `${id}-paging-token`,
+    type: "contract",
+    contractId: "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4",
+    topic: ["transfer"],
+    value: { amount: "10" },
+    ledger: 115,
+    ledgerClosedAt: "2026-06-27T12:00:00Z",
+    txHash: "abc123",
+    inSuccessfulContractCall: true,
+  };
+}
+
+async function flushPoll(): Promise<void> {
+  await vi.advanceTimersByTimeAsync(0);
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+describe("SorobanSubscriber startLedger to cursor polling", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("uses latest ledger minus lookback once, then the previous response cursor", async () => {
+    const rpc = new PollingRpc([
+      { events: [rawEvent()], cursor: "cursor-1", latestLedger: 120 },
+      { events: [], cursor: "cursor-2", latestLedger: 121 },
+    ]);
+    const cursorStore = new MemoryCursorStore();
+    const emitted: SorobanEvent[] = [];
+    const subscriber = new SorobanSubscriber({
+      rpc: rpc as any,
+      cursorStore,
+      startLedgerLookback: 5,
+      pollIntervalMs: 500,
+      pageLimit: 250,
+      onEvent: async (event) => {
+        emitted.push(event);
+      },
+    });
+
+    subscriber.start();
+    await flushPoll();
+
+    expect(rpc.getLatestLedger).toHaveBeenCalledTimes(1);
+    expect(rpc.calls[0]).toEqual({
+      startLedger: 115,
+      pagination: { limit: 250 },
+      xdrFormat: "json",
+    });
+    expect(emitted[0]).toMatchObject({
+      id: "event-1",
+      type: "contract.emitted",
+      decodedData: { amount: "10" },
+    });
+    expect(cursorStore.cursor).toBe("cursor-1");
+
+    await vi.advanceTimersByTimeAsync(500);
+    await flushPoll();
+
+    expect(rpc.getLatestLedger).toHaveBeenCalledTimes(1);
+    expect(rpc.calls[1]).toEqual({
+      pagination: { cursor: "cursor-1", limit: 250 },
+      xdrFormat: "json",
+    });
+    expect(cursorStore.cursor).toBe("cursor-2");
+
+    await subscriber.stop();
+  });
+
+  it("resumes from a persisted cursor without requesting the latest ledger", async () => {
+    const rpc = new PollingRpc([{ events: [], cursor: "cursor-next" }]);
+    const subscriber = new SorobanSubscriber({
+      rpc: rpc as any,
+      cursorStore: new MemoryCursorStore("cursor-saved"),
+    });
+
+    await subscriber.pollOnce();
+
+    expect(rpc.getLatestLedger).not.toHaveBeenCalled();
+    expect(rpc.calls[0]).toEqual({
+      pagination: { cursor: "cursor-saved", limit: 100 },
+      xdrFormat: "json",
+    });
+  });
+
+  it("uses the default two-second interval and stops without another poll", async () => {
+    const rpc = new PollingRpc([{ events: [], cursor: "cursor-1" }]);
+    const subscriber = new SorobanSubscriber({
+      rpc: rpc as any,
+      cursorStore: new MemoryCursorStore(),
+    });
+
+    subscriber.start();
+    await flushPoll();
+    expect(rpc.calls).toHaveLength(1);
+
+    await vi.advanceTimersByTimeAsync(1_999);
+    expect(rpc.calls).toHaveLength(1);
+    await vi.advanceTimersByTimeAsync(1);
+    await flushPoll();
+    expect(rpc.calls).toHaveLength(2);
+
+    await subscriber.stop();
+    await vi.advanceTimersByTimeAsync(4_000);
+    expect(rpc.calls).toHaveLength(2);
+  });
+
+  it("wires EventEngine start and stop to the configured subscriber", async () => {
+    const requests: Array<{ method: string; params?: SorobanGetEventsParams }> = [];
+    const fetchMock = vi.fn(async (_url: string | URL | Request, init?: RequestInit) => {
+      const body = JSON.parse(String(init?.body)) as {
+        id: number;
+        method: string;
+        params?: SorobanGetEventsParams;
+      };
+      requests.push({ method: body.method, params: body.params });
+      const result =
+        body.method === "getLatestLedger"
+          ? { sequence: 200 }
+          : { events: [], cursor: `engine-cursor-${requests.length}` };
+      return new Response(JSON.stringify({ jsonrpc: "2.0", id: body.id, result }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const engine = new EventEngine({
+      network: "testnet",
+      soroban: {
+        rpcUrl: "https://rpc.example",
+        pollIntervalMs: 250,
+        startLedgerLookback: 10,
+      },
+    });
+    (engine as any).server = {
+      operations: () => ({
+        cursor: () => ({
+          stream: () => () => {},
+        }),
+      }),
+    };
+
+    engine.start();
+    await flushPoll();
+    expect(requests.map((request) => request.method)).toEqual(["getLatestLedger", "getEvents"]);
+    expect(requests[1]?.params).toMatchObject({
+      startLedger: 190,
+      pagination: { limit: 100 },
+    });
+
+    await vi.advanceTimersByTimeAsync(250);
+    await flushPoll();
+    expect(requests.filter((request) => request.method === "getEvents")).toHaveLength(2);
+
+    engine.stop();
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(requests.filter((request) => request.method === "getEvents")).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
## What changed

- initializes live Soroban polling from `getLatestLedger() - startLedgerLookback`
- switches subsequent `getEvents` requests to the cursor returned by the previous RPC response, with mutually exclusive start-ledger/cursor parameters
- adds configurable polling intervals and persists the Soroban cursor independently from Horizon
- constructs and starts the subscriber with `EventEngine`, normalizes polled contract events, and stops the loop with the engine
- adds regression coverage for lookback initialization, cursor resume, the default interval, normalized delivery, and engine lifecycle shutdown

## Why

The existing subscriber had timer and shutdown scaffolding but still used the legacy positional cursor API. It was never instantiated by `EventEngine`, never initialized from the latest ledger, and advanced from event paging tokens rather than the RPC response cursor.

## Validation

- Prettier check: passed
- `git diff --check`: passed
- TypeScript syntax transpilation for all changed files: passed
- subscriber cursor-transition and shutdown runtime smoke: passed
- EventEngine normalized-event and lifecycle runtime smoke: passed
- full Vitest/typecheck: blocked locally because the existing pnpm install populated the virtual store without completing dependency links (`rollup`, `@stellar/stellar-sdk`, and Node types are unresolved)

Closes #618