### PR TITLE
[codex] Block private IPv6 webhook targets

### DIFF
--- a/packages/pulse-webhooks/src/index.ts
+++ b/packages/pulse-webhooks/src/index.ts
@@ -6,7 +6,8 @@ import type {
 } from "@orbital-stellar/pulse-core";
 
 import { createHmac, timingSafeEqual, randomUUID } from "crypto";
-import { isIP } from "net";
+import { lookup } from "dns/promises";
+import { BlockList, isIP } from "net";
 
 import { DeadLetterStore } from "./MemoryDeadLetterStore.js";
 import { exponentialJittered } from "./backoff.js";
@@ -14,6 +15,23 @@ import type { BackoffStrategy } from "./backoff.js";
 import type { RetryQueue, RetryRecord } from "./RetryQueue.js";
 import type { Tracer, VerifyWebhookOptions, WebhookConfig } from "./types.js";
 import { DEFAULT_MAX_AGE_MS, DEFAULT_CLOCK_SKEW_MS } from "./types.js";
+
+const BLOCKED_WEBHOOK_ADDRESSES = new BlockList();
+BLOCKED_WEBHOOK_ADDRESSES.addSubnet("10.0.0.0", 8, "ipv4");
+BLOCKED_WEBHOOK_ADDRESSES.addSubnet("127.0.0.0", 8, "ipv4");
+BLOCKED_WEBHOOK_ADDRESSES.addSubnet("172.16.0.0", 12, "ipv4");
+BLOCKED_WEBHOOK_ADDRESSES.addSubnet("192.168.0.0", 16, "ipv4");
+BLOCKED_WEBHOOK_ADDRESSES.addSubnet("169.254.0.0", 16, "ipv4");
+BLOCKED_WEBHOOK_ADDRESSES.addAddress("::1", "ipv6");
+BLOCKED_WEBHOOK_ADDRESSES.addSubnet("fc00::", 7, "ipv6");
+BLOCKED_WEBHOOK_ADDRESSES.addSubnet("fe80::", 10, "ipv6");
+BLOCKED_WEBHOOK_ADDRESSES.addSubnet("::ffff:a00:0", 104, "ipv6");
+BLOCKED_WEBHOOK_ADDRESSES.addSubnet("::ffff:7f00:0", 104, "ipv6");
+BLOCKED_WEBHOOK_ADDRESSES.addSubnet("::ffff:ac10:0", 108, "ipv6");
+BLOCKED_WEBHOOK_ADDRESSES.addSubnet("::ffff:c0a8:0", 112, "ipv6");
+BLOCKED_WEBHOOK_ADDRESSES.addSubnet("::ffff:a9fe:0", 112, "ipv6");
+
+const BLOCKED_ADDRESS_ERROR = "Webhook URL points to a blocked private address";
 export { DeadLetterStore } from "./MemoryDeadLetterStore.js";
 export { NOOP_WEBHOOK_METRICS, CountingWebhookMetrics } from "./metrics.js";
 export type { WebhookAttemptStatus, WebhookMetrics, WebhookTerminalOutcome } from "./types.js";
@@ -176,6 +194,14 @@ export class WebhookDelivery {
       return;
     }
 
+    const resolvedHostnameError = await this.validateResolvedHostname(url);
+    if (this.watcher.stopped) return;
+
+    if (resolvedHostnameError) {
+      this.emitFailure(event, url, resolvedHostnameError, attempt);
+      return;
+    }
+
     const payload = JSON.stringify(event);
     const timestamp = Date.now().toString();
     const signature = this.sign(payload, timestamp);
