### PR TITLE
fix(pulse-core): notify watchers on unrecognized operation type

### DIFF
--- a/packages/pulse-core/src/EventEngine.ts
+++ b/packages/pulse-core/src/EventEngine.ts
@@ -48,6 +48,7 @@ import type {
   Logger,
   CursorStoreLike,
   DecodeFailedNotification,
+  UnrecognizedOperationTypeNotification,
   RawHorizonPayment,
   RawHorizonSetOptions,
   RawHorizonCreateAccount,
@@ -1266,6 +1267,12 @@ export class EventEngine {
       return this.normalizeContractEmitted(r, record);
     }
 
+    const operationType = typeof r.type === "string" ? r.type : String(r.type);
+    this.log.warn("[pulse-core] normalize() dropping record with unrecognized operation type.", {
+      operationType,
+      record,
+    });
+    this.emitUnrecognizedOperationTypeNotification(operationType, record);
     return null;
   }
 
@@ -1844,6 +1851,22 @@ export class EventEngine {
         watcher.emit(event.type, event);
         watcher.emit("*", event);
       }
+    }
+  }
+
+  private emitUnrecognizedOperationTypeNotification(operationType: string, record: unknown): void {
+    const notification: UnrecognizedOperationTypeNotification = {
+      type: "engine.unrecognized_operation_type",
+      operationType,
+      record,
+    };
+
+    for (const watcher of this.registry.values()) {
+      watcher.emit("engine.unrecognized_operation_type", notification);
+    }
+
+    for (const { watcher } of this.contractRegistry.values()) {
+      watcher.emit("engine.unrecognized_operation_type", notification);
     }
   }
 

--- a/packages/pulse-core/src/Watcher.ts
+++ b/packages/pulse-core/src/Watcher.ts
@@ -2,6 +2,7 @@ import { EventEmitter } from "events";
 import type {
   DecodeFailedNotification,
   NormalizedEvent,
+  UnrecognizedOperationTypeNotification,
   WatcherNotification,
   PaymentEvent,
   AccountOptionsEvent,
@@ -20,7 +21,11 @@ import type {
   ContractEmittedEvent,
 } from "./index.js";
 
-type WatcherEvent = NormalizedEvent | WatcherNotification | DecodeFailedNotification;
+type WatcherEvent =
+  | NormalizedEvent
+  | WatcherNotification
+  | DecodeFailedNotification
+  | UnrecognizedOperationTypeNotification;
 
 export type WatcherEventMap = {
   "payment.received": PaymentEvent & { readonly timestampDate: Date };
@@ -53,6 +58,7 @@ export type WatcherEventMap = {
   "engine.cursor_store_unhealthy": WatcherNotification;
   "engine.cursor_expired": WatcherNotification;
   "event.decode_failed": DecodeFailedNotification;
+  "engine.unrecognized_operation_type": UnrecognizedOperationTypeNotification;
   "webhook.failed": NormalizedEvent;
   "webhook.dropped": NormalizedEvent;
   "*": WatcherEvent;

--- a/packages/pulse-core/src/index.ts
+++ b/packages/pulse-core/src/index.ts
@@ -619,6 +619,20 @@ export type DecodeFailedNotification = {
 };
 
 /**
+ * Emitted when `EventEngine` receives a record whose `type` field does not
+ * match any recognized Horizon or Soroban operation type. Distinct from
+ * `DecodeFailedNotification`, which covers ABI-spec lookup failures for
+ * already-recognized `contract_event` records.
+ */
+export type UnrecognizedOperationTypeNotification = {
+  type: "engine.unrecognized_operation_type";
+  /** The unrecognized value of the record's `type` field. */
+  operationType: string;
+  /** The raw record that could not be normalized. */
+  record: unknown;
+};
+
+/**
  * Filter criteria for a contract subscription.
  * All specified fields must match (AND semantics).
  * Omitting a field means "match any".

--- a/packages/pulse-core/test/EventEngine.unrecognizedOperationType.test.ts
+++ b/packages/pulse-core/test/EventEngine.unrecognizedOperationType.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+type StreamHandlers = {
+  onmessage: (record: unknown) => void;
+  onerror: (error: unknown) => void;
+};
+
+type MockStreamInstance = {
+  handlers: StreamHandlers;
+  close: ReturnType<typeof vi.fn>;
+};
+
+const streamInstances: MockStreamInstance[] = [];
+
+vi.mock("@stellar/stellar-sdk", () => {
+  class MockServer {
+    operations() {
+      return {
+        cursor() {
+          return {
+            stream(handlers: StreamHandlers) {
+              const close = vi.fn();
+              streamInstances.push({ handlers, close });
+              return close;
+            },
+          };
+        },
+      };
+    }
+  }
+
+  return {
+    Horizon: {
+      Server: MockServer,
+    },
+  };
+});
+
+import { EventEngine } from "../src/EventEngine.js";
+
+beforeEach(() => {
+  streamInstances.length = 0;
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe("engine.unrecognized_operation_type", () => {
+  it("notifies watchers instead of silently dropping an unrecognized record type", () => {
+    const engine = new EventEngine({ network: "testnet" });
+    const watcher = engine.subscribe("GABC");
+    const onUnrecognized = vi.fn();
+    watcher.on("engine.unrecognized_operation_type", onUnrecognized);
+
+    engine.start();
+    expect(streamInstances).toHaveLength(1);
+
+    const record = {
+      type: "some_future_operation_type",
+      created_at: "2026-01-01T00:00:00Z",
+    };
+    streamInstances[0].handlers.onmessage(record);
+
+    expect(onUnrecognized).toHaveBeenCalledTimes(1);
+    expect(onUnrecognized).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "engine.unrecognized_operation_type",
+        operationType: "some_future_operation_type",
+        record,
+      }),
+    );
+  });
+
+  it("does not emit event.decode_failed for an unrecognized record type", () => {
+    const engine = new EventEngine({ network: "testnet" });
+    const watcher = engine.subscribe("GABC");
+    const onDecodeFailed = vi.fn();
+    watcher.on("event.decode_failed", onDecodeFailed);
+
+    engine.start();
+    streamInstances[0].handlers.onmessage({ type: "another_unknown_type" });
+
+    expect(onDecodeFailed).not.toHaveBeenCalled();
+  });
+
+  it("notifies contract watchers as well as classic watchers", () => {
+    const engine = new EventEngine({ network: "testnet" });
+    const contractWatcher = engine.subscribeContract("CAAA");
+    const onUnrecognized = vi.fn();
+    contractWatcher.on("engine.unrecognized_operation_type", onUnrecognized);
+
+    engine.start();
+    streamInstances[0].handlers.onmessage({ type: "totally_unknown" });
+
+    expect(onUnrecognized).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary
- `_normalize()` in `EventEngine.ts` silently dropped any record whose `type` didn't match a known Horizon/Soroban operation — no log, no watcher signal.
- Adds a distinct `engine.unrecognized_operation_type` notification (own payload: `{ operationType, record }`), separate from `event.decode_failed` (ABI-lookup failures on recognized `contract_event` records).
- Broadcasts to both classic and contract watchers, mirroring `notifyWatchers`.

## Test plan
- [x] New `EventEngine.unrecognizedOperationType.test.ts` — 3 tests covering notification payload, non-collision with `event.decode_failed`, and contract-watcher delivery
- [x] `pnpm typecheck` clean in pulse-core
- [x] Full pulse-core suite: 561 passed / 7 skipped

Closes #850