### PR TITLE
feat(pulse-notify): add caughtUp flag via Last-Event-ID offline replay

### DIFF
--- a/packages/pulse-notify/README.md
+++ b/packages/pulse-notify/README.md
@@ -191,9 +191,11 @@ Customize the built-in styles with CSS custom properties:
 
 ```ts
 type EventState<T extends NormalizedEvent = NormalizedEvent> = {
-  event: T | null;     // Latest event, or null before first arrival
-  connected: boolean;  // True once the SSE handshake completes
-  error: string | null; // Error message if the connection fails
+  event: T | null;            // Latest event, or null before first arrival
+  connected: boolean;         // True once the SSE handshake completes
+  error: string | null;       // Error message if the connection fails
+  lastEventAt: string | null; // ISO timestamp of the most recent event
+  caughtUp: boolean;          // See "Offline replay / Last-Event-ID" below
 };
 ```
 
@@ -334,14 +336,52 @@ If the server is cross-origin, it must respond with `Access-Control-Allow-Creden
 
 The hooks are client-only — they rely on `EventSource`, which does not exist in Node. In Next.js App Router, mark the consuming component with `"use client"`. In Remix or Vite SSR, gate the hook behind a client-only boundary.
 
+## Offline replay / Last-Event-ID
+
+When a network drop causes the `EventSource` to reconnect, the browser automatically sends a `Last-Event-ID` request header containing the last `id:` value it received. The server can use this cursor to replay any events the client missed.
+
+### Backend contract
+
+Each SSE event your server emits must include an `id:` line with the event's cursor value:
+
+```
+id: <cursor>
+data: {"type":"payment.received","amount":"10","asset":"XLM",...}
+
+```
+
+The cursor can be a ledger sequence number, a database row ID, or any opaque string your backend can use to resume the stream. Without `id:` fields the browser cannot send `Last-Event-ID` and no replay occurs.
+
+### Hook behaviour
+
+The hook surfaces the catch-up state via `caughtUp` in `EventState`:
+
+| State | `caughtUp` |
+|---|---|
+| Fresh connection, no prior `id:` seen | `true` |
+| Events arriving on a live connection | `true` |
+| Reconnected after a network drop; awaiting first replay event | `false` |
+| First replay event delivered | `true` |
+
+```tsx
+const { event, connected, caughtUp } = useStellarEvent(serverUrl, address);
+
+if (!connected) return <div>Reconnecting…</div>;
+if (!caughtUp)  return <div>Catching up on missed events…</div>;
+// Now live — render event
+```
+
+`caughtUp` transitions `false → true` as soon as the first post-reconnect event arrives. It does not wait for the server to signal "end of replay" (SSE has no such primitive), so additional events may still be in flight.
+
 ## Current limitations
 
 - Hook instances with the same `serverUrl`, `address`, and `token` share one browser `EventSource`; different keys open separate connections.
-- **No offline queue.** Events that arrive while the tab is backgrounded and the connection is closed are not replayed on reconnect.
 - **`EventSource` reconnect is browser-controlled.** Fine-grained retry policy belongs in a future WebSocket-based transport.
+- Offline replay via `Last-Event-ID` only covers automatic `EventSource` reconnects (network interruptions). Explicitly closed connections (e.g. when the tab is hidden past `hideAfterMs`) create a new `EventSource` without a `Last-Event-ID`, so events during that window are still missed.
 
 ## Related documents
 
+- [Offline replay / Last-Event-ID](#offline-replay--last-event-id) — `caughtUp` flag, backend `id:` contract
 - [Migration guide: from raw EventSource to useStellarEvent](../../apps/web/content/guides/migrate-from-eventsource.md) — before/after for the three most common raw `EventSource` patterns
 - [`docs/ARCHITECTURE.md` § 7 React hook internals](../../docs/ARCHITECTURE.md#7-react-hook-internals) — design choices (stable dep-array, dual call signature, generic narrowing)
 - [`docs/COOKBOOK.md` § 10 Render live payments in React with type narrowing](../../docs/COOKBOOK.md#10-render-live-payments-in-react-with-type-narrowing)

--- a/packages/pulse-notify/src/connectionPool.ts
+++ b/packages/pulse-notify/src/connectionPool.ts
@@ -13,6 +13,8 @@ type ConnectionSubscriber = {
   onParseError: () => void;
   onError: () => void;
   onAuthExpired?: () => void;
+  /** Called with the SSE `id:` field value when non-empty; enables Last-Event-ID catch-up tracking. */
+  onEventId?: (id: string) => void;
 };
 
 type ConnectionEntry = {
@@ -108,7 +110,11 @@ export function acquireEventConnection(key: ConnectionKey, subscriber: Connectio
           return;
         }
         const event = data as NormalizedEvent;
-        notifySubscribers(newEntry, (current) => current.onEvent(event));
+        const id = message.lastEventId;
+        notifySubscribers(newEntry, (current) => {
+          if (id) current.onEventId?.(id);
+          current.onEvent(event);
+        });
         withDevtools((mod) => {
           if (newEntry.devId) mod.updateConnection(newEntry.devId, { lastEvent: Date.now() });
         });
@@ -257,7 +263,11 @@ export function acquireContractEventConnection(
           return;
         }
         const event = data as NormalizedEvent;
-        notifySubscribers(newEntry, (cur) => cur.onEvent(event));
+        const id = message.lastEventId;
+        notifySubscribers(newEntry, (cur) => {
+          if (id) cur.onEventId?.(id);
+          cur.onEvent(event);
+        });
         withDevtools((mod) => {
           if (newEntry.devId) mod.updateConnection(newEntry.devId, { lastEvent: Date.now() });
         });

--- a/packages/pulse-notify/src/index.ts
+++ b/packages/pulse-notify/src/index.ts
@@ -40,6 +40,11 @@ export type EventState<T extends NormalizedEvent = NormalizedEvent> = {
   connected: boolean;
   error: string | null;
   lastEventAt: string | null;
+  /** False only during the brief window after a reconnect where the stream is
+   *  replaying events the browser requested via Last-Event-ID. Becomes true
+   *  again as soon as the first event is delivered, or immediately on a fresh
+   *  connection where no prior event ID was recorded. */
+  caughtUp: boolean;
 };
 
 function useVisibilityState(hideAfterMs = 30000): boolean {
@@ -160,11 +165,16 @@ export function useStellarEvent<T extends NormalizedEvent = NormalizedEvent>(
     connected: false,
     error: null,
     lastEventAt: null,
+    caughtUp: true,
   });
+
+  const lastEventIdRef = useRef("");
 
   const isActive = useVisibilityState(hideAfterMs ?? 30000);
 
   useEffect(() => {
+    lastEventIdRef.current = "";
+
     if (!isActive) {
       setState((prev) => ({ ...prev, connected: false }));
       return;
@@ -180,7 +190,15 @@ export function useStellarEvent<T extends NormalizedEvent = NormalizedEvent>(
       },
       {
         onOpen: () => {
-          setState((prev) => ({ ...prev, connected: true, error: null }));
+          setState((prev) => ({
+            ...prev,
+            connected: true,
+            error: null,
+            caughtUp: !lastEventIdRef.current,
+          }));
+        },
+        onEventId: (id) => {
+          lastEventIdRef.current = id;
         },
         onEvent: (incoming) => {
           onEventRef.current?.(incoming);
@@ -198,6 +216,7 @@ export function useStellarEvent<T extends NormalizedEvent = NormalizedEvent>(
             ...prev,
             event: incoming as T,
             lastEventAt: incoming.timestamp ?? null,
+            caughtUp: true,
           }));
         },
         onParseError: () => {
@@ -408,11 +427,16 @@ export function useContractEvent<
     connected: false,
     error: null,
     lastEventAt: null,
+    caughtUp: true,
   });
+
+  const lastEventIdRef = useRef("");
 
   const isActive = useVisibilityState(hideAfterMs ?? 30000);
 
   useEffect(() => {
+    lastEventIdRef.current = "";
+
     if (!isActive) {
       setState((prev) => ({ ...prev, connected: false }));
       return;
@@ -422,7 +446,15 @@ export function useContractEvent<
       { serverUrl, contractId, topics, token: currentToken, withCredentials },
       {
         onOpen: () => {
-          setState((prev) => ({ ...prev, connected: true, error: null }));
+          setState((prev) => ({
+            ...prev,
+            connected: true,
+            error: null,
+            caughtUp: !lastEventIdRef.current,
+          }));
+        },
+        onEventId: (id) => {
+          lastEventIdRef.current = id;
         },
         onEvent: (incoming) => {
           onEventRef.current?.(incoming);
@@ -439,6 +471,7 @@ export function useContractEvent<
             ...prev,
             event: incoming as unknown as T,
             lastEventAt: incoming.timestamp ?? null,
+            caughtUp: true,
           }));
         },
         onParseError: () => {
@@ -573,7 +606,13 @@ export function useStellarAddresses<T extends NormalizedEvent = NormalizedEvent>
   const [states, setStates] = useState<Record<string, EventState<T>>>(() => {
     const initial: Record<string, EventState<T>> = {};
     for (const addr of addresses) {
-      initial[addr] = { event: null, connected: false, error: null, lastEventAt: null };
+      initial[addr] = {
+        event: null,
+        connected: false,
+        error: null,
+        lastEventAt: null,
+        caughtUp: true,
+      };
     }
     return initial;
   });
@@ -601,7 +640,11 @@ export function useStellarAddresses<T extends NormalizedEvent = NormalizedEvent>
 
   const [tokenRefreshKey, setTokenRefreshKey] = useState(0);
 
+  const lastEventIdMapRef = useRef<Map<string, string>>(new Map());
+
   useEffect(() => {
+    lastEventIdMapRef.current.clear();
+
     if (addresses.length === 0) return;
 
     // Normalise the event-type list once for all subscriptions.
@@ -614,8 +657,16 @@ export function useStellarAddresses<T extends NormalizedEvent = NormalizedEvent>
           onOpen: () => {
             setStates((prev) => ({
               ...prev,
-              [addr]: { ...prev[addr]!, connected: true, error: null },
+              [addr]: {
+                ...prev[addr]!,
+                connected: true,
+                error: null,
+                caughtUp: !lastEventIdMapRef.current.get(addr),
+              },
             }));
+          },
+          onEventId: (id) => {
+            lastEventIdMapRef.current.set(addr, id);
           },
           onEvent: (incoming) => {
             onEventRef.current?.(addr, incoming);
@@ -637,6 +688,7 @@ export function useStellarAddresses<T extends NormalizedEvent = NormalizedEvent>
                 ...prev[addr]!,
                 event: incoming as T,
                 lastEventAt: incoming.timestamp ?? null,
+                caughtUp: true,
               },
             }));
           },

--- a/packages/pulse-notify/test/caughtUp.test.tsx
+++ b/packages/pulse-notify/test/caughtUp.test.tsx
@@ -1,0 +1,188 @@
+/**
+ * Tests for the caughtUp flag in EventState.
+ *
+ * caughtUp is true on a fresh connection (nothing to replay) and transitions
+ * false → true when the EventSource auto-reconnects after a network drop and
+ * the server replays events via Last-Event-ID.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useStellarEvent } from "../src/index.ts";
+import { __resetConnectionPoolForTests } from "../src/connectionPool.ts";
+
+// ---------------------------------------------------------------------------
+// MockEventSource that supports lastEventId on emitted messages
+// ---------------------------------------------------------------------------
+
+class MockEventSource {
+  static instances: MockEventSource[] = [];
+
+  onopen: (() => void) | null = null;
+  onmessage: ((e: { data: string; lastEventId: string }) => void) | null = null;
+  onerror: (() => void) | null = null;
+  closeCount = 0;
+
+  constructor(readonly url: string) {
+    MockEventSource.instances.push(this);
+  }
+
+  close() {
+    this.closeCount += 1;
+  }
+
+  /** Fire onmessage with an optional SSE id field. */
+  emit(event: unknown, lastEventId = "") {
+    this.onmessage?.({ data: JSON.stringify(event), lastEventId });
+  }
+}
+
+let originalEventSource: typeof globalThis.EventSource;
+
+beforeEach(() => {
+  originalEventSource = globalThis.EventSource;
+  globalThis.EventSource = MockEventSource as unknown as typeof EventSource;
+  MockEventSource.instances = [];
+});
+
+afterEach(() => {
+  globalThis.EventSource = originalEventSource;
+  __resetConnectionPoolForTests();
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const SERVER = "https://events.example.com";
+const ADDRESS = "GABC123";
+
+function getSource(): MockEventSource {
+  const src = MockEventSource.instances[0];
+  if (!src) throw new Error("No MockEventSource instance created");
+  return src;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("caughtUp flag", () => {
+  it("is true before any connection opens (initial state)", () => {
+    const { result } = renderHook(() => useStellarEvent(SERVER, ADDRESS));
+    expect(result.current.caughtUp).toBe(true);
+  });
+
+  it("remains true on fresh open when no prior event ID was recorded", () => {
+    const { result } = renderHook(() => useStellarEvent(SERVER, ADDRESS));
+    const src = getSource();
+
+    act(() => {
+      src.onopen?.();
+    });
+
+    expect(result.current.caughtUp).toBe(true);
+  });
+
+  it("remains true when events arrive without an SSE id field", () => {
+    const { result } = renderHook(() => useStellarEvent(SERVER, ADDRESS));
+    const src = getSource();
+
+    act(() => {
+      src.onopen?.();
+    });
+    act(() => {
+      src.emit({ type: "payment.received", timestamp: "2026-01-01T00:00:00Z" });
+    });
+
+    expect(result.current.caughtUp).toBe(true);
+  });
+
+  it("is true while receiving events with an SSE id field (live stream)", () => {
+    const { result } = renderHook(() => useStellarEvent(SERVER, ADDRESS));
+    const src = getSource();
+
+    act(() => {
+      src.onopen?.();
+    });
+    act(() => {
+      src.emit({ type: "payment.received", timestamp: "2026-01-01T00:00:00Z" }, "cursor-1");
+    });
+
+    expect(result.current.caughtUp).toBe(true);
+  });
+
+  it("flips to false on reconnect open when a prior event ID was recorded", () => {
+    const { result } = renderHook(() => useStellarEvent(SERVER, ADDRESS));
+    const src = getSource();
+
+    // Initial connection — receive an event with an SSE id
+    act(() => {
+      src.onopen?.();
+    });
+    act(() => {
+      src.emit({ type: "payment.received", timestamp: "2026-01-01T00:00:00Z" }, "cursor-1");
+    });
+    expect(result.current.caughtUp).toBe(true);
+
+    // Network drop — EventSource fires onerror, then auto-reconnects (onopen again)
+    act(() => {
+      src.onerror?.();
+    });
+    act(() => {
+      src.onopen?.();
+    });
+
+    expect(result.current.connected).toBe(true);
+    expect(result.current.caughtUp).toBe(false);
+  });
+
+  it("returns to true when the first replay event arrives after reconnect", () => {
+    const { result } = renderHook(() => useStellarEvent(SERVER, ADDRESS));
+    const src = getSource();
+
+    // Establish, receive event with id, drop, reconnect
+    act(() => {
+      src.onopen?.();
+    });
+    act(() => {
+      src.emit({ type: "payment.received", timestamp: "2026-01-01T00:00:00Z" }, "cursor-1");
+    });
+    act(() => {
+      src.onerror?.();
+    });
+    act(() => {
+      src.onopen?.();
+    });
+
+    expect(result.current.caughtUp).toBe(false);
+
+    // Replay event arrives
+    act(() => {
+      src.emit({ type: "payment.received", timestamp: "2026-01-01T00:00:01Z" }, "cursor-2");
+    });
+
+    expect(result.current.caughtUp).toBe(true);
+  });
+
+  it("does not flip to false on reconnect when no event id was ever received", () => {
+    const { result } = renderHook(() => useStellarEvent(SERVER, ADDRESS));
+    const src = getSource();
+
+    // Connect, receive events without id, drop, reconnect
+    act(() => {
+      src.onopen?.();
+    });
+    act(() => {
+      src.emit({ type: "payment.received", timestamp: "2026-01-01T00:00:00Z" });
+    });
+    act(() => {
+      src.onerror?.();
+    });
+    act(() => {
+      src.onopen?.();
+    });
+
+    // No prior id — server wasn't sending id fields, so no replay expected
+    expect(result.current.caughtUp).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `caughtUp: boolean` to `EventState` in `@orbital-stellar/pulse-notify`
- Surfaces `false` during the brief window after an auto-reconnect where the browser has sent `Last-Event-ID` and is waiting for the server to replay missed events; reverts to `true` on the first event received
- Documents the backend SSE contract (`id: <cursor>` in every `data:` block) and the updated `EventState` shape in `README.md`

## Changes

**`packages/pulse-notify/src/connectionPool.ts`**
- Added `onEventId?: (id: string) => void` to `ConnectionSubscriber`
- Both `acquireEventConnection` and `acquireContractEventConnection` now forward `message.lastEventId` to subscribers when non-empty

**`packages/pulse-notify/src/index.ts`**
- `EventState<T>` gains `caughtUp: boolean`
- `useStellarEvent`, `useContractEvent`, and `useStellarAddresses` each track the last-seen SSE event ID; `onOpen` sets `caughtUp: !lastEventId` (false on reconnect when an ID was recorded, true on fresh connect); `onEvent` always sets `caughtUp: true`

**`packages/pulse-notify/test/caughtUp.test.tsx`** (new)
- 6 test cases: initial state, fresh open, live events without `id:`, live events with `id:`, reconnect flip to false, return to true on first replay event

**`packages/pulse-notify/README.md`**
- Updated `EventState` type block with `caughtUp` and `lastEventAt`
- New "Offline replay / Last-Event-ID" section with backend contract, state table, and usage example
- Removed "No offline queue" limitation; added accurate scoped caveat

## Verification

```
Tests:  55 passed (55) — 10 test files including new caughtUp.test.tsx
```

All existing tests continue to pass; `onEventId` is optional so no breaking changes to consumers or existing mocks.

closes #690