### PR TITLE
feat(pulse-webhooks): PostgresRetryQueue adapter

### DIFF
--- a/packages/pulse-webhooks/migrations/001_retry_queue.sql
+++ b/packages/pulse-webhooks/migrations/001_retry_queue.sql
@@ -1,0 +1,23 @@
+-- Table backing PostgresRetryQueue. `locked_until` doubles as the
+-- multi-consumer dequeue lock and the crash-recovery visibility timeout:
+-- a row whose lock has expired is eligible for redequeue by the next
+-- consumer, mirroring RedisRetryQueue's in-flight visibility window.
+CREATE TABLE IF NOT EXISTS pulse_webhook_retry_queue (
+  id TEXT PRIMARY KEY,
+  event JSONB NOT NULL,
+  url TEXT NOT NULL,
+  attempt INTEGER NOT NULL,
+  next_retry_at TIMESTAMPTZ NOT NULL,
+  locked_until TIMESTAMPTZ,
+  last_error TEXT,
+  created_at TIMESTAMPTZ,
+  metadata JSONB
+);
+
+-- Dequeue and eviction both scan/order by next_retry_at.
+CREATE INDEX IF NOT EXISTS pulse_webhook_retry_queue_next_retry_at_idx
+  ON pulse_webhook_retry_queue (next_retry_at);
+
+-- Dequeue and size() both filter on lock state.
+CREATE INDEX IF NOT EXISTS pulse_webhook_retry_queue_locked_until_idx
+  ON pulse_webhook_retry_queue (locked_until);

