### PR TITLE
[codex] Enforce contract event type exhaustiveness

### DIFF
--- a/packages/pulse-core/src/index.ts
+++ b/packages/pulse-core/src/index.ts
@@ -384,8 +384,7 @@ export type NormalizedEvent = (
   | LiquidityPoolDepositEvent
   | LiquidityPoolWithdrawEvent
   | TrustAuthEvent
-  | ContractInvokedEvent
-  | ContractEmittedEvent
+  | ContractEvent
 ) & {
   /** Lazy, cached `Date` derived from `event.timestamp`. Non-enumerable; does not appear in JSON.stringify output. */
   readonly timestampDate: Date;
@@ -557,6 +556,7 @@ export type ContractEmittedEvent = {
   raw?: RawSorobanEvent;
 };
 
+/** Discriminated union of every normalized Soroban contract event. */
 export type ContractEvent = ContractInvokedEvent | ContractEmittedEvent;
 
 export type DecodeFailedNotification = {

--- a/packages/pulse-core/test/types.contract.test-d.ts
+++ b/packages/pulse-core/test/types.contract.test-d.ts
@@ -1,0 +1,75 @@
+import type {
+  ContractEmittedEvent,
+  ContractEvent,
+  ContractInvokedEvent,
+  NormalizedEvent,
+  RawSorobanEvent,
+} from "../src/index.js";
+
+type Assert<T extends true> = T;
+type Equal<A, B> = [A] extends [B] ? ([B] extends [A] ? true : false) : false;
+type IsNever<T> = [T] extends [never] ? true : false;
+type IsOptional<T, K extends keyof T> = Record<never, never> extends Pick<T, K> ? true : false;
+
+type ContractNormalizedEvent = Extract<NormalizedEvent, { type: ContractEvent["type"] }>;
+type InvokedMember = Extract<ContractNormalizedEvent, { type: "contract.invoked" }>;
+type EmittedMember = Extract<ContractNormalizedEvent, { type: "contract.emitted" }>;
+
+// Both public contract types must remain members of NormalizedEvent.
+type _InvokedIsPresent = Assert<Equal<IsNever<InvokedMember>, false>>;
+type _EmittedIsPresent = Assert<Equal<IsNever<EmittedMember>, false>>;
+type _InvokedNarrows = Assert<InvokedMember extends ContractInvokedEvent ? true : false>;
+type _EmittedNarrows = Assert<EmittedMember extends ContractEmittedEvent ? true : false>;
+
+// The exported shapes must retain their contract-specific fields.
+type _InvokedFunction = Assert<Equal<ContractInvokedEvent["function"], string>>;
+type _InvokedArgs = Assert<Equal<ContractInvokedEvent["args"], unknown[]>>;
+type _InvokedLedger = Assert<Equal<NonNullable<ContractInvokedEvent["ledger"]>, number>>;
+type _InvokedTxHash = Assert<Equal<NonNullable<ContractInvokedEvent["txHash"]>, string>>;
+type _InvokedRaw = Assert<Equal<NonNullable<ContractInvokedEvent["raw"]>, RawSorobanEvent>>;
+
+type _EmittedTopics = Assert<Equal<ContractEmittedEvent["topics"], string[]>>;
+type _EmittedData = Assert<Equal<ContractEmittedEvent["data"], unknown>>;
+type _EmittedLedger = Assert<Equal<NonNullable<ContractEmittedEvent["ledger"]>, number>>;
+type _EmittedId = Assert<Equal<NonNullable<ContractEmittedEvent["eventId"]>, string>>;
+type _EmittedTxHash = Assert<Equal<NonNullable<ContractEmittedEvent["txHash"]>, string>>;
+type _EmittedSuccess = Assert<
+  Equal<NonNullable<ContractEmittedEvent["inSuccessfulContractCall"]>, boolean>
+>;
+type _EmittedRaw = Assert<Equal<NonNullable<ContractEmittedEvent["raw"]>, RawSorobanEvent>>;
+type _DecodedDataStaysOptional = Assert<IsOptional<ContractEmittedEvent, "decodedData">>;
+
+/**
+ * This switch deliberately has no default clause. Its explicit return type is
+ * valid only while both contract-event variants are handled.
+ */
+export function describeContractEvent(event: ContractNormalizedEvent): string {
+  switch (event.type) {
+    case "contract.invoked": {
+      const invoked: ContractInvokedEvent = event;
+      return invoked.function;
+    }
+    case "contract.emitted": {
+      const emitted: ContractEmittedEvent = event;
+      return emitted.topics.join(",");
+    }
+  }
+}
+
+// Each negative example omits one contract variant. The explicit string return
+// type must therefore fail, proving the positive switch needs both cases.
+// @ts-expect-error - contract.emitted is not handled.
+export function missingEmittedCase(event: ContractNormalizedEvent): string {
+  switch (event.type) {
+    case "contract.invoked":
+      return event.function;
+  }
+}
+
+// @ts-expect-error - contract.invoked is not handled.
+export function missingInvokedCase(event: ContractNormalizedEvent): string {
+  switch (event.type) {
+    case "contract.emitted":
+      return event.topics.join(",");
+  }
+}

--- a/packages/pulse-core/tsconfig.typetest.json
+++ b/packages/pulse-core/tsconfig.typetest.json
@@ -6,5 +6,5 @@
     "declarationMap": false,
     "sourceMap": false
   },
-  "include": ["src", "test/types.exhaustive.test-d.ts"]
+  "include": ["src", "test/types.exhaustive.test-d.ts", "test/types.contract.test-d.ts"]
 }


### PR DESCRIPTION
## What changed

- groups `contract.invoked` and `contract.emitted` in the exported `ContractEvent` discriminated union used by `NormalizedEvent`
- adds a compile-only `types.contract.test-d.ts` covering both exported shapes and their contract-specific fields
- proves a switch with no default clause is exhaustive only when both contract event cases are handled
- wires the new contract type test into the package `test:types` configuration

## Why

The runtime type aliases had already landed on main, but the requested compiled type-level guarantee was missing. Existing tests used a default/`never` branch or Vitest runtime files, so they did not specifically prove the no-default exhaustiveness contract from issue #616.

## Validation

- Prettier check: passed
- `git diff --check`: passed
- the TypeScript compiler reported no diagnostics for `types.contract.test-d.ts`, including its positive and `@ts-expect-error` negative cases
- the complete local typecheck remains blocked by the existing incomplete pnpm dependency links (`@stellar/stellar-sdk`, Node types/events); no new-file diagnostics were reported

Closes #616