### PR TITLE
feat(abi-registry): implement ContractSpec type and JSON schema (#649)

### DIFF
--- a/packages/abi-registry/schema/spec.schema.json
+++ b/packages/abi-registry/schema/spec.schema.json
@@ -1,0 +1,313 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://orbital-stellar.io/schema/spec.schema.json",
+  "title": "ContractSpec",
+  "description": "Canonical ABI specification for a deployed Soroban smart contract. Enumerates every exported function, every emitted event, and every user-defined type referenced by the ABI surface.",
+  "type": "object",
+  "required": ["version", "name", "functions", "events", "types"],
+  "additionalProperties": false,
+  "properties": {
+    "version": {
+      "type": "string",
+      "description": "Semantic version of the spec, e.g. \"1.0.0\".",
+      "pattern": "^\\d+\\.\\d+\\.\\d+$"
+    },
+    "name": {
+      "type": "string",
+      "description": "Human-readable contract name.",
+      "minLength": 1,
+      "maxLength": 100
+    },
+    "description": {
+      "type": "string",
+      "description": "Short description of what the contract does.",
+      "maxLength": 500
+    },
+    "contractId": {
+      "type": "string",
+      "description": "Bech32-encoded Soroban contract address (C…).",
+      "pattern": "^C[A-Z2-7]{55}$"
+    },
+    "network": {
+      "type": "string",
+      "description": "Network the spec was generated from.",
+      "enum": ["mainnet", "testnet", "futurenet"]
+    },
+    "functions": {
+      "type": "array",
+      "description": "All exported Soroban contract functions.",
+      "items": { "$ref": "#/$defs/FunctionSpec" }
+    },
+    "events": {
+      "type": "array",
+      "description": "All events emitted by the contract.",
+      "items": { "$ref": "#/$defs/EventSpec" }
+    },
+    "types": {
+      "type": "object",
+      "description": "Named user-defined types referenced in function signatures or events. Keyed by the type name that NamedType references.",
+      "additionalProperties": { "$ref": "#/$defs/UserDefinedType" }
+    },
+    "xdrEntries": {
+      "type": "array",
+      "description": "Raw XDR entries as base64 strings (if available from on-chain data).",
+      "items": { "type": "string" }
+    }
+  },
+  "$defs": {
+    "PrimitiveType": {
+      "type": "string",
+      "description": "An atomic Soroban scalar type.",
+      "enum": [
+        "bool",
+        "u32",
+        "i32",
+        "u64",
+        "i64",
+        "u128",
+        "i128",
+        "u256",
+        "i256",
+        "bytes",
+        "string",
+        "symbol",
+        "address",
+        "void"
+      ]
+    },
+    "BytesNType": {
+      "type": "object",
+      "description": "A fixed-length byte array, e.g. bytes_n<32>.",
+      "required": ["type", "size"],
+      "additionalProperties": false,
+      "properties": {
+        "type": { "const": "bytes_n" },
+        "size": {
+          "type": "integer",
+          "description": "Byte length of the array.",
+          "minimum": 1,
+          "maximum": 64
+        }
+      }
+    },
+    "OptionType": {
+      "type": "object",
+      "description": "A Soroban Option<T> — a value that may be present or absent.",
+      "required": ["type", "inner"],
+      "additionalProperties": false,
+      "properties": {
+        "type": { "const": "option" },
+        "inner": { "$ref": "#/$defs/TypeSpec" }
+      }
+    },
+    "ResultType": {
+      "type": "object",
+      "description": "A Soroban Result<T, E> — either Ok(T) or Err(E).",
+      "required": ["type", "ok", "err"],
+      "additionalProperties": false,
+      "properties": {
+        "type": { "const": "result" },
+        "ok": { "$ref": "#/$defs/TypeSpec" },
+        "err": { "$ref": "#/$defs/TypeSpec" }
+      }
+    },
+    "VecType": {
+      "type": "object",
+      "description": "A homogeneous variable-length sequence.",
+      "required": ["type", "item"],
+      "additionalProperties": false,
+      "properties": {
+        "type": { "const": "vec" },
+        "item": { "$ref": "#/$defs/TypeSpec" }
+      }
+    },
+    "MapType": {
+      "type": "object",
+      "description": "An ordered key-value map.",
+      "required": ["type", "key", "value"],
+      "additionalProperties": false,
+      "properties": {
+        "type": { "const": "map" },
+        "key": { "$ref": "#/$defs/TypeSpec" },
+        "value": { "$ref": "#/$defs/TypeSpec" }
+      }
+    },
+    "TupleType": {
+      "type": "object",
+      "description": "A fixed-length heterogeneous sequence (Soroban Tuple). Minimum 2 elements.",
+      "required": ["type", "elements"],
+      "additionalProperties": false,
+      "properties": {
+        "type": { "const": "tuple" },
+        "elements": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/TypeSpec" },
+          "minItems": 2
+        }
+      }
+    },
+    "NamedType": {
+      "type": "object",
+      "description": "A reference to a user-defined type declared in ContractSpec.types.",
+      "required": ["type", "name"],
+      "additionalProperties": false,
+      "properties": {
+        "type": { "const": "named" },
+        "name": { "type": "string", "minLength": 1 }
+      }
+    },
+    "TypeSpec": {
+      "description": "Union of every representable Soroban type. Either a primitive string literal or a tagged-object composite type.",
+      "oneOf": [
+        { "$ref": "#/$defs/PrimitiveType" },
+        { "$ref": "#/$defs/BytesNType" },
+        { "$ref": "#/$defs/OptionType" },
+        { "$ref": "#/$defs/ResultType" },
+        { "$ref": "#/$defs/VecType" },
+        { "$ref": "#/$defs/MapType" },
+        { "$ref": "#/$defs/TupleType" },
+        { "$ref": "#/$defs/NamedType" }
+      ]
+    },
+    "FieldSpec": {
+      "type": "object",
+      "description": "A named, typed field used in function params, struct fields, and event data.",
+      "required": ["name", "type"],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Must be a valid identifier.",
+          "minLength": 1,
+          "pattern": "^[a-zA-Z_][a-zA-Z0-9_]*$"
+        },
+        "type": { "$ref": "#/$defs/TypeSpec" },
+        "doc": { "type": "string" }
+      }
+    },
+    "FunctionSpec": {
+      "type": "object",
+      "description": "Specification of one exported Soroban contract function.",
+      "required": ["name", "params", "returns"],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1,
+          "pattern": "^[a-zA-Z_][a-zA-Z0-9_]*$"
+        },
+        "doc": { "type": "string" },
+        "params": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/FieldSpec" }
+        },
+        "returns": { "$ref": "#/$defs/TypeSpec" }
+      }
+    },
+    "EventSpec": {
+      "type": "object",
+      "description": "Specification of one contract event emitted via env.events().publish().",
+      "required": ["name", "topics", "data"],
+      "additionalProperties": false,
+      "properties": {
+        "name": { "type": "string", "minLength": 1 },
+        "doc": { "type": "string" },
+        "topics": {
+          "type": "array",
+          "description": "Ordered topic ScVal descriptors. The first topic is conventionally the event-name Symbol.",
+          "items": { "$ref": "#/$defs/FieldSpec" }
+        },
+        "data": {
+          "type": "array",
+          "description": "Ordered payload data fields emitted alongside the topics.",
+          "items": { "$ref": "#/$defs/FieldSpec" }
+        }
+      }
+    },
+    "StructTypeSpec": {
+      "type": "object",
+      "description": "A user-defined struct type.",
+      "required": ["kind", "name", "fields"],
+      "additionalProperties": false,
+      "properties": {
+        "kind": { "const": "struct" },
+        "name": { "type": "string", "minLength": 1 },
+        "doc": { "type": "string" },
+        "fields": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/FieldSpec" }
+        }
+      }
+    },
+    "EnumVariantSpec": {
+      "type": "object",
+      "description": "A single variant of an enum (unit or tuple style).",
+      "required": ["name", "discriminant"],
+      "additionalProperties": false,
+      "properties": {
+        "name": { "type": "string", "minLength": 1 },
+        "doc": { "type": "string" },
+        "discriminant": {
+          "type": "integer",
+          "description": "XDR discriminant value (u32).",
+          "minimum": 0
+        },
+        "value": { "$ref": "#/$defs/TypeSpec" }
+      }
+    },
+    "EnumTypeSpec": {
+      "type": "object",
+      "description": "A user-defined enum (C-style or tuple-variant) type.",
+      "required": ["kind", "name", "variants"],
+      "additionalProperties": false,
+      "properties": {
+        "kind": { "const": "enum" },
+        "name": { "type": "string", "minLength": 1 },
+        "doc": { "type": "string" },
+        "variants": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/EnumVariantSpec" },
+          "minItems": 1
+        }
+      }
+    },
+    "UnionCaseSpec": {
+      "type": "object",
+      "description": "A single case of a discriminated union.",
+      "required": ["name", "fields"],
+      "additionalProperties": false,
+      "properties": {
+        "name": { "type": "string", "minLength": 1 },
+        "doc": { "type": "string" },
+        "fields": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/FieldSpec" }
+        }
+      }
+    },
+    "UnionTypeSpec": {
+      "type": "object",
+      "description": "A user-defined discriminated union type.",
+      "required": ["kind", "name", "cases"],
+      "additionalProperties": false,
+      "properties": {
+        "kind": { "const": "union" },
+        "name": { "type": "string", "minLength": 1 },
+        "doc": { "type": "string" },
+        "cases": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/UnionCaseSpec" },
+          "minItems": 1
+        }
+      }
+    },
+    "UserDefinedType": {
+      "description": "Any user-defined type that may appear in the contract's ABI surface.",
+      "oneOf": [
+        { "$ref": "#/$defs/StructTypeSpec" },
+        { "$ref": "#/$defs/EnumTypeSpec" },
+        { "$ref": "#/$defs/UnionTypeSpec" }
+      ]
+    }
+  }
+}

