### PR TITLE
feat(pulse-notify): WebSocket transport reconnect with jittered backoff

### DIFF
--- a/packages/pulse-notify/src/wsTransport.ts
+++ b/packages/pulse-notify/src/wsTransport.ts
@@ -1,10 +1,27 @@
 import type { NormalizedEvent } from "@orbital-stellar/pulse-core";
 import type { WsConnectionKey, WsConnectionSubscriber } from "./connectionTypes.js";
 
+// Mirrors the full-jitter exponential backoff formula in
+// packages/pulse-core/src/backoff.ts (used for the Horizon/Soroban reconnect
+// paths). Duplicated here rather than imported since pulse-core does not
+// expose it as a public export and WebSocket reconnect is a browser-only
+// concern specific to this package.
+function fullJitterBackoffMs(attempt: number, initialDelayMs: number, maxDelayMs: number): number {
+  const exponentialDelay = Math.min(initialDelayMs * 2 ** (attempt - 1), maxDelayMs);
+  return Math.floor(Math.random() * exponentialDelay);
+}
+
+const RECONNECT_INITIAL_DELAY_MS = 1000;
+const RECONNECT_MAX_DELAY_MS = 30000;
+
 type WsEntry = {
   ws: WebSocket;
   subscribers: Set<WsConnectionSubscriber>;
   connected: boolean;
+  reconnectAttempt: number;
+  reconnectTimer?: ReturnType<typeof setTimeout>;
+  /** Set once `unsubscribe()` has closed the pool entry intentionally, to stop further reconnects. */
+  closedByClient: boolean;
 };
 
 const pool = new Map<string, WsEntry>();
@@ -22,43 +39,79 @@ function notify(entry: WsEntry, fn: (s: WsConnectionSubscriber) => void) {
   for (const s of [...entry.subscribers]) fn(s);
 }
 
