### PR TITLE
refactor: ClaimPredicate recursive type and evaluatePredicate helper

### DIFF
--- a/packages/pulse-core/src/EventEngine.ts
+++ b/packages/pulse-core/src/EventEngine.ts
@@ -67,6 +67,7 @@ import type {
   RawSorobanEvent,
 } from "./index.js";
 import { UnknownNetworkError, NETWORK_PASSPHRASES } from "./index.js";
+import { normalizeClaimPredicate } from "./claimPredicate.js";
 
 type PendingPaymentEvent = Omit<PaymentEvent, "type"> & { type: "unknown" };
 type NormalizedEventOrPending =
@@ -1479,7 +1480,7 @@ export class EventEngine {
       balanceId: r.balance_id as string,
       claimants: (r.claimants as Array<Record<string, unknown>>).map((c) => ({
         destination: toAccountAddress(c.destination as string),
-        predicate: c.predicate,
+        predicate: normalizeClaimPredicate(c.predicate as Record<string, unknown>),
       })),
       asset,
       amount: toStellarAmount(r.amount as string),

--- a/packages/pulse-core/src/claimPredicate.ts
+++ b/packages/pulse-core/src/claimPredicate.ts
@@ -73,25 +73,27 @@ export function isClaimPredicateType<T extends ClaimPredicate["type"]>(
 }
 
 /**
- * Evaluates a claim predicate against a given timestamp
+ * Evaluates a claim predicate against a given Date
  *
  * @param predicate - The claim predicate to evaluate
- * @param nowSeconds - Current time in UNIX seconds (from ledger close time)
+ * @param now - Current time
  * @returns true if the predicate is satisfied, false otherwise
  */
-export function evaluatePredicate(predicate: ClaimPredicate, nowSeconds: number): boolean {
+export function evaluatePredicate(predicate: ClaimPredicate, now: Date): boolean {
+  const nowSeconds = Math.floor(now.getTime() / 1000);
+
   switch (predicate.type) {
     case "unconditional":
       return true;
 
     case "not":
-      return !evaluatePredicate(predicate.predicate, nowSeconds);
+      return !evaluatePredicate(predicate.predicate, now);
 
     case "and":
-      return predicate.predicates.every((p) => evaluatePredicate(p, nowSeconds));
+      return predicate.predicates.every((p) => evaluatePredicate(p, now));
 
     case "or":
-      return predicate.predicates.some((p) => evaluatePredicate(p, nowSeconds));
+      return predicate.predicates.some((p) => evaluatePredicate(p, now));
 
     case "abs_before": {
       // Parse ISO8601 timestamp to UNIX seconds

--- a/packages/pulse-core/src/index.ts
+++ b/packages/pulse-core/src/index.ts
@@ -1,6 +1,7 @@
 import { CursorStore } from "./CursorStore.js";
 import type { StellarAmount } from "./amount.js";
 import type { AccountAddress, MuxedAddress, ContractAddress } from "./address.js";
+import type { ClaimPredicate } from "./claimPredicate.js";
 
 export { SorobanRpcClient } from "./SorobanRpcClient.js";
 export type {
@@ -62,6 +63,7 @@ export { InMemoryRegistryStore } from "./IRegistryStore.js";
 export { FileRegistryStore } from "./FileRegistryStore.js";
 
 export { isEventType } from "./eventTypeGuard.js";
+export * from "./claimPredicate.js";
 export * from "./raw-horizon.js";
 export * from "./raw-soroban.js";
 import type { RawSorobanEvent } from "./raw-soroban.js";
@@ -239,7 +241,7 @@ export type BumpSequenceEvent = {
 
 export type ClaimableBalanceClaimant = {
   destination: AccountAddress;
-  predicate: unknown;
+  predicate: ClaimPredicate;
 };
 
 export type ClaimableCreatedEvent = {

--- a/packages/pulse-core/test/pulse-core.test.ts
+++ b/packages/pulse-core/test/pulse-core.test.ts
@@ -1544,7 +1544,7 @@ describe("pulse-core EventEngine", () => {
         type: "claimable.created",
         sponsor: "GSPONSOR",
         balanceId: "00000000abc123",
-        claimants: [{ destination: "GCLAIMANT1", predicate: { unconditional: true } }],
+        claimants: [{ destination: "GCLAIMANT1", predicate: { type: "unconditional" } }],
         asset: "XLM",
         amount: "100",
         timestamp: "2026-04-28T12:00:00.000Z",


### PR DESCRIPTION
## Linked issue

Closes #657

## What changed and why

<!-- One paragraph. What does this PR do, and why is the change needed? -->
This PR eliminates the need for consumers to cast `ClaimableBalanceClaimant.predicate` as `any` by introducing a strictly typed, recursive `ClaimPredicate` AST. It updates `index.ts` to narrow the claimant predicate type from `unknown` to `ClaimPredicate` and exports all related types and helpers. The `evaluatePredicate` helper was also updated to accept a standard JavaScript `Date` object rather than raw seconds. Finally, raw Horizon predicates (like `{ unconditional: true }`) are now automatically mapped to their normalized discriminated union shapes (e.g., `{ type: "unconditional" }`) inside `EventEngine`.

## Test plan

<!-- How did you verify this works? Check everything that applies. -->

- [x] Existing tests pass (`pnpm test`)
- [ ] New tests added for new behaviour
- [x] Typechecks pass (`pnpm -r typecheck`)
- [ ] Manually tested against testnet / mainnet (describe what you tested)

## Breaking changes

<!-- Does this change any public API? If yes, describe the migration path. -->

Yes. 
1. `evaluatePredicate` now expects `(predicate, now: Date)` instead of `(predicate, nowSeconds: number)`.
2. `ClaimableBalanceClaimant.predicate` is no longer `unknown`; it is strictly typed to `ClaimPredicate`.
3. Event consumers will now receive normalized predicate shapes (e.g., `{ type: "unconditional" }`) instead of raw Horizon shapes (e.g., `{ unconditional: true }`). Consumers will need to update their code to pattern-match on the `type` property.

## Notes for reviewers

<!-- Anything the reviewer should pay special attention to, or context that isn't obvious from the diff. -->

Take a look at `packages/pulse-core/src/EventEngine.ts`. I integrated `normalizeClaimPredicate` within `normalizeCreateClaimableBalance` to ensure all claimants are normalized at the source. The test assertions in `pulse-core.test.ts` have been updated to reflect this new normalized shape.