--- a/packages/abi-registry/src/AbiRegistryClient.ts
+++ b/packages/abi-registry/src/AbiRegistryClient.ts
@@ -22,13 +22,13 @@
 export const REGISTRY_SPEC_VERSION = 1;
 
 import { LruCache } from "./LruCache.js";
-import type { AbiRegistryClientConfig, AbiRegistryClientTransport, ContractSpec } from "./types.js";
+import type { AbiRegistryClientConfig, AbiRegistryClientTransport, XdrContractSpec } from "./types.js";
 
 const DEFAULT_MAX_CACHE_SIZE = 512;
 const DEFAULT_CACHE_TTL_MS = 5 * 60 * 1000;
 
 type CacheEntry = {
-  value: ContractSpec | null;
+  value: XdrContractSpec | null;
   expiresAt: number;
 };
 
@@ -57,7 +57,7 @@ export class AbiRegistryClient {
   }
 
   /** Fetch a single contract spec (cached). */
-  async getSpec(contractId: string): Promise<ContractSpec | null> {
+  async getSpec(contractId: string): Promise<XdrContractSpec | null> {
     const cached = this.getCached(contractId);
     if (cached !== undefined) return cached;
 
@@ -80,7 +80,7 @@ export class AbiRegistryClient {
       throw new Error(`ABI registry responded with ${response.status} for contract spec fetch`);
     }
 
-    const spec = (await response.json()) as ContractSpec;
+    const spec = (await response.json()) as XdrContractSpec;
     this.setCache(contractId, spec);
     return spec;
   }
@@ -91,8 +91,8 @@ export class AbiRegistryClient {
    *
    * @returns A record mapping each contractId to its spec, or null if not found.
    */
-  async getSpecs(contractIds: string[]): Promise<Record<string, ContractSpec | null>> {
-    const result: Record<string, ContractSpec | null> = {};
+  async getSpecs(contractIds: string[]): Promise<Record<string, XdrContractSpec | null>> {
+    const result: Record<string, XdrContractSpec | null> = {};
     const uncached: string[] = [];
 
     for (const id of contractIds) {
@@ -117,7 +117,7 @@ export class AbiRegistryClient {
     return result;
   }
 
-  private getCached(contractId: string): ContractSpec | null | undefined {
+  private getCached(contractId: string): XdrContractSpec | null | undefined {
     const entry = this.cache.get(contractId);
     if (!entry) return undefined;
     if (Date.now() > entry.expiresAt) {
@@ -127,7 +127,7 @@ export class AbiRegistryClient {
     return entry.value;
   }
 
-  private setCache(contractId: string, value: ContractSpec | null): void {
+  private setCache(contractId: string, value: XdrContractSpec | null): void {
     this.cache.set(contractId, {
       value,
       expiresAt: Date.now() + this.ttlMs,
@@ -137,7 +137,7 @@ export class AbiRegistryClient {
   /**
    * POST /specs with the full list of IDs — one round-trip regardless of batch size.
    */
-  private async fetchBatch(contractIds: string[]): Promise<Record<string, ContractSpec | null>> {
+  private async fetchBatch(contractIds: string[]): Promise<Record<string, XdrContractSpec | null>> {
     const response = await this.transport(`${this.baseUrl}/specs`, {
       method: "POST",
       headers: {
@@ -151,6 +151,6 @@ export class AbiRegistryClient {
       throw new Error(`ABI registry responded with ${response.status} for batch spec fetch`);
     }
 
-    return response.json() as Promise<Record<string, ContractSpec | null>>;
+    return response.json() as Promise<Record<string, XdrContractSpec | null>>;
   }
 }

--- a/packages/abi-registry/src/LocalAbiRegistryClient.ts
+++ b/packages/abi-registry/src/LocalAbiRegistryClient.ts
@@ -3,7 +3,7 @@
 // This enables offline or self‑hosted usage without any network calls.
 
 import { LruCache } from "./LruCache.js";
-import type { ContractSpec } from "./types.js";
+import type { XdrContractSpec } from "./types.js";
 
 const DEFAULT_MAX_CACHE_SIZE = 512;
 const DEFAULT_CACHE_TTL_MS = 5 * 60 * 1000;
@@ -23,7 +23,7 @@ export interface LocalAbiRegistryClientConfig {
 }
 
 type CacheEntry = {
-  value: ContractSpec | null;
+  value: XdrContractSpec | null;
   expiresAt: number;
 };
 
@@ -40,7 +40,7 @@ export class LocalAbiRegistryClient {
   }
 
   /** Fetch a single contract spec from the local directory (cached). */
-  async getSpec(contractId: string): Promise<ContractSpec | null> {
+  async getSpec(contractId: string): Promise<XdrContractSpec | null> {
     const cached = this.getCached(contractId);
     if (cached !== undefined) return cached;
     const spec = await this.loadFromDisk(contractId);
@@ -49,8 +49,8 @@ export class LocalAbiRegistryClient {
   }
 
   /** Fetch multiple specs, loading only those not present in the cache. */
-  async getSpecs(contractIds: string[]): Promise<Record<string, ContractSpec | null>> {
-    const result: Record<string, ContractSpec | null> = {};
+  async getSpecs(contractIds: string[]): Promise<Record<string, XdrContractSpec | null>> {
+    const result: Record<string, XdrContractSpec | null> = {};
     const uncached: string[] = [];
 
     for (const id of contractIds) {
@@ -66,14 +66,14 @@ export class LocalAbiRegistryClient {
 
     const loaded = await Promise.all(uncached.map((id) => this.loadFromDisk(id)));
     for (const [i, id] of uncached.entries()) {
-      const spec = loaded[i] as ContractSpec | null;
+      const spec = loaded[i] as XdrContractSpec | null;
       this.setCache(id, spec);
       result[id] = spec;
     }
     return result;
   }
 
-  private getCached(contractId: string): ContractSpec | null | undefined {
+  private getCached(contractId: string): XdrContractSpec | null | undefined {
     const entry = this.cache.get(contractId);
     if (!entry) return undefined;
     if (Date.now() > entry.expiresAt) {
@@ -83,16 +83,16 @@ export class LocalAbiRegistryClient {
     return entry.value;
   }
 
-  private setCache(contractId: string, value: ContractSpec | null): void {
+  private setCache(contractId: string, value: XdrContractSpec | null): void {
     this.cache.set(contractId, { value, expiresAt: Date.now() + this.ttlMs });
   }
 
-  private async loadFromDisk(contractId: string): Promise<ContractSpec | null> {
+  private async loadFromDisk(contractId: string): Promise<XdrContractSpec | null> {
     const path = `${this.specsDir}/${contractId}.json`;
     try {
       const { readFile } = await import("node:fs/promises");
       const data = await readFile(path, { encoding: "utf8" });
-      const spec: ContractSpec = JSON.parse(data);
+      const spec: XdrContractSpec = JSON.parse(data);
       return spec;
     } catch (e) {
       // Missing file or parse error – treat as not found.

--- a/packages/abi-registry/src/decode.ts
+++ b/packages/abi-registry/src/decode.ts
@@ -1,7 +1,7 @@
 /**
  * XDR → typed JSON decoder for Soroban contract events.
  *
- * Decodes a raw Soroban contract event against a known {@link ContractSpec},
+ * Decodes a raw Soroban contract event against a known {@link XdrContractSpec},
  * mapping each topic and the data payload to a typed JavaScript value.
  *
  * The decoder never throws — shape mismatches and unknown types are returned
@@ -30,7 +30,7 @@
  * | custom struct | `Record<string, DecodedValue>`            |
  */
 
-import type { ContractSpec } from "./types.js";
+import type { XdrContractSpec } from "./types.js";
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -80,14 +80,14 @@ export type DecodeResult = DecodedEvent | DecodeError;
 /**
  * Decode a raw Soroban contract event against a known contract spec.
  *
- * @param spec - The {@link ContractSpec} describing the contract's ABI.
+ * @param spec - The {@link XdrContractSpec} describing the contract's ABI.
  * @param rawEvent - The raw event object as emitted by pulse-core
  *   (`ContractEmittedEvent` or `ContractInvokedEvent`). Must have `topics`
  *   (array) and `data` fields.
  * @returns A {@link DecodedEvent} on success, or `{ error: string }` on
  *   any shape mismatch or unsupported type — never throws.
  */
-export function decodeContractEvent(spec: ContractSpec, rawEvent: unknown): DecodeResult {
+export function decodeContractEvent(spec: XdrContractSpec, rawEvent: unknown): DecodeResult {
   try {
     return _decode(spec, rawEvent);
   } catch (err) {
@@ -97,7 +97,7 @@ export function decodeContractEvent(spec: ContractSpec, rawEvent: unknown): Deco
   }
 }
 
-function _decode(spec: ContractSpec, rawEvent: unknown): DecodeResult {
+function _decode(spec: XdrContractSpec, rawEvent: unknown): DecodeResult {
   // --- Validate rawEvent shape ---
   if (rawEvent === null || typeof rawEvent !== "object") {
     return { error: "rawEvent must be a non-null object" };

--- a/packages/abi-registry/src/generate.ts
+++ b/packages/abi-registry/src/generate.ts
@@ -1,5 +1,5 @@
 import { xdr } from "@stellar/stellar-sdk";
-import type { ContractSpec } from "./types.js";
+import type { XdrContractSpec } from "./types.js";
 
 export type GeneratedContractArtifacts = {
   declarations: string;
@@ -138,7 +138,7 @@ function mapTypeToZod(type: xdr.ScSpecTypeDef | undefined): string {
 }
 
 export function generateContractArtifacts(
-  spec: ContractSpec,
+  spec: XdrContractSpec,
   contractName: string,
 ): GeneratedContractArtifacts {
   const entries = spec.entries
@@ -198,7 +198,7 @@ export function generateContractArtifacts(
   };
 }
 
-export function generateContractTypes(spec: ContractSpec, outputPath: string): string {
+export function generateContractTypes(spec: XdrContractSpec, outputPath: string): string {
   const artifacts = generateContractArtifacts(spec, outputPath);
   return [artifacts.declarations, artifacts.schemas].filter(Boolean).join("\n\n");
 }

--- a/packages/abi-registry/src/index.ts
+++ b/packages/abi-registry/src/index.ts
@@ -2,7 +2,32 @@ export { AbiRegistryClient } from "./AbiRegistryClient.js";
 export { scvalToJs, jsToScval } from "./scval.js";
 export { RegistryPublisher } from "./RegistryPublisher.js";
 
-export type { AbiRegistryClientConfig, ContractSpec } from "./types.js";
+export type { AbiRegistryClientConfig, XdrContractSpec } from "./types.js";
+
+export type {
+  ContractSpec,
+  FunctionSpec,
+  EventSpec,
+  FieldSpec,
+  TypeSpec,
+  PrimitiveType,
+  BytesNType,
+  OptionType,
+  ResultType,
+  VecType,
+  MapType,
+  TupleType,
+  NamedType,
+  StructTypeSpec,
+  StructFieldSpec,
+  EnumTypeSpec,
+  EnumVariantSpec,
+  UnionTypeSpec,
+  UnionCaseSpec,
+  UserDefinedType,
+  ValidationResult,
+} from "./spec.js";
+export { validateSpec } from "./spec.js";
 
 export type { PublishResult } from "./RegistryPublisher.js";
 

--- a/packages/abi-registry/src/spec.ts
+++ b/packages/abi-registry/src/spec.ts
@@ -1,0 +1,394 @@
+/**
+ * Complete type system for the Orbital ABI Spec format (issue #649).
+ *
+ * Covers every Soroban value type, all function/event descriptors,
+ * and the top-level ContractSpec envelope.
+ *
+ * For JSON Schema–based validation see `schema/spec.schema.json`.
+ */
+
+// ── Soroban primitive value types ────────────────────────────────────────────
+
+/** All atomic Soroban scalar types. */
+export type PrimitiveType =
+  | 'bool'
+  | 'u32'
+  | 'i32'
+  | 'u64'
+  | 'i64'
+  | 'u128'
+  | 'i128'
+  | 'u256'
+  | 'i256'
+  | 'bytes'
+  | 'string'
+  | 'symbol'
+  | 'address'
+  | 'void';
+
+/** Fixed-length byte array, e.g. `bytes_n<32>`. */
+export type BytesNType = { readonly type: 'bytes_n'; readonly size: number };
+
+/** Soroban `Option<T>` — a value that may be present or absent. */
+export type OptionType = { readonly type: 'option'; readonly inner: TypeSpec };
+
+/** Soroban `Result<T, E>` — either an `Ok` value or an `Err` value. */
+export type ResultType = {
+  readonly type: 'result';
+  readonly ok: TypeSpec;
+  readonly err: TypeSpec;
+};
+
+/** Homogeneous variable-length sequence. */
+export type VecType = { readonly type: 'vec'; readonly item: TypeSpec };
+
+/** Ordered key–value map. */
+export type MapType = {
+  readonly type: 'map';
+  readonly key: TypeSpec;
+  readonly value: TypeSpec;
+};
+
+/** Fixed-length heterogeneous sequence (Soroban `Tuple`). Minimum 2 elements. */
+export type TupleType = {
+  readonly type: 'tuple';
+  readonly elements: ReadonlyArray<TypeSpec>;
+};
+
+/**
+ * Reference to a user-defined type (struct, enum, or union) declared in
+ * {@link ContractSpec.types}.
+ */
+export type NamedType = { readonly type: 'named'; readonly name: string };
+
+/**
+ * Union of every representable Soroban type.
+ * Either a {@link PrimitiveType} string literal or a tagged-object composite type.
+ */
+export type TypeSpec =
+  | PrimitiveType
+  | BytesNType
+  | OptionType
+  | ResultType
+  | VecType
+  | MapType
+  | TupleType
+  | NamedType;
+
+// ── Shared building-block ─────────────────────────────────────────────────────
+
+/** A named, typed field used in function params, struct fields, and event data. */
+export type FieldSpec = {
+  readonly name: string;
+  readonly type: TypeSpec;
+  readonly doc?: string;
+};
+
+// ── Function and event descriptors ────────────────────────────────────────────
+
+/**
+ * Specification of one exported Soroban contract function.
+ * Maps to a single `ScSpecFunctionV0` XDR entry.
+ */
+export type FunctionSpec = {
+  readonly name: string;
+  readonly doc?: string;
+  readonly params: ReadonlyArray<FieldSpec>;
+  /** Return type. Use `'void'` for functions that return nothing. */
+  readonly returns: TypeSpec;
+};
+
+/**
+ * Specification of one contract event emitted via `env.events().publish()`.
+ * Topics carry discriminant ScVals; data carries the payload body.
+ */
+export type EventSpec = {
+  /** Symbolic name of the event (matched against the first topic). */
+  readonly name: string;
+  readonly doc?: string;
+  /**
+   * Ordered topic ScVal descriptors.
+   * The first topic is conventionally the event-name Symbol.
+   */
+  readonly topics: ReadonlyArray<FieldSpec>;
+  /** Ordered payload data fields emitted alongside the topics. */
+  readonly data: ReadonlyArray<FieldSpec>;
+};
+
+// ── User-defined type descriptors ─────────────────────────────────────────────
+
+/** A named, typed field within a struct. Alias of {@link FieldSpec}. */
+export type StructFieldSpec = FieldSpec;
+
+/** Descriptor for a user-defined struct type. */
+export type StructTypeSpec = {
+  readonly kind: 'struct';
+  readonly name: string;
+  readonly doc?: string;
+  readonly fields: ReadonlyArray<StructFieldSpec>;
+};
+
+/** A single variant of an enum (unit or tuple style). */
+export type EnumVariantSpec = {
+  readonly name: string;
+  readonly doc?: string;
+  /** XDR discriminant value (u32). */
+  readonly discriminant: number;
+  /** Present for tuple-style variants that carry an associated value. */
+  readonly value?: TypeSpec;
+};
+
+/** Descriptor for a user-defined enum (C-style or tuple-variant) type. */
+export type EnumTypeSpec = {
+  readonly kind: 'enum';
+  readonly name: string;
+  readonly doc?: string;
+  readonly variants: ReadonlyArray<EnumVariantSpec>;
+};
+
+/** A single case of a discriminated union (tagged union / Rust enum with data). */
+export type UnionCaseSpec = {
+  readonly name: string;
+  readonly doc?: string;
+  /** Fields carried by this case. Empty array for unit variants. */
+  readonly fields: ReadonlyArray<FieldSpec>;
+};
+
+/** Descriptor for a user-defined discriminated union type. */
+export type UnionTypeSpec = {
+  readonly kind: 'union';
+  readonly name: string;
+  readonly doc?: string;
+  readonly cases: ReadonlyArray<UnionCaseSpec>;
+};
+
+/** Any user-defined type that may appear in the contract's ABI surface. */
+export type UserDefinedType = StructTypeSpec | EnumTypeSpec | UnionTypeSpec;
+
+// ── Top-level ContractSpec ────────────────────────────────────────────────────
+
+/**
+ * Canonical ABI specification for a deployed Soroban smart contract.
+ *
+ * Enumerates every exported function, every emitted event, and every
+ * user-defined type referenced by the ABI surface.
+ *
+ * Serialisable to JSON and validatable against `schema/spec.schema.json`.
+ */
+export type ContractSpec = {
+  /** Semantic version string, e.g. `"1.0.0"`. */
+  readonly version: string;
+  /** Human-readable contract name (1–100 characters). */
+  readonly name: string;
+  readonly description?: string;
+  /** Bech32-encoded Soroban contract address (`C…`). */
+  readonly contractId?: string;
+  /** Network the spec was generated from. */
+  readonly network?: 'mainnet' | 'testnet' | 'futurenet';
+  /** All exported Soroban contract functions. */
+  readonly functions: ReadonlyArray<FunctionSpec>;
+  /** All events emitted by the contract. */
+  readonly events: ReadonlyArray<EventSpec>;
+  /**
+   * Named user-defined types referenced in function signatures or events.
+   * Keyed by the type name that {@link NamedType} references.
+   */
+  readonly types: Readonly<Record<string, UserDefinedType>>;
+  /** Raw XDR entries as base64 strings (if available from on-chain data). */
+  readonly xdrEntries?: ReadonlyArray<string>;
+};
+
+// ── Runtime validation ────────────────────────────────────────────────────────
+
+/** Result returned by {@link validateSpec}. */
+export type ValidationResult =
+  | { readonly valid: true }
+  | { readonly valid: false; readonly errors: ReadonlyArray<string> };
+
+const PRIMITIVE_TYPES: ReadonlySet<string> = new Set<PrimitiveType>([
+  'bool', 'u32', 'i32', 'u64', 'i64', 'u128', 'i128',
+  'u256', 'i256', 'bytes', 'string', 'symbol', 'address', 'void',
+]);
+
+const COMPOSITE_TYPE_TAGS = new Set([
+  'bytes_n', 'option', 'result', 'vec', 'map', 'tuple', 'named',
+]);
+
+const SEMVER_RE = /^\d+\.\d+\.\d+$/;
+const CONTRACT_ID_RE = /^C[A-Z2-7]{55}$/;
+const IDENTIFIER_RE = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
+
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return typeof v === 'object' && v !== null && !Array.isArray(v);
+}
+
+function validateTypeSpec(t: unknown, path: string, errors: string[]): void {
+  if (typeof t === 'string') {
+    if (!PRIMITIVE_TYPES.has(t)) {
+      errors.push(`${path}: unknown primitive type "${t}"`);
+    }
+    return;
+  }
+  if (!isRecord(t)) {
+    errors.push(`${path}: TypeSpec must be a string or object`);
+    return;
+  }
+  const tag = t['type'];
+  if (typeof tag !== 'string' || !COMPOSITE_TYPE_TAGS.has(tag)) {
+    errors.push(`${path}.type: expected one of ${[...COMPOSITE_TYPE_TAGS].join(', ')}, got ${JSON.stringify(tag)}`);
+    return;
+  }
+  switch (tag) {
+    case 'bytes_n': {
+      const size = t['size'];
+      if (typeof size !== 'number' || !Number.isInteger(size) || size < 1) {
+        errors.push(`${path}.size: must be a positive integer`);
+      }
+      break;
+    }
+    case 'option':
+      validateTypeSpec(t['inner'], `${path}.inner`, errors);
+      break;
+    case 'result':
+      validateTypeSpec(t['ok'], `${path}.ok`, errors);
+      validateTypeSpec(t['err'], `${path}.err`, errors);
+      break;
+    case 'vec':
+      validateTypeSpec(t['item'], `${path}.item`, errors);
+      break;
+    case 'map':
+      validateTypeSpec(t['key'], `${path}.key`, errors);
+      validateTypeSpec(t['value'], `${path}.value`, errors);
+      break;
+    case 'tuple': {
+      const elems = t['elements'];
+      if (!Array.isArray(elems) || elems.length < 2) {
+        errors.push(`${path}.elements: tuple requires at least 2 elements`);
+      } else {
+        (elems as unknown[]).forEach((e, i) =>
+          validateTypeSpec(e, `${path}.elements[${i}]`, errors),
+        );
+      }
+      break;
+    }
+    case 'named':
+      if (typeof t['name'] !== 'string' || t['name'].length === 0) {
+        errors.push(`${path}.name: must be a non-empty string`);
+      }
+      break;
+  }
+}
+
+function validateFieldSpec(f: unknown, path: string, errors: string[]): void {
+  if (!isRecord(f)) { errors.push(`${path}: must be an object`); return; }
+  if (typeof f['name'] !== 'string' || !IDENTIFIER_RE.test(f['name'])) {
+    errors.push(`${path}.name: must be a valid identifier`);
+  }
+  validateTypeSpec(f['type'], `${path}.type`, errors);
+}
+
+function validateFunctionSpec(fn: unknown, path: string, errors: string[]): void {
+  if (!isRecord(fn)) { errors.push(`${path}: must be an object`); return; }
+  if (typeof fn['name'] !== 'string' || !IDENTIFIER_RE.test(fn['name'])) {
+    errors.push(`${path}.name: must be a valid identifier`);
+  }
+  if (!Array.isArray(fn['params'])) {
+    errors.push(`${path}.params: must be an array`);
+  } else {
+    (fn['params'] as unknown[]).forEach((p, i) =>
+      validateFieldSpec(p, `${path}.params[${i}]`, errors),
+    );
+  }
+  validateTypeSpec(fn['returns'], `${path}.returns`, errors);
+}
+
+function validateEventSpec(ev: unknown, path: string, errors: string[]): void {
+  if (!isRecord(ev)) { errors.push(`${path}: must be an object`); return; }
+  if (typeof ev['name'] !== 'string' || ev['name'].length === 0) {
+    errors.push(`${path}.name: must be a non-empty string`);
+  }
+  if (!Array.isArray(ev['topics'])) {
+    errors.push(`${path}.topics: must be an array`);
+  } else {
+    (ev['topics'] as unknown[]).forEach((t, i) =>
+      validateFieldSpec(t, `${path}.topics[${i}]`, errors),
+    );
+  }
+  if (!Array.isArray(ev['data'])) {
+    errors.push(`${path}.data: must be an array`);
+  } else {
+    (ev['data'] as unknown[]).forEach((d, i) =>
+      validateFieldSpec(d, `${path}.data[${i}]`, errors),
+    );
+  }
+}
+
+/**
+ * Validates that `spec` conforms to the {@link ContractSpec} shape and all
+ * structural invariants.  Returns a {@link ValidationResult} — never throws.
+ *
+ * For full JSON Schema–based validation run the spec through
+ * `schema/spec.schema.json` using a JSON Schema validator such as Ajv.
+ */
+export function validateSpec(spec: unknown): ValidationResult {
+  const errors: string[] = [];
+
+  if (!isRecord(spec)) {
+    return { valid: false, errors: ['root: ContractSpec must be an object'] };
+  }
+
+  if (typeof spec['version'] !== 'string' || !SEMVER_RE.test(spec['version'])) {
+    errors.push('version: must be a semver string (e.g. "1.0.0")');
+  }
+  if (
+    typeof spec['name'] !== 'string' ||
+    spec['name'].length === 0 ||
+    spec['name'].length > 100
+  ) {
+    errors.push('name: must be a non-empty string of at most 100 characters');
+  }
+  if (spec['description'] !== undefined && typeof spec['description'] !== 'string') {
+    errors.push('description: must be a string');
+  }
+  if (spec['contractId'] !== undefined) {
+    if (
+      typeof spec['contractId'] !== 'string' ||
+      !CONTRACT_ID_RE.test(spec['contractId'])
+    ) {
+      errors.push('contractId: must be a C-prefixed 56-character Stellar strkey');
+    }
+  }
+  if (spec['network'] !== undefined) {
+    const validNetworks = new Set(['mainnet', 'testnet', 'futurenet']);
+    if (!validNetworks.has(spec['network'] as string)) {
+      errors.push('network: must be "mainnet", "testnet", or "futurenet"');
+    }
+  }
+  if (!Array.isArray(spec['functions'])) {
+    errors.push('functions: must be an array');
+  } else {
+    (spec['functions'] as unknown[]).forEach((fn, i) =>
+      validateFunctionSpec(fn, `functions[${i}]`, errors),
+    );
+  }
+  if (!Array.isArray(spec['events'])) {
+    errors.push('events: must be an array');
+  } else {
+    (spec['events'] as unknown[]).forEach((ev, i) =>
+      validateEventSpec(ev, `events[${i}]`, errors),
+    );
+  }
+  if (!isRecord(spec['types'])) {
+    errors.push('types: must be an object');
+  }
+  if (spec['xdrEntries'] !== undefined) {
+    if (
+      !Array.isArray(spec['xdrEntries']) ||
+      !(spec['xdrEntries'] as unknown[]).every((e) => typeof e === 'string')
+    ) {
+      errors.push('xdrEntries: must be an array of strings');
+    }
+  }
+
+  return errors.length === 0 ? { valid: true } : { valid: false, errors };
+}

--- a/packages/abi-registry/src/types.ts
+++ b/packages/abi-registry/src/types.ts
@@ -1,5 +1,9 @@
-/** A parsed Soroban contract ABI spec entry. */
-export type ContractSpec = {
+/**
+ * Minimal XDR-backed contract spec — carries the raw on-chain entries.
+ * For the rich ABI surface (functions, events, type descriptors) use
+ * {@link ContractSpec} from `./spec.js`.
+ */
+export type XdrContractSpec = {
   contractId: string;
   /** Raw XDR entries as base64 strings. */
   entries: string[];

--- a/packages/abi-registry/test/spec.test.ts
+++ b/packages/abi-registry/test/spec.test.ts
@@ -1,0 +1,535 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { validateSpec } from '../src/spec.js';
+import type { ContractSpec } from '../src/spec.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// Load the canonical JSON Schema to make structural assertions about its shape.
+const specSchema = JSON.parse(
+  readFileSync(join(__dirname, '../schema/spec.schema.json'), 'utf-8'),
+) as Record<string, unknown>;
+
+// ── Representative ABI spec (SAC-style fungible token) ────────────────────────
+
+const sampleSpec: ContractSpec = {
+  version: '1.0.0',
+  name: 'Simple Token',
+  description: 'A minimal SEP-41 fungible token.',
+  contractId: 'CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM',
+  network: 'testnet',
+  functions: [
+    {
+      name: 'initialize',
+      doc: 'Set up the token with admin, decimals, name, and symbol.',
+      params: [
+        { name: 'admin', type: 'address', doc: 'Initial admin address.' },
+        { name: 'decimal', type: 'u32' },
+        { name: 'name', type: 'string' },
+        { name: 'symbol', type: 'string' },
+      ],
+      returns: 'void',
+    },
+    {
+      name: 'transfer',
+      doc: 'Transfer tokens from one address to another.',
+      params: [
+        { name: 'from', type: 'address' },
+        { name: 'to', type: 'address' },
+        { name: 'amount', type: 'i128' },
+      ],
+      returns: 'void',
+    },
+    {
+      name: 'balance',
+      doc: 'Return the token balance of an address.',
+      params: [{ name: 'id', type: 'address' }],
+      returns: 'i128',
+    },
+    {
+      name: 'allowance',
+      params: [
+        { name: 'from', type: 'address' },
+        { name: 'spender', type: 'address' },
+      ],
+      returns: { type: 'named', name: 'AllowanceValue' },
+    },
+    {
+      name: 'get_metadata',
+      params: [],
+      returns: { type: 'named', name: 'TokenMetadata' },
+    },
+    {
+      name: 'find_holders',
+      doc: 'Return all addresses holding more than threshold.',
+      params: [{ name: 'threshold', type: 'i128' }],
+      returns: { type: 'vec', item: 'address' },
+    },
+    {
+      name: 'get_balances',
+      doc: 'Return a map of address to balance.',
+      params: [],
+      returns: { type: 'map', key: 'address', value: 'i128' },
+    },
+    {
+      name: 'get_version',
+      params: [],
+      returns: { type: 'tuple', elements: ['u32', 'u32', 'u32'] },
+    },
+    {
+      name: 'get_admin_hash',
+      doc: 'Return the admin hash as a fixed 32-byte value.',
+      params: [],
+      returns: { type: 'bytes_n', size: 32 },
+    },
+    {
+      name: 'try_transfer',
+      doc: 'Transfer with a Result return type.',
+      params: [
+        { name: 'from', type: 'address' },
+        { name: 'to', type: 'address' },
+        { name: 'amount', type: 'i128' },
+      ],
+      returns: { type: 'result', ok: 'void', err: { type: 'named', name: 'TokenError' } },
+    },
+    {
+      name: 'get_optional_spender',
+      params: [{ name: 'id', type: 'address' }],
+      returns: { type: 'option', inner: 'address' },
+    },
+  ],
+  events: [
+    {
+      name: 'transfer',
+      doc: 'Emitted on every successful token transfer.',
+      topics: [
+        { name: 'event_name', type: 'symbol' },
+        { name: 'from', type: 'address' },
+        { name: 'to', type: 'address' },
+      ],
+      data: [{ name: 'amount', type: 'i128' }],
+    },
+    {
+      name: 'mint',
+      topics: [
+        { name: 'event_name', type: 'symbol' },
+        { name: 'admin', type: 'address' },
+        { name: 'to', type: 'address' },
+      ],
+      data: [{ name: 'amount', type: 'i128' }],
+    },
+    {
+      name: 'approve',
+      topics: [
+        { name: 'event_name', type: 'symbol' },
+        { name: 'from', type: 'address' },
+        { name: 'spender', type: 'address' },
+      ],
+      data: [
+        { name: 'amount', type: 'i128' },
+        { name: 'expiration_ledger', type: 'u32' },
+      ],
+    },
+  ],
+  types: {
+    AllowanceValue: {
+      kind: 'struct',
+      name: 'AllowanceValue',
+      doc: 'Approved allowance entry.',
+      fields: [
+        { name: 'amount', type: 'i128' },
+        { name: 'expiration_ledger', type: 'u32' },
+      ],
+    },
+    TokenMetadata: {
+      kind: 'struct',
+      name: 'TokenMetadata',
+      fields: [
+        { name: 'decimal', type: 'u32' },
+        { name: 'name', type: 'string' },
+        { name: 'symbol', type: 'string' },
+      ],
+    },
+    TokenError: {
+      kind: 'enum',
+      name: 'TokenError',
+      doc: 'Error codes returned by the token contract.',
+      variants: [
+        { name: 'NotAuthorized', discriminant: 1 },
+        { name: 'InsufficientBalance', discriminant: 2 },
+        { name: 'InsufficientAllowance', discriminant: 3 },
+        { name: 'Overflow', discriminant: 4 },
+      ],
+    },
+    TransferKind: {
+      kind: 'union',
+      name: 'TransferKind',
+      doc: 'Discriminated union for transfer variants.',
+      cases: [
+        {
+          name: 'Standard',
+          fields: [
+            { name: 'from', type: 'address' },
+            { name: 'to', type: 'address' },
+            { name: 'amount', type: 'i128' },
+          ],
+        },
+        {
+          name: 'Burn',
+          fields: [
+            { name: 'from', type: 'address' },
+            { name: 'amount', type: 'i128' },
+          ],
+        },
+      ],
+    },
+  },
+  xdrEntries: [],
+};
+
+// ── spec.schema.json structural assertions ────────────────────────────────────
+
+describe('spec.schema.json', () => {
+  it('has a valid $schema and $id', () => {
+    expect(specSchema['$schema']).toContain('json-schema.org');
+    expect(typeof specSchema['$id']).toBe('string');
+  });
+
+  it('requires version, name, functions, events, types', () => {
+    const required = specSchema['required'] as string[];
+    expect(required).toContain('version');
+    expect(required).toContain('name');
+    expect(required).toContain('functions');
+    expect(required).toContain('events');
+    expect(required).toContain('types');
+  });
+
+  it('enumerates all 14 Soroban primitive types in PrimitiveType', () => {
+    const defs = specSchema['$defs'] as Record<string, unknown>;
+    const primitive = defs['PrimitiveType'] as Record<string, unknown>;
+    const enumValues = primitive['enum'] as string[];
+    const expected: string[] = [
+      'bool', 'u32', 'i32', 'u64', 'i64', 'u128', 'i128',
+      'u256', 'i256', 'bytes', 'string', 'symbol', 'address', 'void',
+    ];
+    expect(enumValues).toHaveLength(expected.length);
+    expected.forEach((p) => expect(enumValues).toContain(p));
+  });
+
+  it('defines all 8 composite TypeSpec variants', () => {
+    const defs = specSchema['$defs'] as Record<string, unknown>;
+    const expected = [
+      'BytesNType', 'OptionType', 'ResultType', 'VecType',
+      'MapType', 'TupleType', 'NamedType', 'TypeSpec',
+    ];
+    expected.forEach((key) => expect(defs).toHaveProperty(key));
+  });
+
+  it('TypeSpec uses oneOf over all 8 variants', () => {
+    const defs = specSchema['$defs'] as Record<string, unknown>;
+    const typeSpec = defs['TypeSpec'] as Record<string, unknown>;
+    const oneOf = typeSpec['oneOf'] as unknown[];
+    expect(oneOf).toHaveLength(8);
+  });
+
+  it('FunctionSpec requires name, params, returns', () => {
+    const defs = specSchema['$defs'] as Record<string, unknown>;
+    const fn = defs['FunctionSpec'] as Record<string, unknown>;
+    expect(fn['required']).toContain('name');
+    expect(fn['required']).toContain('params');
+    expect(fn['required']).toContain('returns');
+  });
+
+  it('EventSpec requires name, topics, data', () => {
+    const defs = specSchema['$defs'] as Record<string, unknown>;
+    const ev = defs['EventSpec'] as Record<string, unknown>;
+    expect(ev['required']).toContain('name');
+    expect(ev['required']).toContain('topics');
+    expect(ev['required']).toContain('data');
+  });
+
+  it('defines StructTypeSpec, EnumTypeSpec, UnionTypeSpec and UserDefinedType', () => {
+    const defs = specSchema['$defs'] as Record<string, unknown>;
+    ['StructTypeSpec', 'EnumTypeSpec', 'UnionTypeSpec', 'UserDefinedType'].forEach((key) =>
+      expect(defs).toHaveProperty(key),
+    );
+  });
+
+  it('TupleType enforces minItems: 2', () => {
+    const defs = specSchema['$defs'] as Record<string, unknown>;
+    const tupleType = defs['TupleType'] as Record<string, unknown>;
+    const props = tupleType['properties'] as Record<string, unknown>;
+    const elements = props['elements'] as Record<string, unknown>;
+    expect(elements['minItems']).toBe(2);
+  });
+});
+
+// ── validateSpec — representative spec ───────────────────────────────────────
+
+describe('validateSpec — representative spec validates', () => {
+  it('accepts the full representative SEP-41 token spec', () => {
+    const result = validateSpec(sampleSpec);
+    if (!result.valid) {
+      throw new Error(`Expected valid spec but got errors: ${result.errors.join(', ')}`);
+    }
+    expect(result.valid).toBe(true);
+  });
+});
+
+// ── validateSpec — valid inputs ───────────────────────────────────────────────
+
+describe('validateSpec — valid inputs', () => {
+  it('accepts a minimal spec', () => {
+    const minimal: ContractSpec = {
+      version: '0.1.0',
+      name: 'Minimal',
+      functions: [{ name: 'noop', params: [], returns: 'void' }],
+      events: [],
+      types: {},
+    };
+    expect(validateSpec(minimal).valid).toBe(true);
+  });
+
+  it('accepts all 14 Soroban primitive return types', () => {
+    const primitives = [
+      'bool', 'u32', 'i32', 'u64', 'i64', 'u128', 'i128',
+      'u256', 'i256', 'bytes', 'string', 'symbol', 'address', 'void',
+    ] as const;
+    for (const prim of primitives) {
+      const spec: ContractSpec = {
+        version: '1.0.0',
+        name: 'Prim',
+        functions: [{ name: 'f', params: [], returns: prim }],
+        events: [],
+        types: {},
+      };
+      const result = validateSpec(spec);
+      expect(result.valid, `primitive "${prim}" should be valid`).toBe(true);
+    }
+  });
+
+  it('accepts option<vec<address>> nested composite type', () => {
+    const spec: ContractSpec = {
+      version: '1.0.0',
+      name: 'Nested',
+      functions: [
+        {
+          name: 'get_owners',
+          params: [],
+          returns: { type: 'option', inner: { type: 'vec', item: 'address' } },
+        },
+      ],
+      events: [],
+      types: {},
+    };
+    expect(validateSpec(spec).valid).toBe(true);
+  });
+
+  it('accepts result<u128, bytes_n<32>>', () => {
+    const spec: ContractSpec = {
+      version: '1.0.0',
+      name: 'ResultContract',
+      functions: [
+        {
+          name: 'compute',
+          params: [],
+          returns: { type: 'result', ok: 'u128', err: { type: 'bytes_n', size: 32 } },
+        },
+      ],
+      events: [],
+      types: {},
+    };
+    expect(validateSpec(spec).valid).toBe(true);
+  });
+
+  it('accepts map<address, i128> as a param type', () => {
+    const spec: ContractSpec = {
+      version: '1.0.0',
+      name: 'MapContract',
+      functions: [
+        {
+          name: 'set_balances',
+          params: [{ name: 'balances', type: { type: 'map', key: 'address', value: 'i128' } }],
+          returns: 'void',
+        },
+      ],
+      events: [],
+      types: {},
+    };
+    expect(validateSpec(spec).valid).toBe(true);
+  });
+
+  it('accepts all three user-defined type kinds', () => {
+    const spec: ContractSpec = {
+      version: '1.0.0',
+      name: 'UserTypes',
+      functions: [],
+      events: [],
+      types: {
+        MyStruct: {
+          kind: 'struct',
+          name: 'MyStruct',
+          fields: [{ name: 'value', type: 'u64' }],
+        },
+        MyEnum: {
+          kind: 'enum',
+          name: 'MyEnum',
+          variants: [
+            { name: 'A', discriminant: 0 },
+            { name: 'B', discriminant: 1 },
+          ],
+        },
+        MyUnion: {
+          kind: 'union',
+          name: 'MyUnion',
+          cases: [
+            { name: 'SomeValue', fields: [{ name: 'x', type: 'u32' }] },
+            { name: 'None', fields: [] },
+          ],
+        },
+      },
+    };
+    expect(validateSpec(spec).valid).toBe(true);
+  });
+
+  it('accepts optional contractId and network', () => {
+    const spec: ContractSpec = {
+      version: '1.0.0',
+      name: 'WithNetwork',
+      contractId: 'CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM',
+      network: 'mainnet',
+      functions: [],
+      events: [],
+      types: {},
+    };
+    expect(validateSpec(spec).valid).toBe(true);
+  });
+});
+
+// ── validateSpec — invalid inputs ─────────────────────────────────────────────
+
+describe('validateSpec — invalid inputs', () => {
+  it('rejects null, strings, numbers, and arrays', () => {
+    expect(validateSpec(null).valid).toBe(false);
+    expect(validateSpec('spec').valid).toBe(false);
+    expect(validateSpec(42).valid).toBe(false);
+    expect(validateSpec([]).valid).toBe(false);
+  });
+
+  it('rejects missing version', () => {
+    const { version: _v, ...noVersion } = sampleSpec;
+    const result = validateSpec(noVersion);
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.errors.some((e) => e.includes('version'))).toBe(true);
+    }
+  });
+
+  it('rejects non-semver version strings', () => {
+    expect(validateSpec({ ...sampleSpec, version: 'v1.0' }).valid).toBe(false);
+    expect(validateSpec({ ...sampleSpec, version: '1.0' }).valid).toBe(false);
+    expect(validateSpec({ ...sampleSpec, version: '1' }).valid).toBe(false);
+  });
+
+  it('rejects empty name', () => {
+    expect(validateSpec({ ...sampleSpec, name: '' }).valid).toBe(false);
+  });
+
+  it('rejects invalid network value', () => {
+    expect(validateSpec({ ...sampleSpec, network: 'localnet' }).valid).toBe(false);
+    expect(validateSpec({ ...sampleSpec, network: 'devnet' }).valid).toBe(false);
+  });
+
+  it('rejects contractId not starting with C', () => {
+    expect(
+      validateSpec({
+        ...sampleSpec,
+        contractId: 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM',
+      }).valid,
+    ).toBe(false);
+  });
+
+  it('rejects functions that is not an array', () => {
+    expect(validateSpec({ ...sampleSpec, functions: {} }).valid).toBe(false);
+    expect(validateSpec({ ...sampleSpec, functions: null }).valid).toBe(false);
+  });
+
+  it('rejects a function param with an unknown type string', () => {
+    const result = validateSpec({
+      ...sampleSpec,
+      functions: [{ name: 'bad', params: [{ name: 'x', type: 'uint256' }], returns: 'void' }],
+    });
+    expect(result.valid).toBe(false);
+  });
+
+  it('rejects a tuple with only one element', () => {
+    const result = validateSpec({
+      ...sampleSpec,
+      functions: [
+        { name: 'bad_tuple', params: [], returns: { type: 'tuple', elements: ['u32'] } },
+      ],
+    });
+    expect(result.valid).toBe(false);
+  });
+
+  it('rejects bytes_n with size 0', () => {
+    const result = validateSpec({
+      ...sampleSpec,
+      functions: [
+        {
+          name: 'bad_bytes',
+          params: [{ name: 'h', type: { type: 'bytes_n', size: 0 } }],
+          returns: 'void',
+        },
+      ],
+    });
+    expect(result.valid).toBe(false);
+  });
+
+  it('rejects an event missing the topics field', () => {
+    const result = validateSpec({
+      ...sampleSpec,
+      events: [{ name: 'bad', data: [] }],
+    });
+    expect(result.valid).toBe(false);
+  });
+
+  it('returns errors as a non-empty array on failure', () => {
+    const result = validateSpec({ name: 'X', functions: null, events: null, types: null });
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(Array.isArray(result.errors)).toBe(true);
+      expect(result.errors.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+// ── TypeSpec coverage ─────────────────────────────────────────────────────────
+
+describe('TypeSpec — all Soroban composite tags are distinct', () => {
+  it('no duplicate composite type discriminants', () => {
+    const tags = ['bytes_n', 'option', 'result', 'vec', 'map', 'tuple', 'named'];
+    expect(new Set(tags).size).toBe(tags.length);
+  });
+
+  it('NamedType can reference structs, enums, and unions', () => {
+    const spec: ContractSpec = {
+      version: '1.0.0',
+      name: 'NamedRefs',
+      functions: [
+        { name: 'get_s', params: [], returns: { type: 'named', name: 'S' } },
+        { name: 'get_e', params: [], returns: { type: 'named', name: 'E' } },
+        { name: 'get_u', params: [], returns: { type: 'named', name: 'U' } },
+      ],
+      events: [],
+      types: {
+        S: { kind: 'struct', name: 'S', fields: [{ name: 'x', type: 'u32' }] },
+        E: { kind: 'enum', name: 'E', variants: [{ name: 'A', discriminant: 0 }] },
+        U: { kind: 'union', name: 'U', cases: [{ name: 'C', fields: [] }] },
+      },
+    };
+    expect(validateSpec(spec).valid).toBe(true);
+  });
+});


### PR DESCRIPTION
Closes #649

---

Define the full Soroban ABI type system in packages/abi-registry/src/spec.ts: TypeSpec covers all 14 primitives plus bytes_n, option, result, vec, map, tuple, and named composite types. FunctionSpec, EventSpec, FieldSpec, and the three user-defined type descriptors (StructTypeSpec, EnumTypeSpec, UnionTypeSpec) round out the ContractSpec envelope.

Add schema/spec.schema.json (JSON Schema draft-2020-12) for external validators. Export all types and validateSpec() from the package barrel. Rename the existing minimal XDR type to XdrContractSpec to avoid the name collision. Add 31 tests covering valid inputs, all Soroban primitives, nested composites, all three user-defined kinds, and a full suite of invalid-input rejections.

## Linked issue

Closes #

## What changed and why

<!-- One paragraph. What does this PR do, and why is the change needed? -->

## Test plan

<!-- How did you verify this works? Check everything that applies. -->

- [ ] Existing tests pass (`pnpm test`)
- [ ] New tests added for new behaviour
- [ ] Typechecks pass (`pnpm -r typecheck`)
- [ ] Manually tested against testnet / mainnet (describe what you tested)

## Breaking changes

<!-- Does this change any public API? If yes, describe the migration path. -->

None / Yes (describe below)

## Notes for reviewers

<!-- Anything the reviewer should pay special attention to, or context that isn't obvious from the diff. -->
