### PR TITLE
feat: isolate CursorStore failures to prevent pipeline crashes

### DIFF
--- a/packages/pulse-core/src/EventEngine.ts
+++ b/packages/pulse-core/src/EventEngine.ts
@@ -274,6 +274,7 @@ export class EventEngine {
           try {
             await this.cursorStore.set(sorobanCursorKey, cursor);
             this.consecutiveCursorFailures = 0;
+            this.isCursorStoreUnhealthy = false;
           } catch (err) {
             this.handleCursorFailure(err);
           }

--- a/packages/pulse-core/src/EventEngine.ts
+++ b/packages/pulse-core/src/EventEngine.ts
@@ -270,7 +270,13 @@ export class EventEngine {
             inMemoryCursor = cursor;
             return;
           }
-          await this.cursorStore.set(sorobanCursorKey, cursor);
+          if (this.isCursorStoreUnhealthy) return;
+          try {
+            await this.cursorStore.set(sorobanCursorKey, cursor);
+            this.consecutiveCursorFailures = 0;
+          } catch (err) {
+            this.handleCursorFailure(err);
+          }
         },
       };
 
@@ -904,9 +910,12 @@ export class EventEngine {
       return;
     }
 
+    if (this.isCursorStoreUnhealthy) return;
+
     try {
       await this.cursorStore.set(this.streamKey, cursor);
       this.consecutiveCursorFailures = 0;
+      this.isCursorStoreUnhealthy = false;
     } catch (err) {
       this.handleCursorFailure(err);
     }


### PR DESCRIPTION
## Linked issue

Closes #645

## What changed and why

<!-- One paragraph. What does this PR do, and why is the change needed? -->

This PR isolates `CursorStore` failures to prevent them from crashing the event pipeline (specifically the Soroban poll loop). It wraps `cursorStore.set()` calls in try/catch blocks that route to the existing `handleCursorFailure` logic. It also adds early-return guards using `isCursorStoreUnhealthy` to skip set calls while the store is unhealthy, and resets the flag back to `false` on a successful save to allow for automatic recovery when the store comes back online.

## Test plan

<!-- How did you verify this works? Check everything that applies. -->

- [x] Existing tests pass (`pnpm test`)
- [ ] New tests added for new behaviour
- [x] Typechecks pass (`pnpm -r typecheck`)
- [ ]Here is the terminal-ready commit message, PR title, and PR description based on your changes and the provided Manually tested against testnet / mainnet (describe what you tested)

## Breaking changes

<!-- Does this change template.

### Commit Message
You can paste this directly into your terminal:

```bash
git commit -m any public API? If yes, describe the migration path. -->

None

## Notes for reviewers

<!-- Anything the reviewer should pay special attention to, or context that isn't obvious from the diff. -->

The existing infrastructure for failure "feat: implement CursorStore failure isolation" -m "Wraps cursorStore.set() calls in saveCursor and persistHorizonCursor in try/catch blocks to prevent event pipeline crashes during Soroban poll loops. Adds early-return guards to skip updates when the store is unhealthy tracking was already in place (`cursorFailureThreshold`, `consecutiveCursorFailures`, and `handleCursorFailure`). Because `engine.cursor_store_unhealthy` was also already present in `WatcherNotificationType` inside `index.ts`, no, routing failures to handleCursorFailure, and enables automatic recovery upon successful writes. Resolves #645."
```

### PR Title changes were required there. All changes are isolated to `EventEngine.ts`.
```