### PR TITLE
feat(pulse-webhooks): add per-URL timeout override via UrlEntry array

### DIFF
--- a/apps/web/content/guides/migrate-from-eventsource.md
+++ b/apps/web/content/guides/migrate-from-eventsource.md
@@ -1,0 +1,273 @@
+---
+title: Migrate from raw EventSource to useStellarEvent
+description: Before/after for the three most common raw EventSource patterns.
+---
+
+If you're currently wiring a browser `EventSource` by hand to consume an Orbital backend, this guide shows you how to replace that code with `@orbital-stellar/pulse-notify` hooks and what you gain from doing so.
+
+## Why migrate
+
+Raw `EventSource` requires you to write the same wiring every time: open the connection, parse JSON, handle `onerror`, call `.close()` in a cleanup effect, and re-open when the address changes. `pulse-notify` does all of that and shares one underlying connection across hook instances that watch the same endpoint.
+
+## Pattern 1 — listen for a single event type
+
+### Before
+
+```tsx
+"use client";
+import { useEffect, useState } from "react";
+
+interface PaymentEvent {
+  type: "payment.received";
+  amount: string;
+  asset: string;
+  from: string;
+  timestamp: string;
+}
+
+export function LivePayments({ address }: { address: string }) {
+  const [event, setEvent] = useState<PaymentEvent | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const url = `${process.env.NEXT_PUBLIC_ORBITAL_URL}/events/${address}?type=payment.received`;
+    const es = new EventSource(url);
+
+    es.onmessage = (e) => {
+      try {
+        setEvent(JSON.parse(e.data));
+      } catch {
+        setError("Failed to parse event");
+      }
+    };
+
+    es.onerror = () => {
+      setError("Connection error");
+      es.close();
+    };
+
+    return () => {
+      es.close();
+    };
+  }, [address]);
+
+  if (error) return <div className="text-red-500">{error}</div>;
+  if (!event) return <div>Listening for payments…</div>;
+
+  return (
+    <div>
+      +{event.amount} {event.asset} from {event.from.slice(0, 8)}…
+    </div>
+  );
+}
+```
+
+### After
+
+```tsx
+"use client";
+import { useStellarPayment } from "@orbital-stellar/pulse-notify";
+
+export function LivePayments({ address }: { address: string }) {
+  const { event, connected, error } = useStellarPayment(
+    process.env.NEXT_PUBLIC_ORBITAL_URL!,
+    address
+  );
+
+  if (error) return <div className="text-red-500">{error}</div>;
+  if (!connected) return <div>Connecting…</div>;
+  if (!event) return <div>Listening for payments…</div>;
+
+  return (
+    <div>
+      +{event.amount} {event.asset} from {event.from.slice(0, 8)}…
+    </div>
+  );
+}
+```
+
+`useStellarPayment` is a shorthand for `useStellarEvent(serverUrl, address, { event: "payment.received" })`. It handles connection lifecycle and JSON parsing internally.
+
+---
+
+## Pattern 2 — listen for multiple event types
+
+### Before
+
+```tsx
+"use client";
+import { useEffect, useState } from "react";
+import type { NormalizedEvent } from "@orbital-stellar/pulse-core";
+
+const TYPES = ["payment.received", "payment.sent", "trustline.added"];
+
+export function ActivityFeed({ address }: { address: string }) {
+  const [events, setEvents] = useState<NormalizedEvent[]>([]);
+
+  useEffect(() => {
+    const sources = TYPES.map((type) => {
+      const url = `${process.env.NEXT_PUBLIC_ORBITAL_URL}/events/${address}?type=${type}`;
+      const es = new EventSource(url);
+
+      es.onmessage = (e) => {
+        try {
+          const event: NormalizedEvent = JSON.parse(e.data);
+          setEvents((prev) => [event, ...prev].slice(0, 50));
+        } catch {
+          // ignore parse errors
+        }
+      };
+
+      return es;
+    });
+
+    return () => {
+      sources.forEach((es) => es.close());
+    };
+  }, [address]);
+
+  if (!events.length) return <div>No activity yet…</div>;
+
+  return (
+    <ul>
+      {events.map((e, i) => (
+        <li key={i}>{e.type}</li>
+      ))}
+    </ul>
+  );
+}
+```
+
+### After
+
+```tsx
+"use client";
+import { useEffect, useState } from "react";
+import { useStellarEvent } from "@orbital-stellar/pulse-notify";
+import type { NormalizedEvent } from "@orbital-stellar/pulse-core";
+
+const PAYMENT_TYPES = ["payment.received", "payment.sent", "trustline.added"] as const;
+
+export function ActivityFeed({ address }: { address: string }) {
+  const [history, setHistory] = useState<NormalizedEvent[]>([]);
+
+  const { event } = useStellarEvent(
+    process.env.NEXT_PUBLIC_ORBITAL_URL!,
+    address,
+    { event: PAYMENT_TYPES }
+  );
+
+  useEffect(() => {
+    if (event) setHistory((h) => [event, ...h].slice(0, 50));
+  }, [event]);
+
+  if (!history.length) return <div>No activity yet…</div>;
+
+  return (
+    <ul>
+      {history.map((e, i) => (
+        <li key={i}>{e.type}</li>
+      ))}
+    </ul>
+  );
+}
+```
+
+One hook, one connection — regardless of how many event types you subscribe to. Hoist the types array as a constant (or `useMemo` it) so the hook's effect stays stable across renders.
+
+---
+
+## Pattern 3 — authenticated connection with a bearer token
+
+### Before
+
+```tsx
+"use client";
+import { useEffect, useState } from "react";
+import type { NormalizedEvent } from "@orbital-stellar/pulse-core";
+
+export function SecureEventStream({
+  address,
+  token,
+}: {
+  address: string;
+  token: string;
+}) {
+  const [event, setEvent] = useState<NormalizedEvent | null>(null);
+  const [connected, setConnected] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const url = `${process.env.NEXT_PUBLIC_ORBITAL_URL}/events/${address}?token=${token}`;
+    const es = new EventSource(url);
+
+    es.onopen = () => setConnected(true);
+
+    es.onmessage = (e) => {
+      try {
+        setEvent(JSON.parse(e.data));
+      } catch {
+        setError("Failed to parse event");
+      }
+    };
+
+    es.onerror = () => {
+      setConnected(false);
+      setError("Connection error");
+      es.close();
+    };
+
+    return () => {
+      es.close();
+      setConnected(false);
+    };
+  }, [address, token]);
+
+  if (error) return <div className="text-red-500">{error}</div>;
+  if (!connected) return <div>Connecting…</div>;
+  if (!event) return <div>Waiting for events…</div>;
+
+  return <div>{event.type}</div>;
+}
+```
+
+### After
+
+```tsx
+"use client";
+import { useStellarEvent } from "@orbital-stellar/pulse-notify";
+
+export function SecureEventStream({
+  address,
+  token,
+}: {
+  address: string;
+  token: string;
+}) {
+  const { event, connected, error } = useStellarEvent(
+    process.env.NEXT_PUBLIC_ORBITAL_URL!,
+    address,
+    { event: "*", token }
+  );
+
+  if (error) return <div className="text-red-500">{error}</div>;
+  if (!connected) return <div>Connecting…</div>;
+  if (!event) return <div>Waiting for events…</div>;
+
+  return <div>{event.type}</div>;
+}
+```
+
+`pulse-notify` appends the token as `?token=` automatically — the same convention your raw code was using, without the manual string interpolation. The hook reconnects with the new token whenever `token` changes.
+
+> **Note:** `EventSource` does not support custom `Authorization` headers in browsers. Always pass secrets as short-lived per-user tokens, never long-lived API keys. See the [pulse-notify README](../../../packages/pulse-notify/README.md#authentication) for details.
+
+---
+
+## Installation
+
+```bash
+pnpm add @orbital-stellar/pulse-notify react
+```
+
+Requires React 18 or 19.

--- a/packages/pulse-notify/README.md
+++ b/packages/pulse-notify/README.md
@@ -342,6 +342,7 @@ The hooks are client-only — they rely on `EventSource`, which does not exist i
 
 ## Related documents
 
+- [Migration guide: from raw EventSource to useStellarEvent](../../apps/web/content/guides/migrate-from-eventsource.md) — before/after for the three most common raw `EventSource` patterns
 - [`docs/ARCHITECTURE.md` § 7 React hook internals](../../docs/ARCHITECTURE.md#7-react-hook-internals) — design choices (stable dep-array, dual call signature, generic narrowing)
 - [`docs/COOKBOOK.md` § 10 Render live payments in React with type narrowing](../../docs/COOKBOOK.md#10-render-live-payments-in-react-with-type-narrowing)
 - [`docs/COOKBOOK.md` § 11 Stand up an SSE endpoint in Next.js](../../docs/COOKBOOK.md#11-stand-up-an-sse-endpoint-in-nextjs) — the backend the hooks expect

--- a/packages/pulse-webhooks/src/index.ts
+++ b/packages/pulse-webhooks/src/index.ts
@@ -13,7 +13,7 @@ import { DeadLetterStore } from "./MemoryDeadLetterStore.js";
 import { exponentialJittered } from "./backoff.js";
 import type { BackoffStrategy } from "./backoff.js";
 import type { RetryQueue, RetryRecord } from "./RetryQueue.js";
-import type { Tracer, VerifyWebhookOptions, WebhookConfig } from "./types.js";
+import type { Tracer, UrlEntry, VerifyWebhookOptions, WebhookConfig } from "./types.js";
 import { DEFAULT_MAX_AGE_MS, DEFAULT_CLOCK_SKEW_MS } from "./types.js";
 
 const BLOCKED_WEBHOOK_ADDRESSES = new BlockList();
@@ -72,6 +72,7 @@ export type { RetryQueue, RetryRecord } from "./RetryQueue.js";
 export type {
   Span,
   Tracer,
+  UrlEntry,
   VerifierSignatureVersion,
   VerifyWebhookOptions,
   WebhookConfig,
@@ -112,12 +113,30 @@ type ResolvedWebhookConfig = Omit<
   "url" | "tracer" | "urlValidator" | "metrics" | "backoff" | "retryQueue"
 > & {
   urls: string[];
+  urlTimeouts: Map<string, number>;
   backoff: BackoffStrategy;
   tracer?: Tracer;
   urlValidator?: WebhookConfig["urlValidator"];
   metrics?: WebhookConfig["metrics"];
   retryQueue?: RetryQueue;
 };
+
+function normalizeUrlConfig(url: WebhookConfig["url"]): {
+  urls: string[];
+  urlTimeouts: Map<string, number>;
+} {
+  if (!Array.isArray(url)) return { urls: [url], urlTimeouts: new Map() };
+  if (url.length === 0 || typeof url[0] === "string") {
+    return { urls: url as string[], urlTimeouts: new Map() };
+  }
+  const entries = url as UrlEntry[];
+  const urls = entries.map((e) => e.url);
+  const urlTimeouts = new Map<string, number>();
+  for (const e of entries) {
+    if (e.timeoutMs !== undefined) urlTimeouts.set(e.url, e.timeoutMs);
+  }
+  return { urls, urlTimeouts };
+}
 
 export class WebhookDelivery {
   private config: ResolvedWebhookConfig;
@@ -140,6 +159,7 @@ export class WebhookDelivery {
   constructor(watcher: Watcher, config: WebhookConfig, dlq?: DeadLetterStore) {
     this.watcher = watcher;
     this.dlq = dlq ?? new DeadLetterStore();
+    const { urls, urlTimeouts } = normalizeUrlConfig(config.url);
     this.config = {
       retries: 3,
       deliveryTimeoutMs: 10000,
@@ -149,7 +169,8 @@ export class WebhookDelivery {
       retryQueuePollIntervalMs: 1000,
       ...config,
       tracer: config.tracer,
-      urls: Array.isArray(config.url) ? [...config.url] : [config.url],
+      urls,
+      urlTimeouts,
     };
     this.config.maxConcurrentRetries = Math.max(1, this.config.maxConcurrentRetries);
     this.retryQueue = config.retryQueue;
@@ -218,7 +239,7 @@ export class WebhookDelivery {
     const timestamp = Date.now().toString();
     const signature = this.sign(payload, timestamp);
     const controller = new AbortController();
-    const timeoutMs = this.config.deliveryTimeoutMs;
+    const timeoutMs = this.config.urlTimeouts.get(url) ?? this.config.deliveryTimeoutMs;
     const abortTimer = setTimeout(() => controller.abort(), timeoutMs);
 
     // Idempotency header: generate or reuse UUID per event-URL pair
@@ -279,12 +300,12 @@ export class WebhookDelivery {
       const failureMs = Date.now() - startMs;
       span?.setAttribute("webhook.latency_ms", failureMs);
       span?.setAttribute("latency", failureMs);
-      span?.setAttribute("webhook.error", this.getErrorMessage(err));
-      span?.setAttribute("error", this.getErrorMessage(err));
+      span?.setAttribute("webhook.error", this.getErrorMessage(err, timeoutMs));
+      span?.setAttribute("error", this.getErrorMessage(err, timeoutMs));
 
       if (this.watcher.stopped) return { ok: false, error: "stopped" };
 
-      const errorMessage = this.getErrorMessage(err);
+      const errorMessage = this.getErrorMessage(err, timeoutMs);
       this.config.metrics?.recordAttempt(url, attempt, failureMs, "failure");
       this.dlq.recordFailure(url);
       return { ok: false, error: errorMessage };
@@ -543,9 +564,9 @@ export class WebhookDelivery {
     }
   }
 
-  private getErrorMessage(err: unknown): string {
+  private getErrorMessage(err: unknown, timeoutMs?: number): string {
     if (err instanceof Error && err.name === "AbortError") {
-      return `Delivery timed out after ${this.config.deliveryTimeoutMs}ms`;
+      return `Delivery timed out after ${timeoutMs ?? this.config.deliveryTimeoutMs}ms`;
     }
 
     return err instanceof Error ? err.message : "Unknown error";

--- a/packages/pulse-webhooks/src/types.ts
+++ b/packages/pulse-webhooks/src/types.ts
@@ -23,8 +23,10 @@ export type WebhookMetrics = {
   recordTerminal(url: string, outcome: WebhookTerminalOutcome): void;
 };
 
+export type UrlEntry = { url: string; timeoutMs?: number };
+
 export type WebhookConfig = {
-  url: string | string[];
+  url: string | string[] | UrlEntry[];
   secret: string;
   retries?: number;
   deliveryTimeoutMs?: number;

--- a/packages/pulse-webhooks/test/pulse-webhooks.test.ts
+++ b/packages/pulse-webhooks/test/pulse-webhooks.test.ts
@@ -5,7 +5,7 @@ const dnsLookupMock = vi.hoisted(() => vi.fn());
 vi.mock("dns/promises", () => ({ lookup: dnsLookupMock }));
 
 import { Watcher } from "@orbital-stellar/pulse-core";
-import type { RetryQueue, WebhookMetrics } from "../src/index.js";
+import type { RetryQueue, UrlEntry, WebhookMetrics } from "../src/index.js";
 import {
   DeadLetterStore,
   MemoryRetryQueue,
@@ -1858,5 +1858,132 @@ describe("pulse-webhooks WebhookDelivery with retryQueue", () => {
     await vi.advanceTimersByTimeAsync(5000);
 
     expect(vi.mocked(queue.dequeue).mock.calls.length).toBe(dequeueCountBefore);
+  });
+});
+
+describe("pulse-webhooks WebhookDelivery per-URL timeout", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    dnsLookupMock.mockResolvedValue([{ address: "93.184.216.34", family: 4 }]);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("accepts UrlEntry array and delivers to all URLs", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200 });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const urls: UrlEntry[] = [
+      { url: "https://fast.example.com/hook", timeoutMs: 5000 },
+      { url: "https://slow.example.com/hook", timeoutMs: 30000 },
+    ];
+
+    const watcher = new Watcher("GABC");
+    new WebhookDelivery(watcher, { url: urls, secret: "top-secret" });
+
+    watcher.emit("*", deliveryEvent);
+    await flushAsyncWork();
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://fast.example.com/hook",
+      expect.objectContaining({ method: "POST" }),
+    );
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://slow.example.com/hook",
+      expect.objectContaining({ method: "POST" }),
+    );
+  });
+
+  it("uses per-URL timeoutMs as the abort timeout, not the delivery default", async () => {
+    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200 });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const urls: UrlEntry[] = [
+      { url: "https://fast.example.com/hook", timeoutMs: 5000 },
+      { url: "https://slow.example.com/hook", timeoutMs: 30000 },
+    ];
+
+    const watcher = new Watcher("GABC");
+    new WebhookDelivery(watcher, { url: urls, secret: "top-secret", deliveryTimeoutMs: 10000 });
+
+    watcher.emit("*", deliveryEvent);
+    await flushAsyncWork();
+
+    const abortTimerDelays = setTimeoutSpy.mock.calls.map((call) => call[1] as number);
+    expect(abortTimerDelays).toContain(5000);
+    expect(abortTimerDelays).toContain(30000);
+    expect(abortTimerDelays).not.toContain(10000);
+  });
+
+  it("falls back to delivery-level default when a UrlEntry has no timeoutMs", async () => {
+    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200 });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const urls: UrlEntry[] = [
+      { url: "https://override.example.com/hook", timeoutMs: 5000 },
+      { url: "https://default.example.com/hook" },
+    ];
+
+    const watcher = new Watcher("GABC");
+    new WebhookDelivery(watcher, { url: urls, secret: "top-secret", deliveryTimeoutMs: 10000 });
+
+    watcher.emit("*", deliveryEvent);
+    await flushAsyncWork();
+
+    const abortTimerDelays = setTimeoutSpy.mock.calls.map((call) => call[1] as number);
+    expect(abortTimerDelays).toContain(5000);
+    expect(abortTimerDelays).toContain(10000);
+  });
+
+  it("includes per-URL timeoutMs in the timeout error message", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockRejectedValue(Object.assign(new Error("AbortError"), { name: "AbortError" }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const watcher = new Watcher("GABC");
+    const failedHandler = vi.fn();
+    watcher.on("webhook.failed", failedHandler);
+
+    const urls: UrlEntry[] = [{ url: "https://slow.example.com/hook", timeoutMs: 25000 }];
+    new WebhookDelivery(watcher, { url: urls, secret: "top-secret", retries: 1 });
+
+    watcher.emit("*", deliveryEvent);
+    await flushAsyncWork();
+
+    expect(failedHandler).toHaveBeenCalledWith(
+      expect.objectContaining({
+        raw: expect.objectContaining({
+          error: "Delivery timed out after 25000ms",
+        }),
+      }),
+    );
+  });
+
+  it("string[] url form still works with delivery default timeout", async () => {
+    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200 });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const watcher = new Watcher("GABC");
+    new WebhookDelivery(watcher, {
+      url: ["https://a.example.com/hook", "https://b.example.com/hook"],
+      secret: "top-secret",
+      deliveryTimeoutMs: 7500,
+    });
+
+    watcher.emit("*", deliveryEvent);
+    await flushAsyncWork();
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const abortTimerDelays = setTimeoutSpy.mock.calls.map((call) => call[1] as number);
+    expect(abortTimerDelays.filter((d) => d === 7500)).toHaveLength(2);
   });
 });


### PR DESCRIPTION
## Summary

- Extends `WebhookConfig.url` to accept `{ url: string; timeoutMs?: number }[]` in addition to `string` and `string[]`
- Per-URL `timeoutMs` overrides `deliveryTimeoutMs` for that URL only; URLs without `timeoutMs` fall back to the delivery-level default
- Exports new `UrlEntry` type from the package public API
- Timeout error messages reflect the actual per-URL timeout used

## Changes

**`packages/pulse-webhooks/src/types.ts`**
- Added `UrlEntry = { url: string; timeoutMs?: number }` type
- Extended `WebhookConfig.url` to `string | string[] | UrlEntry[]`

**`packages/pulse-webhooks/src/index.ts`**
- Added `normalizeUrlConfig` helper to extract `urls: string[]` and `urlTimeouts: Map<string, number>` from any `url` input form
- Added `urlTimeouts` field to `ResolvedWebhookConfig`
- `doAttempt` looks up per-URL timeout via `urlTimeouts.get(url) ?? deliveryTimeoutMs`
- `getErrorMessage` now accepts an optional `timeoutMs` parameter so abort errors report the correct timeout value
- Exported `UrlEntry` from the public API

**`packages/pulse-webhooks/test/pulse-webhooks.test.ts`**
- 5 new tests covering: `UrlEntry[]` delivery, per-URL abort timer override, fallback to delivery default, correct error message with per-URL timeout, and backward compatibility of `string[]` form

## Verification

```
Tests: 2 failed (pre-existing) | 100 passed | 10 skipped
```
The 2 pre-existing failures (`enqueues retry…` and `continues to use setTimeout…`) were already failing on `main` before this PR due to insufficient async tick flushing for DNS validation in those tests.

closes #395