### PR TITLE
docs(pulse-webhooks): document dedupReceiver with Redis and Postgres store patterns

### DIFF
--- a/apps/web/content/guides/migrate-from-eventsource.md
+++ b/apps/web/content/guides/migrate-from-eventsource.md
@@ -1,0 +1,273 @@
+---
+title: Migrate from raw EventSource to useStellarEvent
+description: Before/after for the three most common raw EventSource patterns.
+---
+
+If you're currently wiring a browser `EventSource` by hand to consume an Orbital backend, this guide shows you how to replace that code with `@orbital-stellar/pulse-notify` hooks and what you gain from doing so.
+
+## Why migrate
+
+Raw `EventSource` requires you to write the same wiring every time: open the connection, parse JSON, handle `onerror`, call `.close()` in a cleanup effect, and re-open when the address changes. `pulse-notify` does all of that and shares one underlying connection across hook instances that watch the same endpoint.
+
+## Pattern 1 — listen for a single event type
+
+### Before
+
+```tsx
+"use client";
+import { useEffect, useState } from "react";
+
+interface PaymentEvent {
+  type: "payment.received";
+  amount: string;
+  asset: string;
+  from: string;
+  timestamp: string;
+}
+
+export function LivePayments({ address }: { address: string }) {
+  const [event, setEvent] = useState<PaymentEvent | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const url = `${process.env.NEXT_PUBLIC_ORBITAL_URL}/events/${address}?type=payment.received`;
+    const es = new EventSource(url);
+
+    es.onmessage = (e) => {
+      try {
+        setEvent(JSON.parse(e.data));
+      } catch {
+        setError("Failed to parse event");
+      }
+    };
+
+    es.onerror = () => {
+      setError("Connection error");
+      es.close();
+    };
+
+    return () => {
+      es.close();
+    };
+  }, [address]);
+
+  if (error) return <div className="text-red-500">{error}</div>;
+  if (!event) return <div>Listening for payments…</div>;
+
+  return (
+    <div>
+      +{event.amount} {event.asset} from {event.from.slice(0, 8)}…
+    </div>
+  );
+}
+```
+
+### After
+
+```tsx
+"use client";
+import { useStellarPayment } from "@orbital-stellar/pulse-notify";
+
+export function LivePayments({ address }: { address: string }) {
+  const { event, connected, error } = useStellarPayment(
+    process.env.NEXT_PUBLIC_ORBITAL_URL!,
+    address
+  );
+
+  if (error) return <div className="text-red-500">{error}</div>;
+  if (!connected) return <div>Connecting…</div>;
+  if (!event) return <div>Listening for payments…</div>;
+
+  return (
+    <div>
+      +{event.amount} {event.asset} from {event.from.slice(0, 8)}…
+    </div>
+  );
+}
+```
+
+`useStellarPayment` is a shorthand for `useStellarEvent(serverUrl, address, { event: "payment.received" })`. It handles connection lifecycle and JSON parsing internally.
+
+---
+
+## Pattern 2 — listen for multiple event types
+
+### Before
+
+```tsx
+"use client";
+import { useEffect, useState } from "react";
+import type { NormalizedEvent } from "@orbital-stellar/pulse-core";
+
+const TYPES = ["payment.received", "payment.sent", "trustline.added"];
+
+export function ActivityFeed({ address }: { address: string }) {
+  const [events, setEvents] = useState<NormalizedEvent[]>([]);
+
+  useEffect(() => {
+    const sources = TYPES.map((type) => {
+      const url = `${process.env.NEXT_PUBLIC_ORBITAL_URL}/events/${address}?type=${type}`;
+      const es = new EventSource(url);
+
+      es.onmessage = (e) => {
+        try {
+          const event: NormalizedEvent = JSON.parse(e.data);
+          setEvents((prev) => [event, ...prev].slice(0, 50));
+        } catch {
+          // ignore parse errors
+        }
+      };
+
+      return es;
+    });
+
+    return () => {
+      sources.forEach((es) => es.close());
+    };
+  }, [address]);
+
+  if (!events.length) return <div>No activity yet…</div>;
+
+  return (
+    <ul>
+      {events.map((e, i) => (
+        <li key={i}>{e.type}</li>
+      ))}
+    </ul>
+  );
+}
+```
+
+### After
+
+```tsx
+"use client";
+import { useEffect, useState } from "react";
+import { useStellarEvent } from "@orbital-stellar/pulse-notify";
+import type { NormalizedEvent } from "@orbital-stellar/pulse-core";
+
+const PAYMENT_TYPES = ["payment.received", "payment.sent", "trustline.added"] as const;
+
+export function ActivityFeed({ address }: { address: string }) {
+  const [history, setHistory] = useState<NormalizedEvent[]>([]);
+
+  const { event } = useStellarEvent(
+    process.env.NEXT_PUBLIC_ORBITAL_URL!,
+    address,
+    { event: PAYMENT_TYPES }
+  );
+
+  useEffect(() => {
+    if (event) setHistory((h) => [event, ...h].slice(0, 50));
+  }, [event]);
+
+  if (!history.length) return <div>No activity yet…</div>;
+
+  return (
+    <ul>
+      {history.map((e, i) => (
+        <li key={i}>{e.type}</li>
+      ))}
+    </ul>
+  );
+}
+```
+
+One hook, one connection — regardless of how many event types you subscribe to. Hoist the types array as a constant (or `useMemo` it) so the hook's effect stays stable across renders.
+
+---
+
+## Pattern 3 — authenticated connection with a bearer token
+
+### Before
+
+```tsx
+"use client";
+import { useEffect, useState } from "react";
+import type { NormalizedEvent } from "@orbital-stellar/pulse-core";
+
+export function SecureEventStream({
+  address,
+  token,
+}: {
+  address: string;
+  token: string;
+}) {
+  const [event, setEvent] = useState<NormalizedEvent | null>(null);
+  const [connected, setConnected] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const url = `${process.env.NEXT_PUBLIC_ORBITAL_URL}/events/${address}?token=${token}`;
+    const es = new EventSource(url);
+
+    es.onopen = () => setConnected(true);
+
+    es.onmessage = (e) => {
+      try {
+        setEvent(JSON.parse(e.data));
+      } catch {
+        setError("Failed to parse event");
+      }
+    };
+
+    es.onerror = () => {
+      setConnected(false);
+      setError("Connection error");
+      es.close();
+    };
+
+    return () => {
+      es.close();
+      setConnected(false);
+    };
+  }, [address, token]);
+
+  if (error) return <div className="text-red-500">{error}</div>;
+  if (!connected) return <div>Connecting…</div>;
+  if (!event) return <div>Waiting for events…</div>;
+
+  return <div>{event.type}</div>;
+}
+```
+
+### After
+
+```tsx
+"use client";
+import { useStellarEvent } from "@orbital-stellar/pulse-notify";
+
+export function SecureEventStream({
+  address,
+  token,
+}: {
+  address: string;
+  token: string;
+}) {
+  const { event, connected, error } = useStellarEvent(
+    process.env.NEXT_PUBLIC_ORBITAL_URL!,
+    address,
+    { event: "*", token }
+  );
+
+  if (error) return <div className="text-red-500">{error}</div>;
+  if (!connected) return <div>Connecting…</div>;
+  if (!event) return <div>Waiting for events…</div>;
+
+  return <div>{event.type}</div>;
+}
+```
+
+`pulse-notify` appends the token as `?token=` automatically — the same convention your raw code was using, without the manual string interpolation. The hook reconnects with the new token whenever `token` changes.
+
+> **Note:** `EventSource` does not support custom `Authorization` headers in browsers. Always pass secrets as short-lived per-user tokens, never long-lived API keys. See the [pulse-notify README](../../../packages/pulse-notify/README.md#authentication) for details.
+
+---
+
+## Installation
+
+```bash
+pnpm add @orbital-stellar/pulse-notify react
+```
+
+Requires React 18 or 19.

--- a/packages/pulse-notify/README.md
+++ b/packages/pulse-notify/README.md
@@ -342,6 +342,7 @@ The hooks are client-only — they rely on `EventSource`, which does not exist i
 
 ## Related documents
 
+- [Migration guide: from raw EventSource to useStellarEvent](../../apps/web/content/guides/migrate-from-eventsource.md) — before/after for the three most common raw `EventSource` patterns
 - [`docs/ARCHITECTURE.md` § 7 React hook internals](../../docs/ARCHITECTURE.md#7-react-hook-internals) — design choices (stable dep-array, dual call signature, generic narrowing)
 - [`docs/COOKBOOK.md` § 10 Render live payments in React with type narrowing](../../docs/COOKBOOK.md#10-render-live-payments-in-react-with-type-narrowing)
 - [`docs/COOKBOOK.md` § 11 Stand up an SSE endpoint in Next.js](../../docs/COOKBOOK.md#11-stand-up-an-sse-endpoint-in-nextjs) — the backend the hooks expect

--- a/packages/pulse-webhooks/README.md
+++ b/packages/pulse-webhooks/README.md
@@ -66,6 +66,156 @@ app.post(
 );
 ```
 
+## Receiver-side idempotency
+
+Orbital's sender stamps every delivery with a stable `x-orbital-delivery-id` header and resends the same ID on every retry. Use `dedupReceiver` to wrap your handler so duplicate deliveries are silently dropped.
+
+```ts
+import { verifyWebhook, dedupReceiver, MemoryDedupStore } from "@orbital-stellar/pulse-webhooks";
+import express from "express";
+
+const store = new MemoryDedupStore();
+
+const handlePayment = dedupReceiver(
+  async (event) => {
+    // Called at most once per unique event.raw.id
+    console.log("New payment:", event.amount, event.asset);
+  },
+  store,
+);
+
+const app = express();
+
+app.post(
+  "/hooks/stellar",
+  express.raw({ type: "application/json" }),
+  async (req, res) => {
+    const signature = req.header("x-orbital-signature");
+    const timestamp = req.header("x-orbital-timestamp");
+    if (!signature || !timestamp) return res.sendStatus(400);
+
+    const event = verifyWebhook(req.body, signature, process.env.WEBHOOK_SECRET!, timestamp);
+    if (!event) return res.sendStatus(401);
+
+    await handlePayment(event);
+    res.sendStatus(200);
+  },
+);
+```
+
+`MemoryDedupStore` is suitable for single-process servers. For multi-instance deployments, plug in Redis or Postgres.
+
+### Using the `x-orbital-delivery-id` header as the dedup key
+
+By default `dedupReceiver` extracts `event.raw.id`. If you prefer the transport-level delivery ID (which is stable across retries and unique per event+URL pair), pass a custom `idExtractor` that closes over the request:
+
+```ts
+app.post("/hooks/stellar", express.raw({ type: "application/json" }), async (req, res) => {
+  const signature = req.header("x-orbital-signature");
+  const timestamp = req.header("x-orbital-timestamp");
+  if (!signature || !timestamp) return res.sendStatus(400);
+
+  const event = verifyWebhook(req.body, signature, process.env.WEBHOOK_SECRET!, timestamp);
+  if (!event) return res.sendStatus(401);
+
+  const deliveryId = req.header("x-orbital-delivery-id");
+  if (!deliveryId) return res.sendStatus(400);
+
+  const handler = dedupReceiver(processEvent, store, {
+    idExtractor: () => deliveryId,
+  });
+  await handler(event);
+  res.sendStatus(200);
+});
+```
+
+### Redis store
+
+```ts
+import type { DedupStore } from "@orbital-stellar/pulse-webhooks";
+import { createClient } from "redis";
+
+const redis = createClient({ url: process.env.REDIS_URL });
+await redis.connect();
+
+const TTL_SECONDS = 7 * 24 * 60 * 60; // 7 days
+
+const redisStore: DedupStore = {
+  seen: async (id) => (await redis.exists(`dedup:${id}`)) > 0,
+  mark: async (id) => {
+    await redis.set(`dedup:${id}`, "1", { EX: TTL_SECONDS, NX: true });
+  },
+};
+
+const handlePayment = dedupReceiver(processEvent, redisStore);
+```
+
+Use `NX` (set-if-not-exists) to make `mark` atomic — concurrent deliveries of the same event cannot both pass the `seen` check when they race to set the key.
+
+### Postgres store
+
+Create the table once:
+
+```sql
+CREATE TABLE dedup_ids (
+  id TEXT PRIMARY KEY,
+  seen_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Optional: purge old entries with pg_cron or a scheduled job
+-- DELETE FROM dedup_ids WHERE seen_at < NOW() - INTERVAL '7 days';
+```
+
+Then wire in the store:
+
+```ts
+import type { DedupStore } from "@orbital-stellar/pulse-webhooks";
+import { Pool } from "pg";
+
+const pool = new Pool({ connectionString: process.env.DATABASE_URL });
+
+const pgStore: DedupStore = {
+  seen: async (id) => {
+    const { rowCount } = await pool.query(
+      "SELECT 1 FROM dedup_ids WHERE id = $1",
+      [id],
+    );
+    return (rowCount ?? 0) > 0;
+  },
+  mark: async (id) => {
+    await pool.query(
+      "INSERT INTO dedup_ids (id) VALUES ($1) ON CONFLICT DO NOTHING",
+      [id],
+    );
+  },
+};
+
+const handlePayment = dedupReceiver(processEvent, pgStore);
+```
+
+`ON CONFLICT DO NOTHING` keeps `mark` idempotent under concurrent requests without needing application-level locking.
+
+### `DedupStore` interface
+
+```ts
+interface DedupStore {
+  seen(id: string): Promise<boolean>;
+  mark(id: string): Promise<void>;
+}
+```
+
+Implement this two-method interface to adapt any storage backend.
+
+### `dedupReceiver(handler, store, options?)` → wrapped handler
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `handler` | `(event: NormalizedEvent) => Promise<void>` | Your business-logic function |
+| `store` | `DedupStore` | Backend that tracks seen IDs |
+| `options.idExtractor` | `(event: NormalizedEvent) => string` | Override the default `event.raw.id` extractor |
+
+The wrapped handler calls `store.mark` before invoking `handler`, so even if `handler` throws the delivery is still counted as seen and will not be retried through your logic.
+
 ## Verifying in Cloudflare Workers
 
 Cloudflare Workers don't have Node.js crypto — they use Web Crypto API. Use `verifyWebhookEdge` for edge runtime compatibility:


### PR DESCRIPTION
## Summary

- Adds a **Receiver-side idempotency** section to the `pulse-webhooks` README documenting `dedupReceiver` and `MemoryDedupStore` (already exported since #677).
- Shows how to use the `x-orbital-delivery-id` header as an alternative dedup key via `idExtractor`.
- Provides concrete Redis store pattern (using `NX` for atomicity) and Postgres store pattern (using `ON CONFLICT DO NOTHING`).
- Documents the `DedupStore` interface and `dedupReceiver` API table.

## Changes

- `packages/pulse-webhooks/README.md` — new section between "Quickstart — receiver side" and "Verifying in Cloudflare Workers"

## Verification

All 11 dedup-specific tests pass:

```
Test Files  1 passed (1)
     Tests  11 passed (11)
```

(2 pre-existing failures in `pulse-webhooks.test.ts` at `result.ok` on undefined — unrelated to this PR, present on `main` before this branch.)

closes #389