### PR TITLE
feat(pulse-webhooks): OpenTelemetry metrics adapter

### DIFF
--- a/packages/pulse-webhooks/src/OtelWebhookMetrics.ts
+++ b/packages/pulse-webhooks/src/OtelWebhookMetrics.ts
@@ -1,0 +1,60 @@
+import type {
+  Meter,
+  OtelCounter,
+  OtelHistogram,
+  WebhookAttemptStatus,
+  WebhookMetrics,
+  WebhookTerminalOutcome,
+} from "./types.js";
+
+/**
+ * OpenTelemetry-backed implementation of the `WebhookMetrics` interface.
+ *
+ * Exposes three metric instruments, the OTel-attribute equivalent of
+ * `PrometheusWebhookMetrics`' label-based metric families:
+ * - `orbital.webhook.attempts` (counter, attributes: `url`, `status`)
+ * - `orbital.webhook.duration` (histogram, unit `ms`, attributes: `url`, `status`)
+ * - `orbital.webhook.terminal_outcomes` (counter, attributes: `url`, `outcome`)
+ *
+ * Accepts any object structurally compatible with `@opentelemetry/api`'s
+ * `Meter` interface (see {@link Meter}), matching this package's existing
+ * `Tracer`/`Span` pattern — pulse-webhooks does not need a hard dependency
+ * on `@opentelemetry/api`. Construct with a real `Meter` from
+ * `metrics.getMeter("orbital-pulse-webhooks")` (or any collector adapter
+ * exposing the same shape) and export it to your OTel collector as usual.
+ *
+ * @note `url` is used as an attribute value, which can cause high
+ *       cardinality in some backends. See the same caveat on
+ *       `PrometheusWebhookMetrics`.
+ */
+export class OtelWebhookMetrics implements WebhookMetrics {
+  private readonly attemptsTotal: OtelCounter;
+  private readonly durationMs: OtelHistogram;
+  private readonly terminalOutcomesTotal: OtelCounter;
+
+  constructor(meter: Meter) {
+    this.attemptsTotal = meter.createCounter("orbital.webhook.attempts", {
+      description: "Total number of webhook delivery attempts",
+    });
+    this.durationMs = meter.createHistogram("orbital.webhook.duration", {
+      description: "Duration of webhook delivery attempts in milliseconds",
+    });
+    this.terminalOutcomesTotal = meter.createCounter("orbital.webhook.terminal_outcomes", {
+      description: "Total number of terminal webhook delivery outcomes",
+    });
+  }
+
+  recordAttempt(
+    url: string,
+    _attempt: number,
+    durationMs: number,
+    status: WebhookAttemptStatus,
+  ): void {
+    this.attemptsTotal.add(1, { url, status });
+    this.durationMs.record(durationMs, { url, status });
+  }
+
+  recordTerminal(url: string, outcome: WebhookTerminalOutcome): void {
+    this.terminalOutcomesTotal.add(1, { url, outcome });
+  }
+}

--- a/packages/pulse-webhooks/src/index.ts
+++ b/packages/pulse-webhooks/src/index.ts
@@ -52,6 +52,7 @@ export { MemoryDeadLetterStore };
 export const DeadLetterStore = MemoryDeadLetterStore;
 export { NOOP_WEBHOOK_METRICS, CountingWebhookMetrics } from "./metrics.js";
 export { PrometheusWebhookMetrics } from "./PrometheusWebhookMetrics.js";
+export { OtelWebhookMetrics } from "./OtelWebhookMetrics.js";
 export type { WebhookAttemptStatus, WebhookMetrics, WebhookTerminalOutcome } from "./types.js";
 export { exponentialJittered, linear, cappedExponential, constant } from "./backoff.js";
 export type { BackoffStrategy } from "./backoff.js";
