### PR TITLE
feat(pulse-webhooks): add DeadLetterStore.failureRate(url, windowMs)

### DIFF
--- a/packages/pulse-webhooks/src/MemoryDeadLetterStore.ts
+++ b/packages/pulse-webhooks/src/MemoryDeadLetterStore.ts
@@ -137,6 +137,22 @@ export class DeadLetterStore {
     return [...this.metrics.keys()];
   }
 
+  /**
+   * Returns the failure rate for a URL over the given window.
+   *
+   * Rate = failures_in_window / (failures_in_window + successes_in_window).
+   * Returns 0 if no events are recorded in the window.
+   */
+  failureRate(url: string, windowMs: number): number {
+    const metrics = this.metrics.get(url);
+    if (!metrics) return 0;
+    const cutoff = Date.now() - windowMs;
+    const failures = metrics.failures.filter((ts) => ts > cutoff).length;
+    const successes = metrics.successes.filter((ts) => ts > cutoff).length;
+    const total = failures + successes;
+    return total === 0 ? 0 : failures / total;
+  }
+
   private getOrCreateMetrics(url: string): UrlMetrics {
     let metrics = this.metrics.get(url);
     if (!metrics) {

--- a/packages/pulse-webhooks/test/pulse-webhooks.test.ts
+++ b/packages/pulse-webhooks/test/pulse-webhooks.test.ts
@@ -1323,6 +1323,49 @@ describe("pulse-webhooks DeadLetterStore", () => {
 
     vi.useRealTimers();
   });
+
+  it("failureRate returns the correct rate over the given window", () => {
+    vi.useFakeTimers();
+    const dlq = new DeadLetterStore();
+    const url = "https://example.com/webhooks";
+    const windowMs = 60_000; // 1 minute
+
+    const now = new Date("2026-06-29T08:00:00Z").getTime();
+    vi.setSystemTime(now);
+
+    // 3 failures + 1 success inside the window → rate = 3/4 = 0.75
+    dlq.recordFailure(url, now - 10_000);
+    dlq.recordFailure(url, now - 20_000);
+    dlq.recordFailure(url, now - 30_000);
+    dlq.recordSuccess(url, now - 40_000);
+
+    // 1 failure outside the window — must be ignored
+    dlq.recordFailure(url, now - 90_000);
+
+    const rate = dlq.failureRate(url, windowMs);
+    expect(rate).toBe(3 / 4);
+
+    vi.useRealTimers();
+  });
+
+  it("failureRate returns 0 for unknown URL", () => {
+    const dlq = new DeadLetterStore();
+    expect(dlq.failureRate("https://unknown.example.com", 60_000)).toBe(0);
+  });
+
+  it("failureRate returns 0 when no events fall within the window", () => {
+    vi.useFakeTimers();
+    const dlq = new DeadLetterStore();
+    const url = "https://example.com/webhooks";
+    const now = new Date("2026-06-29T08:00:00Z").getTime();
+    vi.setSystemTime(now);
+
+    dlq.recordFailure(url, now - 120_000); // 2 minutes ago, outside 1-minute window
+
+    expect(dlq.failureRate(url, 60_000)).toBe(0);
+
+    vi.useRealTimers();
+  });
 });
 
 describe("pulse-webhooks WebhookDelivery with retryQueue", () => {


### PR DESCRIPTION
## Summary

Closes #387.

Adds `dlqStore.failureRate(url, windowMs)` to `DeadLetterStore`.

**Rate computation:** `failures_in_window / (failures_in_window + successes_in_window)` using the existing per-URL health-tracking timestamp arrays. Returns `0` when the URL is unknown or no events fall within the window.

## Changes

- `packages/pulse-webhooks/src/MemoryDeadLetterStore.ts` — new `failureRate(url, windowMs)` method
- `packages/pulse-webhooks/test/pulse-webhooks.test.ts` — 3 tests covering hand-calculated rate, unknown URL, and empty window

## Testing

```
✓ failureRate returns the correct rate over the given window
✓ failureRate returns 0 for unknown URL
✓ failureRate returns 0 when no events fall within the window
```