### PR TITLE
test(pulse-core): Add exhaustive switch type tests for event.type (#624)

### DIFF
--- a/packages/pulse-core/test/types.exhaustive.test-d.ts
+++ b/packages/pulse-core/test/types.exhaustive.test-d.ts
@@ -66,3 +66,78 @@ export function assertIncompleteIsRejected(event: NormalizedEvent): string {
     }
   }
 }
+
+// ---------------------------------------------------------------------------
+// No-default-clause variant (M3 "done when" requirement)
+// ---------------------------------------------------------------------------
+
+/**
+ * Positive case: exhaustive switch with NO default clause.  TypeScript's
+ * control-flow analysis narrows the union after the switch; when every branch
+ * is covered the function's return type `string` is satisfied.  Omit a branch
+ * and the function no longer returns `string` on all paths.
+ */
+export function assertExhaustiveNoDefault(event: NormalizedEvent): string {
+  switch (event.type) {
+    case "payment.received":
+    case "payment.sent":
+    case "payment.self":
+    case "account.created":
+    case "account.options_changed":
+    case "account.merged":
+    case "account.bump_sequence":
+    case "trustline.added":
+    case "trustline.removed":
+    case "trustline.updated":
+    case "trustline.authorized":
+    case "trustline.deauthorized":
+    case "offer.created":
+    case "offer.updated":
+    case "offer.deleted":
+    case "data.set":
+    case "data.cleared":
+    case "claimable.created":
+    case "claimable.claimed":
+    case "lp.deposited":
+    case "lp.withdrawn":
+    case "contract.invoked":
+    case "contract.emitted":
+      return event.type;
+  }
+}
+
+/**
+ * Negative case: incomplete switch with NO default clause and one omitted
+ * branch.  The missing `"contract.emitted"` case means the function does not
+ * return `string` on all paths, producing a compile error that
+ * `@ts-expect-error` asserts.  Add `"contract.emitted"` back (or the union
+ * loses that member) and the directive becomes unused, failing the build.
+ */
+// @ts-expect-error - contract.emitted is not handled here.
+export function assertMissingBranchNoDefault(event: NormalizedEvent): string {
+  switch (event.type) {
+    case "payment.received":
+    case "payment.sent":
+    case "payment.self":
+    case "account.created":
+    case "account.options_changed":
+    case "account.merged":
+    case "account.bump_sequence":
+    case "trustline.added":
+    case "trustline.removed":
+    case "trustline.updated":
+    case "trustline.authorized":
+    case "trustline.deauthorized":
+    case "offer.created":
+    case "offer.updated":
+    case "offer.deleted":
+    case "data.set":
+    case "data.cleared":
+    case "claimable.created":
+    case "claimable.claimed":
+    case "lp.deposited":
+    case "lp.withdrawn":
+    case "contract.invoked":
+      return event.type;
+  }
+}


### PR DESCRIPTION
## Linked issue

Closes #624

## What changed and why

This PR fulfills the milestone M3 "done when" criteria by adding type-only tests to `packages/pulse-core/test/types.exhaustive.test-d.ts` that guarantee exhaustive switch statements on `event.type` (without a `default` clause) are strictly enforced by TypeScript. It includes a positive test (`assertExhaustiveNoDefault`) handling all 23 `NormalizedEvent` variants, and a negative test (`assertMissingBranchNoDefault`) that intentionally omits the `"contract.emitted"` branch with a `// @ts-expect-error` directive to assert the resulting `TS2366` compilation error.

## Test plan

- [x] Existing tests pass (`pnpm test`)
- [x] New tests added for new behaviour
- [x] Typechecks pass (`pnpm -r typecheck`)
- [ ] Manually tested against testnet / mainnet (describe what you tested)

## Breaking changes

None

## Notes for reviewers

I manually verified the robustness of this test by:
1. Confirming the type tests pass with the `@ts-expect-error` directive in place.
2. Removing the directive and confirming it correctly surfaces the TypeScript error (`TS2366: Function lacks ending return statement and return type does not include 'undefined'`).
3. Verifying that adding a hypothetical new event type to `NormalizedEvent` without updating these switches immediately triggers a build failure, securing our guarantee moving forward.