--- a/packages/pulse-webhooks/src/PostgresRetryQueue.ts
+++ b/packages/pulse-webhooks/src/PostgresRetryQueue.ts
@@ -1,0 +1,186 @@
+import type { RetryQueue, RetryRecord } from "./RetryQueue.js";
+import type { PgLike } from "./PostgresDeadLetterStore.js";
+
+export type PostgresRetryQueueOptions = {
+  /** Table name. Defaults to `pulse_webhook_retry_queue` (see `migrations/001_retry_queue.sql`). */
+  tableName?: string;
+  now?: () => number;
+  /** How long a dequeued-but-unacked record stays locked before it's eligible for redequeue. Defaults to 30,000ms. */
+  visibilityTimeoutMs?: number;
+};
+
+const DEFAULT_TABLE_NAME = "pulse_webhook_retry_queue";
+const DEFAULT_VISIBILITY_TIMEOUT_MS = 30_000;
+
+type RetryQueueRow = {
+  id: string;
+  event: unknown | string;
+  url: string;
+  attempt: number;
+  next_retry_at: Date | string;
+  locked_until: Date | string | null;
+  last_error: string | null;
+  created_at: Date | string | null;
+  metadata: Record<string, unknown> | string | null;
+};
+
+/**
+ * Postgres-backed `RetryQueue`. Multi-consumer-safe dequeue is implemented
+ * as `UPDATE ... WHERE id = (SELECT ... FOR UPDATE SKIP LOCKED)`: concurrent
+ * consumers each lock and claim a different ready row in one atomic
+ * statement, so no record is ever handed to two consumers at once.
+ *
+ * Requires the table created by `migrations/001_retry_queue.sql`.
+ */
+export class PostgresRetryQueue implements RetryQueue {
+  private readonly tableSql: string;
+  private readonly now: () => number;
+  private readonly visibilityTimeoutMs: number;
+
+  constructor(
+    private readonly pg: PgLike,
+    options: PostgresRetryQueueOptions = {},
+  ) {
+    this.tableSql = quoteIdentifier(options.tableName ?? DEFAULT_TABLE_NAME);
+    this.now = options.now ?? Date.now;
+    this.visibilityTimeoutMs = Math.max(
+      1,
+      Math.floor(options.visibilityTimeoutMs ?? DEFAULT_VISIBILITY_TIMEOUT_MS),
+    );
+  }
+
+  async enqueue(record: RetryRecord): Promise<void> {
+    this.assertRecord(record);
+
+    await this.pg.query(
+      `INSERT INTO ${this.tableSql}
+         (id, event, url, attempt, next_retry_at, last_error, created_at, metadata)
+       VALUES ($1, $2::jsonb, $3, $4, $5, $6, $7, $8::jsonb)
+       ON CONFLICT (id) DO UPDATE SET
+         event = EXCLUDED.event,
+         url = EXCLUDED.url,
+         attempt = EXCLUDED.attempt,
+         next_retry_at = EXCLUDED.next_retry_at,
+         locked_until = NULL,
+         last_error = EXCLUDED.last_error,
+         metadata = EXCLUDED.metadata`,
+      [
+        record.id,
+        JSON.stringify(record.event),
+        record.url,
+        record.attempt,
+        toTimestamp(record.nextRetryAt),
+        record.lastError ?? null,
+        record.createdAt !== undefined ? toTimestamp(record.createdAt) : null,
+        record.metadata !== undefined ? JSON.stringify(record.metadata) : null,
+      ],
+    );
+  }
+
+  async dequeue(nowMs = this.now()): Promise<RetryRecord | null> {
+    const nowTs = toTimestamp(nowMs);
+    const lockedUntilTs = toTimestamp(nowMs + this.visibilityTimeoutMs);
+
+    const result = await this.pg.query<RetryQueueRow>(
+      `UPDATE ${this.tableSql}
+       SET locked_until = $2
+       WHERE id = (
+         SELECT id FROM ${this.tableSql}
+         WHERE next_retry_at <= $1
+           AND (locked_until IS NULL OR locked_until <= $1)
+         ORDER BY next_retry_at ASC
+         LIMIT 1
+         FOR UPDATE SKIP LOCKED
+       )
+       RETURNING id, event, url, attempt, next_retry_at, locked_until, last_error, created_at, metadata`,
+      [nowTs, lockedUntilTs],
+    );
+
+    const row = result.rows[0];
+    return row ? mapRow(row) : null;
+  }
+
+  async ack(recordId: string): Promise<void> {
+    await this.pg.query(`DELETE FROM ${this.tableSql} WHERE id = $1`, [recordId]);
+  }
+
+  async nack(recordId: string, requeueDelayMs: number): Promise<void> {
+    const delayMs = Number.isFinite(requeueDelayMs) ? Math.max(0, Math.floor(requeueDelayMs)) : 0;
+    const nextRetryAt = toTimestamp(this.now() + delayMs);
+
+    await this.pg.query(
+      `UPDATE ${this.tableSql}
+       SET next_retry_at = $2, locked_until = NULL
+       WHERE id = $1`,
+      [recordId, nextRetryAt],
+    );
+  }
+
+  async evictNewest(): Promise<RetryRecord | null> {
+    const result = await this.pg.query<RetryQueueRow>(
+      `DELETE FROM ${this.tableSql}
+       WHERE id = (
+         SELECT id FROM ${this.tableSql}
+         WHERE locked_until IS NULL
+         ORDER BY next_retry_at DESC
+         LIMIT 1
+         FOR UPDATE SKIP LOCKED
+       )
+       RETURNING id, event, url, attempt, next_retry_at, locked_until, last_error, created_at, metadata`,
+    );
+
+    const row = result.rows[0];
+    return row ? mapRow(row) : null;
+  }
+
+  async size(): Promise<number> {
+    const result = await this.pg.query<{ count: string }>(
+      `SELECT COUNT(*) AS count FROM ${this.tableSql} WHERE locked_until IS NULL OR locked_until <= $1`,
+      [toTimestamp(this.now())],
+    );
+    return Number(result.rows[0]?.count ?? 0);
+  }
+
+  private assertRecord(record: RetryRecord): void {
+    if (!record.id) {
+      throw new Error("RetryRecord.id is required");
+    }
+
+    if (!Number.isFinite(record.nextRetryAt)) {
+      throw new Error("RetryRecord.nextRetryAt must be a finite timestamp");
+    }
+  }
+}
+
+function quoteIdentifier(identifier: string): string {
+  if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(identifier)) {
+    throw new Error(`Invalid Postgres identifier: ${identifier}`);
+  }
+  return `"${identifier}"`;
+}
+
+function toTimestamp(ms: number): string {
+  return new Date(ms).toISOString();
+}
+
+function parseTimestamp(value: Date | string): number {
+  return value instanceof Date ? value.getTime() : new Date(value).getTime();
+}
+
+function mapRow(row: RetryQueueRow): RetryRecord {
+  const record: RetryRecord = {
+    id: row.id,
+    event: typeof row.event === "string" ? JSON.parse(row.event) : row.event,
+    url: row.url,
+    attempt: row.attempt,
+    nextRetryAt: parseTimestamp(row.next_retry_at),
+  };
+
+  if (row.last_error !== null) record.lastError = row.last_error;
+  if (row.created_at !== null) record.createdAt = parseTimestamp(row.created_at);
+  if (row.metadata !== null) {
+    record.metadata = typeof row.metadata === "string" ? JSON.parse(row.metadata) : row.metadata;
+  }
+
+  return record;
+}

