### PR TITLE
feat(abi-registry,pulse-core): per-version contract spec lookup

### DIFF
--- a/packages/abi-registry/src/AbiRegistryClient.ts
+++ b/packages/abi-registry/src/AbiRegistryClient.ts
@@ -83,6 +83,46 @@ export class AbiRegistryClient {
   }
 
   /**
+   * Fetch the contract spec as it existed at a specific ledger, for contracts
+   * that have upgraded and no longer match `getSpec`'s latest-spec lookup.
+   * The registry server is responsible for ledger-versioned spec storage;
+   * this client just passes `ledger` through as a query parameter.
+   *
+   * Cached separately from `getSpec` (keyed by `contractId@ledger`) since a
+   * historical spec must never be conflated with the latest one.
+   */
+  async getSpecAt(contractId: string, ledger: number): Promise<XdrContractSpec | null> {
+    const cacheKey = `${contractId}@${ledger}`;
+    const cached = this.getCached(cacheKey);
+    if (cached !== undefined) return cached;
+
+    const response = await this.transport(
+      `${this.baseUrl}/specs/${encodeURIComponent(contractId)}?ledger=${encodeURIComponent(ledger)}`,
+      {
+        method: "GET",
+        headers: {
+          Accept: `application/vnd.orbital.abi-registry+json; version=${REGISTRY_SPEC_VERSION}`,
+        },
+      },
+    );
+
+    if (response.status === 404) {
+      this.setCache(cacheKey, null);
+      return null;
+    }
+
+    if (!response.ok) {
+      throw new Error(
+        `ABI registry responded with ${response.status} for versioned contract spec fetch`,
+      );
+    }
+
+    const spec = (await response.json()) as XdrContractSpec;
+    this.setCache(cacheKey, spec);
+    return spec;
+  }
+
+  /**
    * Fetch specs for multiple contract IDs in a single round-trip.
    * Results are cached; only uncached IDs are fetched from the registry.
    *

--- a/packages/abi-registry/test/AbiRegistryClient.test.ts
+++ b/packages/abi-registry/test/AbiRegistryClient.test.ts
@@ -203,6 +203,66 @@ describe("AbiRegistryClient", () => {
     });
   });
 
+  describe("getSpecAt", () => {
+    it("fetches a ledger-versioned spec from GET /specs/:id?ledger=N", async () => {
+      const spec = makeSpec("CONTRACT_Z");
+      mockFetch(() => new Response(JSON.stringify(spec), { status: 200 }));
+
+      const client = new AbiRegistryClient({ baseUrl: "https://abi.example.com" });
+      const result = await client.getSpecAt("CONTRACT_Z", 12345);
+
+      expect(result).toEqual(spec);
+      expect(fetch).toHaveBeenCalledWith(
+        "https://abi.example.com/specs/CONTRACT_Z?ledger=12345",
+        expect.objectContaining({ method: "GET" }),
+      );
+    });
+
+    it("returns null when no spec is recorded at that ledger (404)", async () => {
+      mockFetch(() => new Response(null, { status: 404 }));
+
+      const client = new AbiRegistryClient({ baseUrl: "https://abi.example.com" });
+      expect(await client.getSpecAt("CONTRACT_Z", 1)).toBeNull();
+    });
+
+    it("throws when the registry returns a non-OK status", async () => {
+      mockFetch(() => new Response("Internal Server Error", { status: 500 }));
+
+      const client = new AbiRegistryClient({ baseUrl: "https://abi.example.com" });
+      await expect(client.getSpecAt("CONTRACT_Z", 1)).rejects.toThrow(
+        "ABI registry responded with 500",
+      );
+    });
+
+    it("caches getSpecAt results independently of getSpec (different ledgers, different specs)", async () => {
+      const specV1 = makeSpec("CONTRACT_UPGRADED_V1");
+      const specV2 = makeSpec("CONTRACT_UPGRADED_V2");
+      const specLatest = makeSpec("CONTRACT_UPGRADED_LATEST");
+
+      const fetchMock = vi.fn((url: string) => {
+        if (url.includes("ledger=100")) {
+          return Promise.resolve(new Response(JSON.stringify(specV1), { status: 200 }));
+        }
+        if (url.includes("ledger=200")) {
+          return Promise.resolve(new Response(JSON.stringify(specV2), { status: 200 }));
+        }
+        return Promise.resolve(new Response(JSON.stringify(specLatest), { status: 200 }));
+      });
+      vi.stubGlobal("fetch", fetchMock);
+
+      const client = new AbiRegistryClient({ baseUrl: "https://abi.example.com" });
+
+      expect(await client.getSpecAt("CONTRACT_UPGRADED", 100)).toEqual(specV1);
+      expect(await client.getSpecAt("CONTRACT_UPGRADED", 200)).toEqual(specV2);
+      expect(await client.getSpec("CONTRACT_UPGRADED")).toEqual(specLatest);
+      expect(fetchMock).toHaveBeenCalledTimes(3);
+
+      // Re-fetching the same ledger is served from cache, not a 4th network call.
+      expect(await client.getSpecAt("CONTRACT_UPGRADED", 100)).toEqual(specV1);
+      expect(fetchMock).toHaveBeenCalledTimes(3);
+    });
+  });
+
   describe("LRU eviction", () => {
     it("evicts the least-recently-used entry when maxCacheSize is exceeded", async () => {
       // Cache size of 2: fill with A and B, then access A, then add C.

--- a/packages/pulse-core/src/EventEngine.ts
+++ b/packages/pulse-core/src/EventEngine.ts
@@ -2063,7 +2063,11 @@ export class EventEngine {
         // subscribers always receive a fully-enriched (or gracefully degraded)
         // event rather than a partially-populated one.
         const contractId = event.contractId;
-        this.abiRegistry.getSpec(contractId).then(
+        const specPromise =
+          this.abiRegistry.getSpecAt && event.ledger !== undefined
+            ? this.abiRegistry.getSpecAt(contractId, event.ledger)
+            : this.abiRegistry.getSpec(contractId);
+        specPromise.then(
           (spec) => {
             if (spec !== null && spec !== undefined) {
               (event as ContractEmittedEvent).decodedData =

--- a/packages/pulse-core/src/index.ts
+++ b/packages/pulse-core/src/index.ts
@@ -485,6 +485,13 @@ export interface Logger {
  */
 export interface AbiRegistryClientLike {
   getSpec(contractId: string): Promise<unknown>;
+  /**
+   * Optional ledger-versioned spec lookup. When implemented, `EventEngine`
+   * calls it with the emitting event's `ledger` instead of `getSpec`, so a
+   * contract that upgraded mid-stream decodes against the spec at its
+   * ledger rather than the latest one.
+   */
+  getSpecAt?(contractId: string, ledger: number): Promise<unknown>;
 }
 
 export type SorobanConfig = {

--- a/packages/pulse-core/test/EventEngine.abiRegistry.test.ts
+++ b/packages/pulse-core/test/EventEngine.abiRegistry.test.ts
@@ -191,6 +191,52 @@ describe("EventEngine — ABI registry integration", () => {
     expect(received[0]!.decodedData).toBeUndefined();
   });
 
+  it("calls getSpecAt with the event's ledger instead of getSpec, when implemented", async () => {
+    const spec = { contractId: "CABC1234", entries: ["versioned-entry=="] };
+    const abiRegistry: AbiRegistryClientLike = {
+      getSpec: vi.fn().mockResolvedValue({ contractId: "CABC1234", entries: ["latest-entry=="] }),
+      getSpecAt: vi.fn().mockResolvedValue(spec),
+    };
+
+    const { engine, simulateRecord } = buildEngine(abiRegistry);
+    const received: ContractEmittedEvent[] = [];
+
+    const watcher = engine.subscribeContract("sub1");
+    watcher.on("contract.emitted", (e) => received.push(e as ContractEmittedEvent));
+
+    simulateRecord(makeEmittedRecord({ ledger: 42000 }));
+
+    await vi.waitFor(() => expect(received).toHaveLength(1));
+
+    expect(abiRegistry.getSpecAt).toHaveBeenCalledWith("CABC1234", 42000);
+    expect(abiRegistry.getSpec).not.toHaveBeenCalled();
+    expect(received[0]!.decodedData).toEqual(spec.entries);
+  });
+
+  it("falls back to getSpec when getSpecAt is implemented but the event has no ledger", async () => {
+    const spec = { contractId: "CABC1234", entries: ["latest-entry=="] };
+    const abiRegistry: AbiRegistryClientLike = {
+      getSpec: vi.fn().mockResolvedValue(spec),
+      getSpecAt: vi.fn().mockResolvedValue(null),
+    };
+
+    const { engine, simulateRecord } = buildEngine(abiRegistry);
+    const received: ContractEmittedEvent[] = [];
+
+    const watcher = engine.subscribeContract("sub1");
+    watcher.on("contract.emitted", (e) => received.push(e as ContractEmittedEvent));
+
+    const record = makeEmittedRecord();
+    delete record.ledger;
+    simulateRecord(record);
+
+    await vi.waitFor(() => expect(received).toHaveLength(1));
+
+    expect(abiRegistry.getSpecAt).not.toHaveBeenCalled();
+    expect(abiRegistry.getSpec).toHaveBeenCalledWith("CABC1234");
+    expect(received[0]!.decodedData).toEqual(spec.entries);
+  });
+
   it("does not call getSpec for contract.invoked events", async () => {
     const abiRegistry: AbiRegistryClientLike = {
       getSpec: vi.fn().mockResolvedValue(null),


### PR DESCRIPTION
## Summary
- `AbiRegistryClient.getSpecAt(contractId, ledger)` — fetches the spec as it existed at a specific ledger via `GET /specs/:id?ledger=N`. The registry server owns ledger-versioned storage; the client just passes `ledger` through.
- Cached separately from `getSpec` (`contractId@ledger` key) so a historical spec is never conflated with the latest one.
- `AbiRegistryClientLike.getSpecAt` added as an optional interface method.
- `EventEngine`'s `contract.emitted` decode path now prefers `abiRegistry.getSpecAt(contractId, event.ledger)` over `getSpec` when the client implements it and the event carries a `ledger`; falls back to `getSpec` otherwise (no ledger on the event, or the client doesn't implement `getSpecAt`).

## Test plan
- [x] New `getSpecAt` describe block in `AbiRegistryClient.test.ts` — 4 tests: query param, 404 → null, non-OK throws, cached independently per ledger from `getSpec`
- [x] Two new tests in `EventEngine.abiRegistry.test.ts` — prefers `getSpecAt` with the event's ledger when implemented; falls back to `getSpec` when the event has no ledger
- [x] `pnpm typecheck` clean in both packages
- [x] abi-registry suite: 132 passed; pulse-core suite: 563 passed / 7 skipped

Closes #362