### PR TITLE
feat(pulse-core): add reconnection and rate-limit resilience to SorobanSubscriber

### DIFF
--- a/apps/web/content/guides/migrate-from-eventsource.md
+++ b/apps/web/content/guides/migrate-from-eventsource.md
@@ -1,0 +1,273 @@
+---
+title: Migrate from raw EventSource to useStellarEvent
+description: Before/after for the three most common raw EventSource patterns.
+---
+
+If you're currently wiring a browser `EventSource` by hand to consume an Orbital backend, this guide shows you how to replace that code with `@orbital-stellar/pulse-notify` hooks and what you gain from doing so.
+
+## Why migrate
+
+Raw `EventSource` requires you to write the same wiring every time: open the connection, parse JSON, handle `onerror`, call `.close()` in a cleanup effect, and re-open when the address changes. `pulse-notify` does all of that and shares one underlying connection across hook instances that watch the same endpoint.
+
+## Pattern 1 — listen for a single event type
+
+### Before
+
+```tsx
+"use client";
+import { useEffect, useState } from "react";
+
+interface PaymentEvent {
+  type: "payment.received";
+  amount: string;
+  asset: string;
+  from: string;
+  timestamp: string;
+}
+
+export function LivePayments({ address }: { address: string }) {
+  const [event, setEvent] = useState<PaymentEvent | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const url = `${process.env.NEXT_PUBLIC_ORBITAL_URL}/events/${address}?type=payment.received`;
+    const es = new EventSource(url);
+
+    es.onmessage = (e) => {
+      try {
+        setEvent(JSON.parse(e.data));
+      } catch {
+        setError("Failed to parse event");
+      }
+    };
+
+    es.onerror = () => {
+      setError("Connection error");
+      es.close();
+    };
+
+    return () => {
+      es.close();
+    };
+  }, [address]);
+
+  if (error) return <div className="text-red-500">{error}</div>;
+  if (!event) return <div>Listening for payments…</div>;
+
+  return (
+    <div>
+      +{event.amount} {event.asset} from {event.from.slice(0, 8)}…
+    </div>
+  );
+}
+```
+
+### After
+
+```tsx
+"use client";
+import { useStellarPayment } from "@orbital-stellar/pulse-notify";
+
+export function LivePayments({ address }: { address: string }) {
+  const { event, connected, error } = useStellarPayment(
+    process.env.NEXT_PUBLIC_ORBITAL_URL!,
+    address
+  );
+
+  if (error) return <div className="text-red-500">{error}</div>;
+  if (!connected) return <div>Connecting…</div>;
+  if (!event) return <div>Listening for payments…</div>;
+
+  return (
+    <div>
+      +{event.amount} {event.asset} from {event.from.slice(0, 8)}…
+    </div>
+  );
+}
+```
+
+`useStellarPayment` is a shorthand for `useStellarEvent(serverUrl, address, { event: "payment.received" })`. It handles connection lifecycle and JSON parsing internally.
+
+---
+
+## Pattern 2 — listen for multiple event types
+
+### Before
+
+```tsx
+"use client";
+import { useEffect, useState } from "react";
+import type { NormalizedEvent } from "@orbital-stellar/pulse-core";
+
+const TYPES = ["payment.received", "payment.sent", "trustline.added"];
+
+export function ActivityFeed({ address }: { address: string }) {
+  const [events, setEvents] = useState<NormalizedEvent[]>([]);
+
+  useEffect(() => {
+    const sources = TYPES.map((type) => {
+      const url = `${process.env.NEXT_PUBLIC_ORBITAL_URL}/events/${address}?type=${type}`;
+      const es = new EventSource(url);
+
+      es.onmessage = (e) => {
+        try {
+          const event: NormalizedEvent = JSON.parse(e.data);
+          setEvents((prev) => [event, ...prev].slice(0, 50));
+        } catch {
+          // ignore parse errors
+        }
+      };
+
+      return es;
+    });
+
+    return () => {
+      sources.forEach((es) => es.close());
+    };
+  }, [address]);
+
+  if (!events.length) return <div>No activity yet…</div>;
+
+  return (
+    <ul>
+      {events.map((e, i) => (
+        <li key={i}>{e.type}</li>
+      ))}
+    </ul>
+  );
+}
+```
+
+### After
+
+```tsx
+"use client";
+import { useEffect, useState } from "react";
+import { useStellarEvent } from "@orbital-stellar/pulse-notify";
+import type { NormalizedEvent } from "@orbital-stellar/pulse-core";
+
+const PAYMENT_TYPES = ["payment.received", "payment.sent", "trustline.added"] as const;
+
+export function ActivityFeed({ address }: { address: string }) {
+  const [history, setHistory] = useState<NormalizedEvent[]>([]);
+
+  const { event } = useStellarEvent(
+    process.env.NEXT_PUBLIC_ORBITAL_URL!,
+    address,
+    { event: PAYMENT_TYPES }
+  );
+
+  useEffect(() => {
+    if (event) setHistory((h) => [event, ...h].slice(0, 50));
+  }, [event]);
+
+  if (!history.length) return <div>No activity yet…</div>;
+
+  return (
+    <ul>
+      {history.map((e, i) => (
+        <li key={i}>{e.type}</li>
+      ))}
+    </ul>
+  );
+}
+```
+
+One hook, one connection — regardless of how many event types you subscribe to. Hoist the types array as a constant (or `useMemo` it) so the hook's effect stays stable across renders.
+
+---
+
+## Pattern 3 — authenticated connection with a bearer token
+
+### Before
+
+```tsx
+"use client";
+import { useEffect, useState } from "react";
+import type { NormalizedEvent } from "@orbital-stellar/pulse-core";
+
+export function SecureEventStream({
+  address,
+  token,
+}: {
+  address: string;
+  token: string;
+}) {
+  const [event, setEvent] = useState<NormalizedEvent | null>(null);
+  const [connected, setConnected] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const url = `${process.env.NEXT_PUBLIC_ORBITAL_URL}/events/${address}?token=${token}`;
+    const es = new EventSource(url);
+
+    es.onopen = () => setConnected(true);
+
+    es.onmessage = (e) => {
+      try {
+        setEvent(JSON.parse(e.data));
+      } catch {
+        setError("Failed to parse event");
+      }
+    };
+
+    es.onerror = () => {
+      setConnected(false);
+      setError("Connection error");
+      es.close();
+    };
+
+    return () => {
+      es.close();
+      setConnected(false);
+    };
+  }, [address, token]);
+
+  if (error) return <div className="text-red-500">{error}</div>;
+  if (!connected) return <div>Connecting…</div>;
+  if (!event) return <div>Waiting for events…</div>;
+
+  return <div>{event.type}</div>;
+}
+```
+
+### After
+
+```tsx
+"use client";
+import { useStellarEvent } from "@orbital-stellar/pulse-notify";
+
+export function SecureEventStream({
+  address,
+  token,
+}: {
+  address: string;
+  token: string;
+}) {
+  const { event, connected, error } = useStellarEvent(
+    process.env.NEXT_PUBLIC_ORBITAL_URL!,
+    address,
+    { event: "*", token }
+  );
+
+  if (error) return <div className="text-red-500">{error}</div>;
+  if (!connected) return <div>Connecting…</div>;
+  if (!event) return <div>Waiting for events…</div>;
+
+  return <div>{event.type}</div>;
+}
+```
+
+`pulse-notify` appends the token as `?token=` automatically — the same convention your raw code was using, without the manual string interpolation. The hook reconnects with the new token whenever `token` changes.
+
+> **Note:** `EventSource` does not support custom `Authorization` headers in browsers. Always pass secrets as short-lived per-user tokens, never long-lived API keys. See the [pulse-notify README](../../../packages/pulse-notify/README.md#authentication) for details.
+
+---
+
+## Installation
+
+```bash
+pnpm add @orbital-stellar/pulse-notify react
+```
+
+Requires React 18 or 19.

--- a/packages/pulse-core/src/SorobanRpcClient.ts
+++ b/packages/pulse-core/src/SorobanRpcClient.ts
@@ -1,5 +1,9 @@
 import type { ContractSubscriptionFilter, Logger } from "./index.js";
-import { SorobanRpcError, type SorobanRpcErrorCode } from "./errors.js";
+import {
+  SorobanRpcError,
+  type SorobanRpcErrorCode,
+  type SorobanRpcErrorOptions,
+} from "./errors.js";
 
 const DEFAULT_TIMEOUT_MS = 10_000;
 
@@ -136,6 +140,14 @@ function classifyJsonRpcCode(code: number): {
 } {
   if (code <= -32000 && code >= -32099) return { code: "server", retryable: true };
   return { code: "invalid_request", retryable: false };
+}
+
+function parseRetryAfterHeader(header: string | null): number | null {
+  if (!header) return null;
+  const seconds = Number.parseInt(header, 10);
+  if (!Number.isNaN(seconds)) return seconds * 1000;
+  const date = new Date(header).getTime();
+  return Number.isNaN(date) ? null : Math.max(date - Date.now(), 0);
 }
 
 function isAbortError(err: unknown): boolean {
@@ -303,9 +315,14 @@ export class SorobanRpcClient {
 
     if (!response.ok) {
       const { code, retryable } = classifyHttpStatus(response.status);
+      const opts: SorobanRpcErrorOptions = { code, retryable, status: response.status };
+      if (response.status === 429) {
+        const retryAfterMs = parseRetryAfterHeader(response.headers.get("Retry-After"));
+        if (retryAfterMs !== null) opts.retryAfterMs = retryAfterMs;
+      }
       throw new SorobanRpcError(
         `Soroban RPC request failed: ${response.status} ${response.statusText}`,
-        { code, retryable, status: response.status },
+        opts,
       );
     }
 

--- a/packages/pulse-core/src/SorobanSubscriber.ts
+++ b/packages/pulse-core/src/SorobanSubscriber.ts
@@ -109,8 +109,14 @@ export interface SorobanSubscriberOptions {
   startLedger?: number;
   /** Ledgers subtracted from `getLatestLedger()` for the first live poll. Defaults to 0. */
   startLedgerLookback?: number;
-  /** Delay before retrying after a retryable RPC error. Defaults to 1000ms. */
+  /** Delay before retrying after a cursor-expired recovery. Defaults to 1000ms. */
   retryDelayMs?: number;
+  /** Initial backoff delay for the Full-Jitter reconnect algorithm. Defaults to 1000ms. */
+  initialDelayMs?: number;
+  /** Maximum backoff delay cap for reconnection. Defaults to 30000ms. */
+  maxDelayMs?: number;
+  /** Maximum number of retry attempts before giving up. Defaults to Infinity. */
+  maxRetries?: number;
   /** Injectable timer scheduler (for testing). Defaults to `globalThis.setTimeout`. */
   setTimeoutFn?: typeof setTimeout;
   /** Injectable timer canceller (for testing). Defaults to `globalThis.clearTimeout`. */
@@ -194,6 +200,10 @@ export class SorobanSubscriber extends EventEmitter {
 
   // --- Retry state ---
   private readonly retryDelayMs: number;
+  private readonly initialDelayMs: number;
+  private readonly maxDelayMs: number;
+  private readonly maxRetries: number;
+  private reconnectAttempt = 0;
   private readonly setTimeoutFn: typeof setTimeout;
   private readonly clearTimeoutFn: typeof clearTimeout;
   private readonly onRetryableError?: (error: SorobanRpcError) => void;
@@ -234,6 +244,9 @@ export class SorobanSubscriber extends EventEmitter {
     this.startLedger = options.startLedger;
     this.startLedgerLookback = startLedgerLookback;
     this.retryDelayMs = options.retryDelayMs ?? 1000;
+    this.initialDelayMs = options.initialDelayMs ?? 1000;
+    this.maxDelayMs = options.maxDelayMs ?? 30_000;
+    this.maxRetries = options.maxRetries ?? Number.POSITIVE_INFINITY;
     this.setTimeoutFn = options.setTimeoutFn ?? globalThis.setTimeout;
     this.clearTimeoutFn = options.clearTimeoutFn ?? globalThis.clearTimeout;
     this.onRetryableError = options.onRetryableError;
@@ -439,18 +452,59 @@ export class SorobanSubscriber extends EventEmitter {
             // fallback fetch failed; continue with the original cursor-expired error
           }
         }
-        if ((err as SorobanRpcError).retryable) {
-          if (this.onRetryableError) {
-            this.onRetryableError(err as SorobanRpcError);
-            this.scheduleRetry();
+        if (err.retryable) {
+          this.reconnectAttempt += 1;
+          this.onRetryableError?.(err);
+          if (this.reconnectAttempt > this.maxRetries) {
+            if (this.onTerminalError) this.onTerminalError(err);
             return;
           }
-        } else if (this.onTerminalError) {
-          this.onTerminalError(err);
+          let delayMs: number;
+          if (err.code === "rate_limit") {
+            delayMs = err.retryAfterMs ?? 60_000;
+            this.emit("engine.rate_limited", {
+              type: "engine.rate_limited",
+              attempt: this.reconnectAttempt,
+              delayMs,
+              source: "soroban",
+              emittedAt: new Date().toISOString(),
+            });
+          } else {
+            const exponentialDelay = Math.min(
+              this.initialDelayMs * 2 ** (this.reconnectAttempt - 1),
+              this.maxDelayMs,
+            );
+            delayMs = Math.floor(Math.random() * exponentialDelay);
+            this.emit("engine.reconnecting", {
+              type: "engine.reconnecting",
+              attempt: this.reconnectAttempt,
+              delayMs,
+              cursor: currentCursor,
+              source: "soroban",
+              emittedAt: new Date().toISOString(),
+            });
+          }
+          this.scheduleRetry(delayMs);
           return;
+        } else {
+          if (this.onTerminalError) {
+            this.onTerminalError(err);
+            return;
+          }
         }
       }
       throw err;
+    }
+
+    if (this.reconnectAttempt > 0) {
+      const attempt = this.reconnectAttempt;
+      this.reconnectAttempt = 0;
+      this.emit("engine.reconnected", {
+        type: "engine.reconnected",
+        attempt,
+        source: "soroban",
+        emittedAt: new Date().toISOString(),
+      });
     }
 
     const allEventsMap = new Map<string, SorobanEvent>();
@@ -662,13 +716,13 @@ export class SorobanSubscriber extends EventEmitter {
   }
 
   /** Schedules a single deferred re-poll using the injectable timer. */
-  private scheduleRetry(): void {
+  private scheduleRetry(delayMs?: number): void {
     if (this.isStopped) return;
     this.retryTimer = this.setTimeoutFn(() => {
       this.retryTimer = null;
       if (this.isStopped) return;
       this.inflightPoll = (this.inflightPoll ?? Promise.resolve()).then(() => this.pollOnce());
-    }, this.retryDelayMs);
+    }, delayMs ?? this.retryDelayMs);
   }
 
   /**

--- a/packages/pulse-core/src/errors.ts
+++ b/packages/pulse-core/src/errors.ts
@@ -76,6 +76,7 @@ export type SorobanRpcErrorOptions = {
   code: SorobanRpcErrorCode;
   retryable: boolean;
   status?: number;
+  retryAfterMs?: number;
   cause?: unknown;
 };
 
@@ -83,6 +84,7 @@ export class SorobanRpcError extends Error {
   readonly code: SorobanRpcErrorCode;
   readonly retryable: boolean;
   readonly status?: number;
+  readonly retryAfterMs?: number;
   override readonly cause?: unknown;
 
   constructor(message: string, options: SorobanRpcErrorOptions) {
@@ -92,6 +94,9 @@ export class SorobanRpcError extends Error {
     this.retryable = options.retryable;
     if (options.status !== undefined) {
       this.status = options.status;
+    }
+    if (options.retryAfterMs !== undefined) {
+      this.retryAfterMs = options.retryAfterMs;
     }
     this.cause = options.cause;
   }

--- a/packages/pulse-core/test/SorobanSubscriber.test.ts
+++ b/packages/pulse-core/test/SorobanSubscriber.test.ts
@@ -11,6 +11,7 @@ import type {
   SorobanRpcCallOptions,
   SorobanRpcEvent,
 } from "../src/SorobanRpcClient.js";
+import { SorobanRpcError } from "../src/errors.js";
 
 class MemoryCursorStore implements CursorStoreLike {
   constructor(public cursor?: string) {}
@@ -212,5 +213,216 @@ describe("SorobanSubscriber startLedger to cursor polling", () => {
     engine.stop();
     await vi.advanceTimersByTimeAsync(1_000);
     expect(requests.filter((request) => request.method === "getEvents")).toHaveLength(2);
+  });
+});
+
+describe("SorobanSubscriber reconnection and rate-limit handling", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  function makeNetworkError(): SorobanRpcError {
+    return new SorobanRpcError("network failure", { code: "network", retryable: true });
+  }
+
+  function makeRateLimitError(retryAfterMs?: number): SorobanRpcError {
+    return new SorobanRpcError("rate limited", {
+      code: "rate_limit",
+      retryable: true,
+      status: 429,
+      retryAfterMs,
+    });
+  }
+
+  function makeRpc(responses: Array<SorobanGetEventsResult | SorobanRpcError>) {
+    let i = 0;
+    return {
+      getLatestLedger: vi.fn(async () => 100),
+      getEvents: vi.fn(async (_params: SorobanGetEventsParams, _opts?: SorobanRpcCallOptions) => {
+        const r = responses[i++];
+        if (r instanceof SorobanRpcError) throw r;
+        return r ?? { events: [], cursor: `c-${i}` };
+      }),
+    };
+  }
+
+  it("emits engine.reconnecting with Full-Jitter delay on network error, then engine.reconnected on success", async () => {
+    vi.spyOn(Math, "random").mockReturnValue(0.5);
+
+    const rpc = makeRpc([makeNetworkError(), { events: [], cursor: "c-2" }]);
+
+    const subscriber = new SorobanSubscriber({
+      rpc: rpc as any,
+      cursorStore: new MemoryCursorStore("cursor-a"),
+      initialDelayMs: 1000,
+      maxDelayMs: 30_000,
+      setTimeoutFn: globalThis.setTimeout,
+      clearTimeoutFn: globalThis.clearTimeout,
+    });
+
+    const reconnecting: unknown[] = [];
+    const reconnected: unknown[] = [];
+    subscriber.on("engine.reconnecting", (p) => reconnecting.push(p));
+    subscriber.on("engine.reconnected", (p) => reconnected.push(p));
+
+    // First poll throws a network error
+    const poll1 = subscriber.pollOnce();
+    await flushPoll();
+    await poll1;
+
+    expect(reconnecting).toHaveLength(1);
+    expect(reconnecting[0]).toMatchObject({
+      type: "engine.reconnecting",
+      attempt: 1,
+      source: "soroban",
+      cursor: "cursor-a",
+    });
+    // Full-Jitter: Math.floor(0.5 * min(1000 * 2^0, 30000)) = Math.floor(0.5 * 1000) = 500
+    expect((reconnecting[0] as any).delayMs).toBe(500);
+    expect(reconnected).toHaveLength(0);
+
+    // Advance past retry delay so the retry fires
+    await vi.advanceTimersByTimeAsync(500);
+    await flushPoll();
+    await flushPoll();
+
+    expect(reconnected).toHaveLength(1);
+    expect(reconnected[0]).toMatchObject({
+      type: "engine.reconnected",
+      attempt: 1,
+      source: "soroban",
+    });
+
+    await subscriber.stop();
+  });
+
+  it("emits engine.rate_limited with Retry-After delay on HTTP 429", async () => {
+    const rpc = makeRpc([makeRateLimitError(5_000), { events: [], cursor: "c-2" }]);
+
+    const subscriber = new SorobanSubscriber({
+      rpc: rpc as any,
+      cursorStore: new MemoryCursorStore("cursor-b"),
+      setTimeoutFn: globalThis.setTimeout,
+      clearTimeoutFn: globalThis.clearTimeout,
+    });
+
+    const rateLimited: unknown[] = [];
+    const reconnected: unknown[] = [];
+    subscriber.on("engine.rate_limited", (p) => rateLimited.push(p));
+    subscriber.on("engine.reconnected", (p) => reconnected.push(p));
+
+    const poll1 = subscriber.pollOnce();
+    await flushPoll();
+    await poll1;
+
+    expect(rateLimited).toHaveLength(1);
+    expect(rateLimited[0]).toMatchObject({
+      type: "engine.rate_limited",
+      attempt: 1,
+      delayMs: 5_000,
+      source: "soroban",
+    });
+
+    await vi.advanceTimersByTimeAsync(5_000);
+    await flushPoll();
+    await flushPoll();
+
+    expect(reconnected).toHaveLength(1);
+    expect(reconnected[0]).toMatchObject({ type: "engine.reconnected", attempt: 1 });
+
+    await subscriber.stop();
+  });
+
+  it("uses 60s fallback delay when 429 has no Retry-After", async () => {
+    const rpc = makeRpc([makeRateLimitError(undefined)]);
+
+    const subscriber = new SorobanSubscriber({
+      rpc: rpc as any,
+      cursorStore: new MemoryCursorStore(),
+      setTimeoutFn: globalThis.setTimeout,
+      clearTimeoutFn: globalThis.clearTimeout,
+    });
+
+    const rateLimited: unknown[] = [];
+    subscriber.on("engine.rate_limited", (p) => rateLimited.push(p));
+
+    const poll1 = subscriber.pollOnce();
+    await flushPoll();
+    await poll1;
+
+    expect(rateLimited[0]).toMatchObject({ delayMs: 60_000 });
+    await subscriber.stop();
+  });
+
+  it("resets reconnectAttempt after successful poll", async () => {
+    const rpc = makeRpc([
+      makeNetworkError(),
+      makeNetworkError(),
+      { events: [], cursor: "c-3" },
+      makeNetworkError(),
+    ]);
+
+    const subscriber = new SorobanSubscriber({
+      rpc: rpc as any,
+      cursorStore: new MemoryCursorStore(),
+      initialDelayMs: 1000,
+      maxDelayMs: 30_000,
+      setTimeoutFn: globalThis.setTimeout,
+      clearTimeoutFn: globalThis.clearTimeout,
+    });
+
+    const reconnecting: unknown[] = [];
+    subscriber.on("engine.reconnecting", (p) => reconnecting.push(p));
+
+    // Call pollOnce directly to drive each poll without timer interference
+    await subscriber.pollOnce(); // error → attempt 1
+    await subscriber.pollOnce(); // error → attempt 2
+    await subscriber.pollOnce(); // success → resets to 0
+    await subscriber.pollOnce(); // error → attempt 1 (fresh counter)
+
+    const attempts = reconnecting.map((p) => (p as any).attempt);
+    expect(attempts[0]).toBe(1);
+    expect(attempts[1]).toBe(2);
+    // After successful poll reset, next failure starts from 1 again
+    expect(attempts[2]).toBe(1);
+
+    await subscriber.stop();
+  });
+
+  it("stops retrying once maxRetries is exceeded and calls onTerminalError", async () => {
+    const rpc = makeRpc([makeNetworkError(), makeNetworkError(), makeNetworkError()]);
+
+    const terminalErrors: unknown[] = [];
+    const subscriber = new SorobanSubscriber({
+      rpc: rpc as any,
+      cursorStore: new MemoryCursorStore(),
+      initialDelayMs: 1,
+      maxDelayMs: 10,
+      maxRetries: 2,
+      setTimeoutFn: globalThis.setTimeout,
+      clearTimeoutFn: globalThis.clearTimeout,
+      onTerminalError: (err) => terminalErrors.push(err),
+    });
+
+    // First poll fails → attempt 1 (within maxRetries=2, schedules retry)
+    await subscriber.pollOnce();
+    await vi.advanceTimersByTimeAsync(10);
+    await flushPoll();
+    // Retry fires → attempt 2 (within maxRetries=2, schedules retry)
+    await vi.advanceTimersByTimeAsync(10);
+    await flushPoll();
+    // Retry fires → attempt 3 > maxRetries → calls onTerminalError, no more retry
+    await vi.advanceTimersByTimeAsync(10);
+    await flushPoll();
+
+    expect(terminalErrors).toHaveLength(1);
+    expect(terminalErrors[0]).toBeInstanceOf(SorobanRpcError);
+
+    await subscriber.stop();
   });
 });

--- a/packages/pulse-notify/README.md
+++ b/packages/pulse-notify/README.md
@@ -342,6 +342,7 @@ The hooks are client-only — they rely on `EventSource`, which does not exist i
 
 ## Related documents
 
+- [Migration guide: from raw EventSource to useStellarEvent](../../apps/web/content/guides/migrate-from-eventsource.md) — before/after for the three most common raw `EventSource` patterns
 - [`docs/ARCHITECTURE.md` § 7 React hook internals](../../docs/ARCHITECTURE.md#7-react-hook-internals) — design choices (stable dep-array, dual call signature, generic narrowing)
 - [`docs/COOKBOOK.md` § 10 Render live payments in React with type narrowing](../../docs/COOKBOOK.md#10-render-live-payments-in-react-with-type-narrowing)
 - [`docs/COOKBOOK.md` § 11 Stand up an SSE endpoint in Next.js](../../docs/COOKBOOK.md#11-stand-up-an-sse-endpoint-in-nextjs) — the backend the hooks expect


### PR DESCRIPTION
## Summary

- Wraps each `getEvents` call in try/catch; on failure schedules retry with AWS Full-Jitter backoff (configurable `initialDelayMs`/`maxDelayMs`/`maxRetries`).
- On HTTP 429, parses `Retry-After` header (seconds or HTTP-date) stored on `SorobanRpcError.retryAfterMs` and emits `engine.rate_limited` with the parsed delay (fallback: 60 s).
- Emits `engine.reconnecting` with jittered delay and current cursor on transient network/server errors.
- Emits `engine.reconnected` (with attempt number) after the first successful poll following failures; resets counter.

## Changes

- **`src/errors.ts`** — adds `retryAfterMs` field to `SorobanRpcErrorOptions` and `SorobanRpcError`.
- **`src/SorobanRpcClient.ts`** — parses `Retry-After` response header for HTTP 429 and stores it on the thrown `SorobanRpcError`.
- **`src/SorobanSubscriber.ts`** — adds `initialDelayMs`, `maxDelayMs`, `maxRetries` options; Full-Jitter backoff; `engine.rate_limited` / `engine.reconnecting` / `engine.reconnected` emit logic; `scheduleRetry(delayMs?)` signature.

## Verification

```
npx vitest run test/SorobanSubscriber.test.ts
# 9 passed (5 new reconnection/rate-limit tests)

npx vitest run
# 510 passed | 7 skipped — zero regressions
```

closes #619