@@ -85,6 +86,10 @@ export type {
 } from "./SqsRetryQueue.js";
 export type { RetryQueue, RetryRecord } from "./RetryQueue.js";
 export type {
+  Meter,
+  MetricAttributes,
+  OtelCounter,
+  OtelHistogram,
   Span,
   Tracer,
   UrlEntry,

--- a/packages/pulse-webhooks/src/types.ts
+++ b/packages/pulse-webhooks/src/types.ts
@@ -23,6 +23,28 @@ export type WebhookMetrics = {
   recordTerminal(url: string, outcome: WebhookTerminalOutcome): void;
 };
 
+/** Attribute bag attached to an OpenTelemetry counter/histogram data point. */
+export type MetricAttributes = Record<string, string | number | boolean>;
+
+export type OtelCounter = {
+  add(value: number, attributes?: MetricAttributes): void;
+};
+
+export type OtelHistogram = {
+  record(value: number, attributes?: MetricAttributes): void;
+};
+
+/**
+ * Minimal structural subset of `@opentelemetry/api`'s `Meter` interface,
+ * mirroring this file's `Tracer`/`Span` pattern: a real OTel `Meter` (or any
+ * compatible object) satisfies this type, so pulse-webhooks does not need a
+ * hard dependency on `@opentelemetry/api`.
+ */
+export type Meter = {
+  createCounter(name: string, options?: { description?: string }): OtelCounter;
+  createHistogram(name: string, options?: { description?: string }): OtelHistogram;
+};
+
 export type UrlEntry = { url: string; timeoutMs?: number };
 
 export type WebhookConfig = {

--- a/packages/pulse-webhooks/test/OtelWebhookMetrics.test.ts
+++ b/packages/pulse-webhooks/test/OtelWebhookMetrics.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi } from "vitest";
+import { OtelWebhookMetrics } from "../src/OtelWebhookMetrics.js";
+import type { Meter, MetricAttributes } from "../src/types.js";
+
+type RecordedPoint = { value: number; attributes?: MetricAttributes };
+
+function makeFakeMeter(): {
+  meter: Meter;
+  counters: Map<string, RecordedPoint[]>;
+  histograms: Map<string, RecordedPoint[]>;
+} {
+  const counters = new Map<string, RecordedPoint[]>();
+  const histograms = new Map<string, RecordedPoint[]>();
+
+  const meter: Meter = {
+    createCounter: (name) => {
+      counters.set(name, []);
+      return {
+        add: (value, attributes) => {
+          counters.get(name)!.push({ value, attributes });
+        },
+      };
+    },
+    createHistogram: (name) => {
+      histograms.set(name, []);
+      return {
+        record: (value, attributes) => {
+          histograms.get(name)!.push({ value, attributes });
+        },
+      };
+    },
+  };
+
+  return { meter, counters, histograms };
+}
+
+describe("OtelWebhookMetrics", () => {
+  it("creates the three documented instruments on construction", () => {
+    const { meter, counters, histograms } = makeFakeMeter();
+    new OtelWebhookMetrics(meter);
+
+    expect(counters.has("orbital.webhook.attempts")).toBe(true);
+    expect(histograms.has("orbital.webhook.duration")).toBe(true);
+    expect(counters.has("orbital.webhook.terminal_outcomes")).toBe(true);
+  });
+
+  it("records an attempt as a counter increment and a duration observation with matching attributes", () => {
+    const { meter, counters, histograms } = makeFakeMeter();
+    const metrics = new OtelWebhookMetrics(meter);
+
+    metrics.recordAttempt("https://prod.example.com/webhooks/stellar", 1, 123, "success");
+
+    expect(counters.get("orbital.webhook.attempts")).toEqual([
+      {
+        value: 1,
+        attributes: { url: "https://prod.example.com/webhooks/stellar", status: "success" },
+      },
+    ]);
+    expect(histograms.get("orbital.webhook.duration")).toEqual([
+      {
+        value: 123,
+        attributes: { url: "https://prod.example.com/webhooks/stellar", status: "success" },
+      },
+    ]);
+  });
+
+  it("records a terminal outcome as a counter increment with matching attributes", () => {
+    const { meter, counters } = makeFakeMeter();
+    const metrics = new OtelWebhookMetrics(meter);
+
+    metrics.recordTerminal("https://prod.example.com/webhooks/stellar", "dropped");
+
+    expect(counters.get("orbital.webhook.terminal_outcomes")).toEqual([
+      {
+        value: 1,
+        attributes: { url: "https://prod.example.com/webhooks/stellar", outcome: "dropped" },
+      },
+    ]);
+  });
+
+  it("accepts a structurally-compatible Meter without depending on @opentelemetry/api", () => {
+    // Mirrors how a real @opentelemetry/api Meter would be passed, without
+    // importing the package — proves the interface is duck-typed.
+    const add = vi.fn();
+    const record = vi.fn();
+    const otelLikeMeter = {
+      createCounter: vi.fn().mockReturnValue({ add }),
+      createHistogram: vi.fn().mockReturnValue({ record }),
+    };
+
+    const metrics = new OtelWebhookMetrics(otelLikeMeter);
+    metrics.recordAttempt("https://x.example.com", 1, 50, "failure");
+
+    expect(add).toHaveBeenCalledWith(1, { url: "https://x.example.com", status: "failure" });
+    expect(record).toHaveBeenCalledWith(50, { url: "https://x.example.com", status: "failure" });
+  });
+});


### PR DESCRIPTION
## Summary
- Only `PrometheusWebhookMetrics` existed; no OTel reference adapter.
- Adds `OtelWebhookMetrics implements WebhookMetrics`, constructed with a `Meter`, exposing three instruments (the OTel-attribute equivalent of Prometheus's label-based families):
  - `orbital.webhook.attempts` (counter, attributes: `url`, `status`)
  - `orbital.webhook.duration` (histogram, unit ms, attributes: `url`, `status`)
  - `orbital.webhook.terminal_outcomes` (counter, attributes: `url`, `outcome`)
- `Meter`/`OtelCounter`/`OtelHistogram` are minimal **structural** types in `types.ts`, mirroring this package's existing `Tracer`/`Span` pattern — a real `@opentelemetry/api` `Meter` (or any compatible object) satisfies them, so pulse-webhooks doesn't need a hard dependency on `@opentelemetry/api`.

## Test plan
- [x] New `test/OtelWebhookMetrics.test.ts` — 4 tests: instruments created on construction, attempt recorded as counter+histogram with matching attributes, terminal outcome recorded, structurally-compatible (duck-typed) Meter accepted without importing `@opentelemetry/api`
- [x] `pnpm build` clean
- [x] Full pulse-webhooks suite: 197 passed (12 files)

Closes #399