+/** Schedules a jittered-backoff reconnect unless the entry was closed intentionally or has no subscribers left. */
+function scheduleReconnect(poolKey: string, key: WsConnectionKey, entry: WsEntry): void {
+  if (entry.closedByClient || entry.subscribers.size === 0) return;
+  if (entry.reconnectTimer !== undefined) return;
+
+  entry.reconnectAttempt += 1;
+  const delayMs = fullJitterBackoffMs(
+    entry.reconnectAttempt,
+    RECONNECT_INITIAL_DELAY_MS,
+    RECONNECT_MAX_DELAY_MS,
+  );
+
+  entry.reconnectTimer = setTimeout(() => {
+    entry.reconnectTimer = undefined;
+    if (entry.closedByClient || entry.subscribers.size === 0) return;
+    entry.ws = new WebSocket(getWsUrl(key));
+    attachHandlers(entry.ws, poolKey, key, entry);
+  }, delayMs);
+}
+
+function attachHandlers(
+  ws: WebSocket,
+  poolKey: string,
+  key: WsConnectionKey,
+  entry: WsEntry,
+): void {
+  ws.onopen = () => {
+    entry.connected = true;
+    entry.reconnectAttempt = 0;
+    notify(entry, (s) => s.onOpen());
+  };
+
+  ws.onmessage = (msg) => {
+    try {
+      const data = JSON.parse(msg.data as string);
+      if (data && typeof data === "object" && data.type === "auth_expired") {
+        entry.connected = false;
+        notify(entry, (s) => s.onAuthExpired?.());
+        return;
+      }
+      const event = data as NormalizedEvent;
+      notify(entry, (s) => s.onEvent(event));
+    } catch {
+      notify(entry, (s) => s.onParseError());
+    }
+  };
+
+  ws.onerror = () => {
+    entry.connected = false;
+    notify(entry, (s) => s.onError());
+  };
+
+  ws.onclose = () => {
+    entry.connected = false;
+    notify(entry, (s) => s.onError());
+    scheduleReconnect(poolKey, key, entry);
+  };
+}
+
 export function acquireWsConnection(key: WsConnectionKey, subscriber: WsConnectionSubscriber) {
   const poolKey = getKey(key);
   let entry = pool.get(poolKey);
 
   if (!entry) {
     const ws = new WebSocket(getWsUrl(key));
-    const newEntry: WsEntry = { ws, subscribers: new Set(), connected: false };
-
-    ws.onopen = () => {
-      newEntry.connected = true;
-      notify(newEntry, (s) => s.onOpen());
+    const newEntry: WsEntry = {
+      ws,
+      subscribers: new Set(),
+      connected: false,
+      reconnectAttempt: 0,
+      closedByClient: false,
     };
-
-    ws.onmessage = (msg) => {
-      try {
-        const data = JSON.parse(msg.data as string);
-        if (data && typeof data === "object" && data.type === "auth_expired") {
-          newEntry.connected = false;
-          notify(newEntry, (s) => s.onAuthExpired?.());
-          return;
-        }
-        const event = data as NormalizedEvent;
-        notify(newEntry, (s) => s.onEvent(event));
-      } catch {
-        notify(newEntry, (s) => s.onParseError());
-      }
-    };
-
-    ws.onerror = () => {
-      newEntry.connected = false;
-      notify(newEntry, (s) => s.onError());
-    };
-
-    ws.onclose = () => {
-      newEntry.connected = false;
-      notify(newEntry, (s) => s.onError());
-    };
+    attachHandlers(ws, poolKey, key, newEntry);
 
     pool.set(poolKey, newEntry);
     entry = newEntry;
@@ -73,6 +126,11 @@ export function acquireWsConnection(key: WsConnectionKey, subscriber: WsConnecti
     unsubscribe: () => {
       entry.subscribers.delete(subscriber);
       if (entry.subscribers.size === 0) {
+        entry.closedByClient = true;
+        if (entry.reconnectTimer !== undefined) {
+          clearTimeout(entry.reconnectTimer);
+          entry.reconnectTimer = undefined;
+        }
         entry.ws.close();
         pool.delete(poolKey);
       }
@@ -85,6 +143,10 @@ export function __getWsPoolSizeForTests() {
 }
 
 export function __resetWsPoolForTests() {
-  for (const entry of pool.values()) entry.ws.close();
+  for (const entry of pool.values()) {
+    entry.closedByClient = true;
+    if (entry.reconnectTimer !== undefined) clearTimeout(entry.reconnectTimer);
+    entry.ws.close();
+  }
   pool.clear();
 }

--- a/packages/pulse-notify/test/wsTransport.reconnect.test.ts
+++ b/packages/pulse-notify/test/wsTransport.reconnect.test.ts
@@ -1,0 +1,132 @@
+/**
+ * WebSocket reconnect — proves a dropped connection is retried with jittered
+ * backoff (mirroring pulse-core's full-jitter algorithm) instead of staying
+ * dead, and that an intentional unsubscribe() does not trigger a reconnect.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { acquireWsConnection, __resetWsPoolForTests } from "../src/wsTransport.js";
+
+class MockWebSocket {
+  static instances: MockWebSocket[] = [];
+  onopen: (() => void) | null = null;
+  onmessage: ((e: { data: string }) => void) | null = null;
+  onerror: (() => void) | null = null;
+  onclose: (() => void) | null = null;
+  closeCount = 0;
+  constructor(readonly url: string) {
+    MockWebSocket.instances.push(this);
+  }
+  close() {
+    this.closeCount++;
+  }
+}
+
+(globalThis as any).WebSocket = MockWebSocket;
+
+const SERVER = "https://events.example.com";
+const ADDRESS = "GABC123";
+
+function makeSubscriber() {
+  const opens: number[] = [];
+  const errors: number[] = [];
+  return {
+    opens,
+    errors,
+    sub: {
+      onOpen: () => opens.push(Date.now()),
+      onEvent: () => {},
+      onParseError: () => {},
+      onError: () => errors.push(Date.now()),
+    },
+  };
+}
+
+describe("WebSocket reconnect", () => {
+  beforeEach(() => {
+    MockWebSocket.instances = [];
+    __resetWsPoolForTests();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    __resetWsPoolForTests();
+    vi.useRealTimers();
+  });
+
+  it("reconnects with a new WebSocket after the connection drops", () => {
+    const { sub } = makeSubscriber();
+    acquireWsConnection({ serverUrl: SERVER, address: ADDRESS }, sub);
+    expect(MockWebSocket.instances).toHaveLength(1);
+
+    // Server drops the connection.
+    MockWebSocket.instances[0]!.onclose!();
+
+    // Advance past the max possible first-attempt backoff delay.
+    vi.advanceTimersByTime(1000);
+
+    expect(MockWebSocket.instances).toHaveLength(2);
+  });
+
+  it("notifies onError for a dropped connection (existing error field surfaces reconnects)", () => {
+    const { sub, errors } = makeSubscriber();
+    acquireWsConnection({ serverUrl: SERVER, address: ADDRESS }, sub);
+
+    MockWebSocket.instances[0]!.onclose!();
+
+    expect(errors).toHaveLength(1);
+  });
+
+  it("resets the reconnect attempt counter once the new connection opens", () => {
+    const { sub } = makeSubscriber();
+    acquireWsConnection({ serverUrl: SERVER, address: ADDRESS }, sub);
+
+    MockWebSocket.instances[0]!.onclose!();
+    vi.advanceTimersByTime(1000);
+    expect(MockWebSocket.instances).toHaveLength(2);
+
+    MockWebSocket.instances[1]!.onopen!();
+
+    // A second drop should schedule with a fresh attempt=1 window, not attempt=2.
+    MockWebSocket.instances[1]!.onclose!();
+    vi.advanceTimersByTime(1000);
+    expect(MockWebSocket.instances).toHaveLength(3);
+  });
+
+  it("backs off exponentially across repeated drops", () => {
+    const { sub } = makeSubscriber();
+    acquireWsConnection({ serverUrl: SERVER, address: ADDRESS }, sub);
+
+    // Drop repeatedly without ever reopening, growing the attempt counter.
+    for (let i = 0; i < 5; i++) {
+      const current = MockWebSocket.instances.at(-1)!;
+      current.onclose!();
+      vi.advanceTimersByTime(30_000);
+    }
+
+    // Each drop schedules at most one reconnect; five drops -> six total instances.
+    expect(MockWebSocket.instances).toHaveLength(6);
+  });
+
+  it("does not reconnect after an intentional unsubscribe", () => {
+    const { sub } = makeSubscriber();
+    const conn = acquireWsConnection({ serverUrl: SERVER, address: ADDRESS }, sub);
+    conn.unsubscribe();
+
+    vi.advanceTimersByTime(60_000);
+
+    expect(MockWebSocket.instances).toHaveLength(1);
+  });
+
+  it("does not schedule a second reconnect timer while one is already pending", () => {
+    const { sub } = makeSubscriber();
+    acquireWsConnection({ serverUrl: SERVER, address: ADDRESS }, sub);
+
+    // onerror followed by onclose (typical browser sequence) must not double-schedule.
+    MockWebSocket.instances[0]!.onerror!();
+    MockWebSocket.instances[0]!.onclose!();
+
+    vi.advanceTimersByTime(1000);
+
+    expect(MockWebSocket.instances).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
## Summary
- `wsTransport.ts`'s `onclose`/`onerror` only notified subscribers (existing `error` field) and left the connection dead — unlike `EventSource`, `WebSocket` has no built-in reconnect.
- Adds full-jitter exponential backoff, mirroring the formula in `packages/pulse-core/src/backoff.ts` used for Horizon/Soroban reconnects (duplicated locally since it isn't a public pulse-core export and this is a browser-only concern).
- On drop: schedules a reconnect at `fullJitterBackoffMs(attempt, 1000, 30000)`, opens a new `WebSocket`, rewires handlers.
- On successful reopen: resets the attempt counter.
- On intentional `unsubscribe()`: sets `closedByClient` and clears any pending reconnect timer so a deliberate close never reconnects.
- Reconnect attempts continue to surface via the existing `onError`/`error` field, per the issue's ask — no new state field needed.

## Test plan
- [x] New `test/wsTransport.reconnect.test.ts` — 6 tests: reconnect creates a new WebSocket, error field fires, attempt counter resets on reopen, backoff across repeated drops, no reconnect after unsubscribe, no double-scheduling on error+close
- [x] `pnpm build` clean
- [x] Full pulse-notify suite: 72 passed (13 files), including the pre-existing `transports.test.ts` parity tests

Closes #421