@@ -213,6 +239,8 @@ export class WebhookDelivery {
     try {
       const res = await fetch(url, {
         method: "POST",
+        // Redirect targets have not passed the URL and DNS checks above.
+        redirect: "manual",
         headers: {
           "Content-Type": "application/json",
           "x-orbital-signature": signature,
@@ -290,16 +318,11 @@ export class WebhookDelivery {
 
     const hostname = this.normalizeHostname(parsedUrl.hostname);
     if (hostname === "localhost") {
-      return "Webhook URL points to a blocked private address";
+      return BLOCKED_ADDRESS_ERROR;
     }
 
-    const ipVersion = isIP(hostname);
-    if (ipVersion === 4 && this.isBlockedIpv4(hostname)) {
-      return "Webhook URL points to a blocked private address";
-    }
-
-    if (ipVersion === 6 && this.isBlockedIpv6(hostname)) {
-      return "Webhook URL points to a blocked private address";
+    if (this.isBlockedIp(hostname)) {
+      return BLOCKED_ADDRESS_ERROR;
     }
 
     return null;
@@ -309,25 +332,39 @@ export class WebhookDelivery {
     return hostname.replace(/^\[/, "").replace(/\]$/, "").toLowerCase();
   }
 
-  private isBlockedIpv4(hostname: string): boolean {
-    const [a = -1, b = -1] = hostname.split(".").map((segment) => Number(segment));
-
-    return (
-      a === 10 ||
-      a === 127 ||
-      (a === 172 && b >= 16 && b <= 31) ||
-      (a === 192 && b === 168) ||
-      (a === 169 && b === 254)
-    );
-  }
-
-  private isBlockedIpv6(hostname: string): boolean {
-    if (hostname === "::1") return true;
-    if (/^::ffff:(\d{1,3}\.){3}\d{1,3}$/i.test(hostname)) {
-      return this.isBlockedIpv4(hostname.slice(hostname.lastIndexOf(":") + 1));
+  private isBlockedIp(address: string): boolean {
+    const ipVersion = isIP(address);
+    if (ipVersion === 4) {
+      return BLOCKED_WEBHOOK_ADDRESSES.check(address, "ipv4");
+    }
+    if (ipVersion === 6) {
+      // URL normalisation converts mapped dotted forms such as
+      // ::ffff:10.0.0.1 to their canonical hexadecimal form ::ffff:a00:1.
+      return BLOCKED_WEBHOOK_ADDRESSES.check(address, "ipv6");
     }
 
-    return /^fe[89ab][0-9a-f]:/i.test(hostname) || /^f[cd][0-9a-f]{2}:/i.test(hostname);
+    return false;
+  }
+
+  private async validateResolvedHostname(url: string): Promise<string | null> {
+    const hostname = this.normalizeHostname(new URL(url).hostname);
+    if (isIP(hostname) !== 0) return null;
+
+    try {
+      // Check every A and AAAA answer before each attempt. This prevents a
+      // public answer from masking a private IPv6 answer and re-checks retries.
+      const addresses = await lookup(hostname, { all: true, verbatim: true });
+      if (addresses.length === 0) {
+        return "Webhook hostname did not resolve to an IP address";
+      }
+
+      return addresses.some(({ address }) => this.isBlockedIp(address))
+        ? BLOCKED_ADDRESS_ERROR
+        : null;
+    } catch {
+      // DNS failures must fail closed; delivery can retry and resolve again.
+      return "Webhook hostname could not be resolved";
+    }
   }
 
   private extractTraceId(event: NormalizedEvent): string | undefined {

--- a/packages/pulse-webhooks/test/pulse-webhooks.test.ts
+++ b/packages/pulse-webhooks/test/pulse-webhooks.test.ts
@@ -1,6 +1,9 @@
 import { createHmac } from "crypto";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+const dnsLookupMock = vi.hoisted(() => vi.fn());
+vi.mock("dns/promises", () => ({ lookup: dnsLookupMock }));
+
 import { Watcher } from "@orbital-stellar/pulse-core";
 import type { WebhookMetrics } from "../src/index.js";
 import {
@@ -26,7 +29,14 @@ const deliveryEvent = {
 async function flushAsyncWork(): Promise<void> {
   await Promise.resolve();
   await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
 }
+
+beforeEach(() => {
+  dnsLookupMock.mockReset();
+  dnsLookupMock.mockResolvedValue([{ address: "93.184.216.34", family: 4 }]);
+});
 
 function signWebhookPayload(secret: string, payload: string, timestamp: string): string {
   return createHmac("sha256", secret).update(`${timestamp}.${payload}`).digest("hex");
@@ -43,7 +53,7 @@ describe("pulse-webhooks WebhookDelivery", () => {
     vi.restoreAllMocks();
   });
 
-  it("delivers each event to every configured URL", () => {
+  it("delivers each event to every configured URL", async () => {
     vi.setSystemTime(new Date("2026-04-27T00:00:00.000Z"));
     const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200 });
     vi.stubGlobal("fetch", fetchMock);
@@ -64,6 +74,7 @@ describe("pulse-webhooks WebhookDelivery", () => {
     });
 
     watcher.emit("*", deliveryEvent);
+    await flushAsyncWork();
 
     expect(fetchMock).toHaveBeenCalledTimes(3);
     expect(fetchMock).toHaveBeenNthCalledWith(
@@ -246,6 +257,123 @@ describe("pulse-webhooks WebhookDelivery", () => {
 
     expect(fetchMock).not.toHaveBeenCalled();
     expect(failedHandler).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    "https://[fc00::1]/hook",
+    "https://[fdff:ffff::1]/hook",
+    "https://[fe80::1]/hook",
+    "https://[febf:ffff::1]/hook",
+    "https://[::ffff:10.0.0.1]/hook",
+    "https://[::ffff:127.0.0.1]/hook",
+    "https://[::ffff:172.31.255.255]/hook",
+    "https://[::ffff:192.168.1.1]/hook",
+    "https://[::ffff:169.254.1.1]/hook",
+  ])("blocks private IPv6 destination %s", async (url) => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200 });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const watcher = new Watcher("GABC");
+    const failedHandler = vi.fn();
+    watcher.on("webhook.failed", failedHandler);
+
+    new WebhookDelivery(watcher, { url, secret: "top-secret" });
+    watcher.emit("*", deliveryEvent);
+    await flushAsyncWork();
+
+    expect(dnsLookupMock).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(failedHandler).toHaveBeenCalledWith(
+      expect.objectContaining({
+        raw: expect.objectContaining({
+          url,
+          error: "Webhook URL points to a blocked private address",
+        }),
+      }),
+    );
+  });
+
+  it.each([
+    "https://[fbff:ffff::1]/hook",
+    "https://[fe7f:ffff::1]/hook",
+    "https://[fec0::1]/hook",
+    "https://[::ffff:8.8.8.8]/hook",
+  ])("allows IPv6 destination outside the blocked ranges %s", async (url) => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200 });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const watcher = new Watcher("GABC");
+    new WebhookDelivery(watcher, { url, secret: "top-secret" });
+    watcher.emit("*", deliveryEvent);
+    await flushAsyncWork();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("blocks a hostname when any DNS answer is private IPv6", async () => {
+    dnsLookupMock.mockResolvedValue([
+      { address: "2606:4700:4700::1111", family: 6 },
+      { address: "fe80::1234", family: 6 },
+    ]);
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200 });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const url = "https://hooks.example.com/stellar";
+    const watcher = new Watcher("GABC");
+    const failedHandler = vi.fn();
+    watcher.on("webhook.failed", failedHandler);
+
+    new WebhookDelivery(watcher, { url, secret: "top-secret" });
+    watcher.emit("*", deliveryEvent);
+    await flushAsyncWork();
+
+    expect(dnsLookupMock).toHaveBeenCalledWith("hooks.example.com", {
+      all: true,
+      verbatim: true,
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(failedHandler).toHaveBeenCalledWith(
+      expect.objectContaining({
+        raw: expect.objectContaining({
+          error: "Webhook URL points to a blocked private address",
+        }),
+      }),
+    );
+  });
+
+  it("re-checks DNS before a retry and blocks a rebound private address", async () => {
+    dnsLookupMock
+      .mockResolvedValueOnce([{ address: "2606:4700:4700::1111", family: 6 }])
+      .mockResolvedValueOnce([{ address: "fc00::1234", family: 6 }]);
+    const fetchMock = vi.fn().mockRejectedValue(new Error("network down"));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const watcher = new Watcher("GABC");
+    const failedHandler = vi.fn();
+    watcher.on("webhook.failed", failedHandler);
+
+    new WebhookDelivery(watcher, {
+      url: "https://hooks.example.com/stellar",
+      secret: "top-secret",
+      retries: 2,
+      random: () => 0,
+    });
+    watcher.emit("*", deliveryEvent);
+    await flushAsyncWork();
+
+    vi.advanceTimersByTime(0);
+    await flushAsyncWork();
+
+    expect(dnsLookupMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(failedHandler).toHaveBeenCalledWith(
+      expect.objectContaining({
+        raw: expect.objectContaining({
+          error: "Webhook URL points to a blocked private address",
+          attempts: 2,
+        }),
+      }),
+    );
   });
 
   it("keeps delivering to other URLs when one URL fails", async () => {


### PR DESCRIPTION
## What changed
- replace ad-hoc IP parsing with CIDR-aware block lists for IPv4, `fc00::/7`, `fe80::/10`, loopback, and IPv4-mapped private ranges
- resolve and inspect every A/AAAA answer before each delivery attempt, failing closed when any answer is private
- re-check DNS on retries and refuse unchecked redirects
- add boundary, mapped-address, mixed-DNS, and DNS-rebinding regression coverage

## Why
IPv6 unique-local and link-local targets could bypass the webhook SSRF guard. URL canonicalization also converts dotted IPv4-mapped literals into hexadecimal forms, which the previous regex did not recognize.

## Validation
- `git diff --check`
- direct Node CIDR boundary/mapped-address smoke checks
- TypeScript transpilation of the changed source and test files
- Full Vitest execution could not start because this checkout has incomplete pnpm links (`vitest`/`rollup` unavailable); a frozen offline install is missing the cached `geist@1.7.0` tarball and the online relink timed out.

Closes #681