--- a/packages/pulse-webhooks/src/index.ts
+++ b/packages/pulse-webhooks/src/index.ts
@@ -60,6 +60,7 @@ export { PostgresDeadLetterStore } from "./PostgresDeadLetterStore.js";
 export { RedisRetryQueue } from "./RedisRetryQueue.js";
 export { MemoryRetryQueue } from "./MemoryRetryQueue.js";
 export { SqsRetryQueue } from "./SqsRetryQueue.js";
+export { PostgresRetryQueue } from "./PostgresRetryQueue.js";
 export { verifyWebhookEdge, verifyWebhookEdgeRaw, verifyWebhookEdgeStream } from "./edge.js";
 export { dedupReceiver, MemoryDedupStore } from "./dedup.js";
 export type { DedupStore, DedupReceiverOptions } from "./dedup.js";
@@ -73,6 +74,7 @@ export type {
 } from "./PostgresDeadLetterStore.js";
 export type { RedisLike, RedisRetryQueueOptions } from "./RedisRetryQueue.js";
 export type { MemoryRetryQueueOptions } from "./MemoryRetryQueue.js";
+export type { PostgresRetryQueueOptions } from "./PostgresRetryQueue.js";
 export type {
   SqsLike,
   SqsRetryQueueOptions,

--- a/packages/pulse-webhooks/test/PostgresRetryQueue.test.ts
+++ b/packages/pulse-webhooks/test/PostgresRetryQueue.test.ts
@@ -1,0 +1,268 @@
+import { describe, expect, it } from "vitest";
+
+import type { NormalizedEvent } from "@orbital-stellar/pulse-core";
+import {
+  PostgresRetryQueue,
+  type PgLike,
+  type PgQueryResult,
+  type RetryRecord,
+} from "../src/index.js";
+
+/**
+ * In-memory simulation of the `pulse_webhook_retry_queue` table, dispatching
+ * on the distinguishing SQL fragments PostgresRetryQueue actually issues.
+ * Mirrors RedisRetryQueue.test.ts's MockRedis: it re-implements the intended
+ * row-selection semantics (including the SKIP LOCKED-equivalent "exclude
+ * locked, unexpired rows" filter) so behavior is verified against real
+ * query semantics, not just call recording. Row-level lock concurrency
+ * itself can only be verified against a real Postgres instance.
+ */
+type Row = {
+  id: string;
+  event: string;
+  url: string;
+  attempt: number;
+  next_retry_at: string;
+  locked_until: string | null;
+  last_error: string | null;
+  created_at: string | null;
+  metadata: string | null;
+};
+
+class MockPg implements PgLike {
+  private readonly rows = new Map<string, Row>();
+
+  async query<R = Record<string, unknown>>(
+    sql: string,
+    values: readonly unknown[] = [],
+  ): Promise<PgQueryResult<R>> {
+    if (sql.startsWith("INSERT INTO")) {
+      const [id, event, url, attempt, nextRetryAt, lastError, createdAt, metadata] = values as [
+        string,
+        string,
+        string,
+        number,
+        string,
+        string | null,
+        string | null,
+        string | null,
+      ];
+      this.rows.set(id, {
+        id,
+        event,
+        url,
+        attempt,
+        next_retry_at: nextRetryAt,
+        locked_until: null,
+        last_error: lastError,
+        created_at: createdAt,
+        metadata,
+      });
+      return { rows: [] } as unknown as PgQueryResult<R>;
+    }
+
+    if (sql.includes("SET locked_until = $2")) {
+      const [nowTs, lockedUntilTs] = values as [string, string];
+      const row = [...this.rows.values()]
+        .filter(
+          (r) => r.next_retry_at <= nowTs && (r.locked_until === null || r.locked_until <= nowTs),
+        )
+        .sort((a, b) => (a.next_retry_at < b.next_retry_at ? -1 : 1))[0];
+      if (!row) return { rows: [] } as unknown as PgQueryResult<R>;
+      row.locked_until = lockedUntilTs;
+      return { rows: [{ ...row }] } as unknown as PgQueryResult<R>;
+    }
+
+    if (sql.includes("SET next_retry_at = $2, locked_until = NULL")) {
+      const [id, nextRetryAt] = values as [string, string];
+      const row = this.rows.get(id);
+      if (row) {
+        row.next_retry_at = nextRetryAt;
+        row.locked_until = null;
+      }
+      return { rows: [] } as unknown as PgQueryResult<R>;
+    }
+
+    if (sql.startsWith("DELETE FROM") && sql.includes("ORDER BY next_retry_at DESC")) {
+      const row = [...this.rows.values()]
+        .filter((r) => r.locked_until === null)
+        .sort((a, b) => (a.next_retry_at > b.next_retry_at ? -1 : 1))[0];
+      if (!row) return { rows: [] } as unknown as PgQueryResult<R>;
+      this.rows.delete(row.id);
+      return { rows: [{ ...row }] } as unknown as PgQueryResult<R>;
+    }
+
+    if (sql.startsWith("DELETE FROM")) {
+      const [id] = values as [string];
+      const existed = this.rows.delete(id);
+      return { rows: [], rowCount: existed ? 1 : 0 } as unknown as PgQueryResult<R>;
+    }
+
+    if (sql.startsWith("SELECT COUNT(*)")) {
+      const [nowTs] = values as [string];
+      const count = [...this.rows.values()].filter(
+        (r) => r.locked_until === null || r.locked_until <= nowTs,
+      ).length;
+      return { rows: [{ count: String(count) }] } as unknown as PgQueryResult<R>;
+    }
+
+    throw new Error(`MockPg: unrecognized query: ${sql}`);
+  }
+}
+
+const event: NormalizedEvent = {
+  type: "payment.received",
+  to: "GDEST",
+  from: "GSRC",
+  amount: "10",
+  asset: "XLM",
+  timestamp: "2026-04-26T12:00:00.000Z",
+  raw: { id: "evt_1" },
+};
+
+function retryRecord(overrides: Partial<RetryRecord> = {}): RetryRecord {
+  return {
+    id: "retry-1",
+    event,
+    url: "https://example.com/webhooks/stellar",
+    attempt: 2,
+    nextRetryAt: 1_000,
+    lastError: "HTTP 503",
+    ...overrides,
+  };
+}
+
+describe("PostgresRetryQueue", () => {
+  it("round-trips due records ordered by nextRetryAt", async () => {
+    const queue = new PostgresRetryQueue(new MockPg());
+    const first = retryRecord({ id: "retry-1", nextRetryAt: 1_000 });
+    const second = retryRecord({ id: "retry-2", nextRetryAt: 500 });
+
+    await queue.enqueue(first);
+    await queue.enqueue(second);
+
+    expect(await queue.size()).toBe(2);
+    expect(await queue.dequeue(1_000)).toEqual(second);
+    expect(await queue.dequeue(1_000)).toEqual(first);
+    expect(await queue.dequeue(1_000)).toBeNull();
+  });
+
+  it("does not dequeue records before nextRetryAt", async () => {
+    const queue = new PostgresRetryQueue(new MockPg());
+    const record = retryRecord({ nextRetryAt: 2_000 });
+
+    await queue.enqueue(record);
+
+    expect(await queue.dequeue(1_999)).toBeNull();
+    expect(await queue.size()).toBe(1);
+    expect(await queue.dequeue(2_000)).toEqual(record);
+  });
+
+  it("does not redeliver a record that is already locked (dequeued) by another consumer", async () => {
+    const queue = new PostgresRetryQueue(new MockPg());
+    await queue.enqueue(retryRecord({ id: "only", nextRetryAt: 1_000 }));
+
+    const firstConsumer = await queue.dequeue(1_000);
+    const secondConsumer = await queue.dequeue(1_000);
+
+    expect(firstConsumer?.id).toBe("only");
+    expect(secondConsumer).toBeNull();
+  });
+
+  it("redelivers a locked record once its visibility timeout expires", async () => {
+    const queue = new PostgresRetryQueue(new MockPg(), { visibilityTimeoutMs: 5_000 });
+    await queue.enqueue(retryRecord({ id: "only", nextRetryAt: 1_000 }));
+
+    expect((await queue.dequeue(1_000))?.id).toBe("only");
+    expect(await queue.dequeue(1_000)).toBeNull();
+    // Lock expires at 1_000 + 5_000 = 6_000.
+    expect(await queue.dequeue(5_999)).toBeNull();
+    expect((await queue.dequeue(6_000))?.id).toBe("only");
+  });
+
+  it("removes the record on ack", async () => {
+    const queue = new PostgresRetryQueue(new MockPg());
+    await queue.enqueue(retryRecord({ id: "only", nextRetryAt: 1_000 }));
+    await queue.dequeue(1_000);
+
+    await queue.ack("only");
+
+    expect(await queue.size()).toBe(0);
+    expect(await queue.dequeue(999_999)).toBeNull();
+  });
+
+  it("reschedules and unlocks the record on nack", async () => {
+    // A fake `now` makes the rescheduled nextRetryAt deterministic.
+    const queue = new PostgresRetryQueue(new MockPg(), { now: () => 1_000 });
+    await queue.enqueue(retryRecord({ id: "only", nextRetryAt: 1_000 }));
+    await queue.dequeue(1_000);
+
+    await queue.nack("only", 500);
+
+    expect(await queue.dequeue(1_499)).toBeNull();
+    expect((await queue.dequeue(1_500))?.id).toBe("only");
+  });
+
+  it("evicts the newest scheduled retry, skipping locked (in-flight) records", async () => {
+    const queue = new PostgresRetryQueue(new MockPg(), { now: () => 9_000 });
+    const lockedNewest = retryRecord({ id: "locked-newest", nextRetryAt: 9_000 });
+    await queue.enqueue(lockedNewest);
+    await queue.dequeue(9_000); // locks "locked-newest" — it's the only ready record
+
+    const oldest = retryRecord({ id: "oldest", nextRetryAt: 1_000 });
+    const newest = retryRecord({ id: "newest", nextRetryAt: 5_000 });
+    await queue.enqueue(oldest);
+    await queue.enqueue(newest);
+
+    // "locked-newest" has the globally highest nextRetryAt but is locked,
+    // so eviction must fall through to the newest *unlocked* record.
+    const evicted = await queue.evictNewest();
+
+    expect(evicted?.id).toBe("newest");
+    expect(await queue.size()).toBe(1); // "oldest" remains ready; "locked-newest" stays locked, excluded
+  });
+
+  it("size() excludes a locked record until its visibility timeout expires", async () => {
+    let simulatedNow = 0;
+    const queue = new PostgresRetryQueue(new MockPg(), {
+      visibilityTimeoutMs: 1_000,
+      now: () => simulatedNow,
+    });
+    await queue.enqueue(retryRecord({ id: "a", nextRetryAt: 0 }));
+    await queue.dequeue(0); // locks "a" until 0 + 1_000 = 1_000
+
+    expect(await queue.size()).toBe(0);
+
+    simulatedNow = 1_000; // lock has now expired
+    expect(await queue.size()).toBe(1);
+  });
+
+  it("rejects a record without an id", async () => {
+    const queue = new PostgresRetryQueue(new MockPg());
+    await expect(queue.enqueue(retryRecord({ id: "" }))).rejects.toThrow(
+      "RetryRecord.id is required",
+    );
+  });
+
+  it("rejects a record with a non-finite nextRetryAt", async () => {
+    const queue = new PostgresRetryQueue(new MockPg());
+    await expect(queue.enqueue(retryRecord({ nextRetryAt: NaN }))).rejects.toThrow(
+      "RetryRecord.nextRetryAt must be a finite timestamp",
+    );
+  });
+
+  it("round-trips lastError, createdAt, and metadata", async () => {
+    const queue = new PostgresRetryQueue(new MockPg());
+    const record = retryRecord({
+      id: "full",
+      lastError: "HTTP 500",
+      createdAt: 123,
+      metadata: { region: "us-east" },
+    });
+
+    await queue.enqueue(record);
+    const dequeued = await queue.dequeue(1_000);
+
+    expect(dequeued).toEqual(record);
+  });
+});


### PR DESCRIPTION
## Summary
- No Postgres-backed durable retry queue existed — only Redis and SQS adapters.
- Adds `PostgresRetryQueue` against the existing `PgLike` interface (reused from `PostgresDeadLetterStore`).
- Multi-consumer-safe `dequeue()` is a single `UPDATE ... WHERE id = (SELECT ... FOR UPDATE SKIP LOCKED)` statement — concurrent consumers each atomically claim a different ready row, never the same one twice.
- `locked_until` doubles as both the dequeue lock and the crash-recovery visibility timeout (default 30s, matching `RedisRetryQueue`'s default): a locked row whose lock has expired is eligible for redequeue.
- `ack` deletes the row; `nack` clears the lock and reschedules `next_retry_at`; `evictNewest`/`size` both exclude currently-locked rows.
- Includes `migrations/001_retry_queue.sql`.

## Test plan
- [x] New `test/PostgresRetryQueue.test.ts` — 11 tests against an in-memory table simulator that re-implements the real row-selection semantics (ordering, due-time gating, lock exclusion, lock expiry, ack/nack, eviction skipping locked rows, validation, full field round-trip). Row-level lock *concurrency* itself can only be verified against a real Postgres instance — out of scope here, matching this package's existing mock-only Postgres test convention (`PostgresDeadLetterStore.test.ts`).
- [x] `pnpm build` clean
- [x] Full pulse-webhooks suite: 208 passed (13 files)

Closes #377