### PR TITLE
feat(pulse-webhooks): replay queue health probe

### DIFF
--- a/packages/pulse-webhooks/src/RetryQueue.ts
+++ b/packages/pulse-webhooks/src/RetryQueue.ts
@@ -16,4 +16,10 @@ export type RetryQueue = {
   nack(recordId: string, requeueDelayMs: number): Promise<void>;
   evictNewest(): Promise<RetryRecord | null>;
   size(): Promise<number>;
+  /**
+   * Optional liveness probe used by {@link WebhookDelivery.healthCheck}. Adapters
+   * backed by a network service (Redis, Postgres, SQS) may implement this to
+   * verify connectivity; a rejection flips delivery health to unhealthy.
+   */
+  ping?(): Promise<void>;
 };

--- a/packages/pulse-webhooks/src/index.ts
+++ b/packages/pulse-webhooks/src/index.ts
@@ -1,5 +1,6 @@
 import type {
   DecodeFailedNotification,
+  HealthCheckResult,
   NormalizedEvent,
   UnrecognizedOperationTypeNotification,
   Watcher,
@@ -283,6 +284,30 @@ export class WebhookDelivery {
   /** Re-deliver a stored terminal failure by dead-letter id. */
   async replayFailure(failureId: string): Promise<void> {
     await this.dlq.replay(failureId);
+  }
+
+  /**
+   * Reports whether this delivery instance and its durable retry queue (if
+   * configured) are healthy. A failing `retryQueue.ping()` flips health to
+   * unhealthy, mirroring `EventEngine.healthCheck()`'s treatment of
+   * `cursorStore.ping()`.
+   */
+  async healthCheck(): Promise<HealthCheckResult> {
+    const reasons: string[] = [];
+
+    if (this.stopped) {
+      reasons.push("webhook delivery is stopped");
+    }
+
+    if (this.retryQueue?.ping) {
+      try {
+        await this.retryQueue.ping();
+      } catch (err) {
+        reasons.push(`retryQueue: ${err instanceof Error ? err.message : String(err)}`);
+      }
+    }
+
+    return { ok: reasons.length === 0, reasons };
   }
 
   private resolveDeadLetterStore(

--- a/packages/pulse-webhooks/test/healthCheck.test.ts
+++ b/packages/pulse-webhooks/test/healthCheck.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { Watcher } from "@orbital-stellar/pulse-core";
+import type { RetryQueue } from "../src/index.js";
+import { WebhookDelivery } from "../src/index.js";
+
+function makeRetryQueue(overrides: Partial<RetryQueue> = {}): RetryQueue {
+  return {
+    enqueue: vi.fn(),
+    dequeue: vi.fn().mockResolvedValue(null),
+    ack: vi.fn(),
+    nack: vi.fn(),
+    evictNewest: vi.fn().mockResolvedValue(null),
+    size: vi.fn().mockResolvedValue(0),
+    ...overrides,
+  };
+}
+
+describe("WebhookDelivery.healthCheck()", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("is healthy when no retryQueue is configured", async () => {
+    const watcher = new Watcher("GABC");
+    const delivery = new WebhookDelivery(watcher, {
+      url: "https://prod.example.com/webhooks/stellar",
+      secret: "top-secret",
+    });
+
+    const result = await delivery.healthCheck();
+
+    expect(result).toEqual({ ok: true, reasons: [] });
+  });
+
+  it("is healthy when the configured retryQueue's ping() resolves", async () => {
+    const ping = vi.fn().mockResolvedValue(undefined);
+    const watcher = new Watcher("GABC");
+    const delivery = new WebhookDelivery(watcher, {
+      url: "https://prod.example.com/webhooks/stellar",
+      secret: "top-secret",
+      retryQueue: makeRetryQueue({ ping }),
+    });
+
+    const result = await delivery.healthCheck();
+
+    expect(ping).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({ ok: true, reasons: [] });
+  });
+
+  it("flips to unhealthy when the retryQueue's ping() rejects", async () => {
+    const ping = vi.fn().mockRejectedValue(new Error("ECONNREFUSED"));
+    const watcher = new Watcher("GABC");
+    const delivery = new WebhookDelivery(watcher, {
+      url: "https://prod.example.com/webhooks/stellar",
+      secret: "top-secret",
+      retryQueue: makeRetryQueue({ ping }),
+    });
+
+    const result = await delivery.healthCheck();
+
+    expect(result.ok).toBe(false);
+    expect(result.reasons).toEqual(["retryQueue: ECONNREFUSED"]);
+  });
+
+  it("is healthy when the retryQueue has no ping() implementation", async () => {
+    const watcher = new Watcher("GABC");
+    const delivery = new WebhookDelivery(watcher, {
+      url: "https://prod.example.com/webhooks/stellar",
+      secret: "top-secret",
+      retryQueue: makeRetryQueue(),
+    });
+
+    const result = await delivery.healthCheck();
+
+    expect(result).toEqual({ ok: true, reasons: [] });
+  });
+
+  it("reports unhealthy once stopped", async () => {
+    const watcher = new Watcher("GABC");
+    const delivery = new WebhookDelivery(watcher, {
+      url: "https://prod.example.com/webhooks/stellar",
+      secret: "top-secret",
+    });
+
+    delivery.stop();
+    const result = await delivery.healthCheck();
+
+    expect(result.ok).toBe(false);
+    expect(result.reasons).toEqual(["webhook delivery is stopped"]);
+  });
+});


### PR DESCRIPTION
## Summary
- Added optional `RetryQueue.ping(): Promise<void>` for network-backed adapters (Redis, Postgres, SQS) to implement.
- Added `WebhookDelivery.healthCheck(): Promise<HealthCheckResult>` — calls `retryQueue.ping()` if present and reports unhealthy on rejection, or once the delivery instance is `stopped`. Mirrors `EventEngine.healthCheck()`'s treatment of `cursorStore.ping()`.

## Test plan
- [x] New `test/healthCheck.test.ts` — 5 tests: no queue configured, ping resolves, ping rejects → unhealthy with reason, queue with no ping impl, stopped delivery
- [x] `pnpm build` clean
- [x] Full pulse-webhooks suite: 193 passed (11 files) — note `DeadLetterStore.test.ts` has a pre-existing timing flake on this repo unrelated to this change (reproduces identically on clean `main`, passes on rerun)

Closes #382