### PR TITLE
feat(pulse-core): multi-network engine (mainnet + testnet simultaneously)

### DIFF
--- a/packages/pulse-core/src/EventEngine.ts
+++ b/packages/pulse-core/src/EventEngine.ts
@@ -31,6 +31,7 @@ import type {
   LiquidityPoolReserve,
   LiquidityPoolWithdrawEvent,
   Network,
+  NetworkSourceConfig,
   NormalizedEvent,
   OfferEvent,
   OfferEventType,
@@ -219,6 +220,16 @@ export class EventEngine {
   private sorobanNetworkReady?: Promise<SorobanNetworkInfo | undefined>;
   /** Optional ABI registry used to enrich `contract.emitted` events with `decodedData`. */
   private abiRegistry?: AbiRegistryClientLike;
+  /**
+   * Present only when constructed with `CoreConfig.network` as an array.
+   * Each value is a fully independent single-network `EventEngine` (own
+   * Horizon stream, own Soroban subscriber, own reconnect/cursor state).
+   * Every public method branches to a sub-engine fan-out at its top when
+   * this is set, before touching any of the single-network-only fields
+   * above (`server`, `reconnectConfig`, `network`, `streamKey`), which are
+   * left with harmless placeholder values in this mode.
+   */
+  private networkSources?: Map<Network, EventEngine>;
 
   /**
    * Creates a new EventEngine instance.
@@ -226,6 +237,21 @@ export class EventEngine {
    */
   constructor(config: CoreConfig) {
     this.sorobanPageLimit = resolveSorobanPageLimit(config.soroban?.pageLimit);
+
+    if (Array.isArray(config.network)) {
+      this.networkSources = this.buildNetworkSources(config.network, config);
+
+      // Placeholders for fields with no meaning at the orchestrator level —
+      // never read, since every public method fans out to networkSources
+      // before reaching the single-network logic that reads them.
+      this.server = null as unknown as Horizon.Server;
+      this.reconnectConfig = { ...DEFAULT_RECONNECT };
+      this.log = config.logger ?? noop;
+      this.streamKey = "";
+      this.cursorFailureThreshold = config.cursorFailureThreshold ?? 5;
+      this.network = null as unknown as Network;
+      return;
+    }
 
     let horizonUrl: string;
     if (config.horizonUrl !== undefined) {
@@ -306,6 +332,67 @@ export class EventEngine {
         onEvent: async (event) => this.handleSorobanEvent(event),
       });
     }
+  }
+
+  /**
+   * Builds one independent single-network `EventEngine` per configured
+   * source. Every public method checks `networkSources` first and fans out
+   * to these sub-engines instead of using the single-network-only fields.
+   */
+  private buildNetworkSources(
+    sources: NetworkSourceConfig[],
+    config: CoreConfig,
+  ): Map<Network, EventEngine> {
+    if (sources.length === 0) {
+      throw new Error("CoreConfig.network: at least one network source is required.");
+    }
+
+    const seen = new Set<Network>();
+    for (const source of sources) {
+      if (seen.has(source.network)) {
+        throw new Error(
+          `CoreConfig.network: duplicate network source "${source.network}". Each network may appear at most once.`,
+        );
+      }
+      seen.add(source.network);
+    }
+
+    const networkSources = new Map<Network, EventEngine>();
+    for (const source of sources) {
+      const subEngine = new EventEngine({
+        network: source.network,
+        horizonUrl: source.horizonUrl,
+        soroban: source.soroban,
+        reconnect: config.reconnect,
+        logger: config.logger,
+        cursorStore: config.cursorStore,
+        cursorFailureThreshold: config.cursorFailureThreshold,
+        abiRegistry: config.abiRegistry,
+        streamKey: config.streamKey ? `${config.streamKey}:${source.network}` : undefined,
+      });
+      networkSources.set(source.network, subEngine);
+    }
+    return networkSources;
+  }
+
+  /**
+   * Forwards every event/notification from a sub-engine's watcher to the
+   * parent composite watcher, tagging it with the originating `network`.
+   * Filtering (if any) already happened inside the sub-engine, since
+   * `options`/`config` are passed through to it unchanged.
+   */
+  private forwardMultiNetworkEvents(
+    subWatcher: Watcher,
+    parentWatcher: Watcher,
+    network: Network,
+  ): void {
+    subWatcher.on("*", (event) => {
+      if (parentWatcher.stopped) return;
+      const type = (event as { type: string }).type;
+      const tagged = { ...(event as Record<string, unknown>), network };
+      parentWatcher.emit(type, tagged);
+      parentWatcher.emit("*", tagged);
+    });
   }
 
   /**
@@ -427,6 +514,25 @@ export class EventEngine {
     if (options?.name !== undefined) {
       this.subscriptionNames.set(address, options.name);
     }
+
+    if (this.networkSources) {
+      // Filtering (if any) happens inside each sub-engine, since `options`
+      // (including `options.filter`) is passed through unchanged.
+      const subWatchers: Watcher[] = [];
+      for (const [network, subEngine] of this.networkSources) {
+        const subWatcher = subEngine.subscribe(address, options);
+        subWatchers.push(subWatcher);
+        this.forwardMultiNetworkEvents(subWatcher, watcher, network);
+      }
+      watcher.addStopHandler(() => {
+        this.registry.delete(address);
+        this.subscriptionNames.delete(address);
+        for (const subWatcher of subWatchers) subWatcher.stop();
+      });
+      this.registry.set(address, watcher);
+      return watcher;
+    }
+
     if (options?.filter) {
       this.filters.set(address, options.filter);
     }
@@ -494,6 +600,22 @@ export class EventEngine {
       if (existing) return existing;
 
       const watcher = new Watcher(key);
+
+      if (this.networkSources) {
+        const subWatchers: Watcher[] = [];
+        for (const [network, subEngine] of this.networkSources) {
+          const subWatcher = subEngine.subscribeContract(config);
+          subWatchers.push(subWatcher);
+          this.forwardMultiNetworkEvents(subWatcher, watcher, network);
+        }
+        watcher.addStopHandler(() => {
+          this.contractConfigRegistry.delete(key);
+          for (const subWatcher of subWatchers) subWatcher.stop();
+        });
+        this.contractConfigRegistry.set(key, watcher);
+        return watcher;
+      }
+
       watcher.addStopHandler(() => this.contractConfigRegistry.delete(key));
       this.contractConfigRegistry.set(key, watcher);
       return watcher;
@@ -517,6 +639,23 @@ export class EventEngine {
     if (options?.name !== undefined) {
       this.subscriptionNames.set(id, options.name);
     }
+
+    if (this.networkSources) {
+      const subWatchers: Watcher[] = [];
+      for (const [network, subEngine] of this.networkSources) {
+        const subWatcher = subEngine.subscribeContract(id, options);
+        subWatchers.push(subWatcher);
+        this.forwardMultiNetworkEvents(subWatcher, watcher, network);
+      }
+      watcher.addStopHandler(() => {
+        this.contractRegistry.delete(id);
+        this.subscriptionNames.delete(id);
+        for (const subWatcher of subWatchers) subWatcher.stop();
+      });
+      this.contractRegistry.set(id, { watcher, filters });
+      return watcher;
+    }
+
     if (options?.filter) {
       this.filters.set(id, options.filter);
     }
@@ -645,6 +784,14 @@ export class EventEngine {
    * Pass `{ strict: true }` to throw EngineAlreadyStartedError instead of returning false.
    */
   start(options?: { strict?: boolean }): boolean {
+    if (this.networkSources) {
+      let allStarted = true;
+      for (const subEngine of this.networkSources.values()) {
+        allStarted = subEngine.start(options) && allStarted;
+      }
+      return allStarted;
+    }
+
     if (this.isRunning || this.reconnectTimer) {
       if (options?.strict) {
         throw new EngineAlreadyStartedError();
@@ -703,6 +850,17 @@ export class EventEngine {
   }
 
   async healthCheck(thresholdMs = 5 * 60 * 1000): Promise<HealthCheckResult> {
+    if (this.networkSources) {
+      const reasons: string[] = [];
+      for (const [network, subEngine] of this.networkSources) {
+        const subResult = await subEngine.healthCheck(thresholdMs);
+        for (const reason of subResult.reasons) {
+          reasons.push(`${network}: ${reason}`);
+        }
+      }
+      return { ok: reasons.length === 0, reasons };
+    }
+
     const reasons: string[] = [];
 
     if (!this.isRunning) {
@@ -752,6 +910,11 @@ export class EventEngine {
    * @param source - The source to pause: "horizon" or "soroban"
    */
   pauseSource(source: "horizon" | "soroban"): void {
+    if (this.networkSources) {
+      for (const subEngine of this.networkSources.values()) subEngine.pauseSource(source);
+      return;
+    }
+
     if (this.pausedSources.has(source)) {
       this.log.warn(`[pulse-core] pauseSource("${source}") called but source is already paused.`, {
         source,
@@ -768,6 +931,11 @@ export class EventEngine {
    * @param source - The source to resume: "horizon" or "soroban"
    */
   resumeSource(source: "horizon" | "soroban"): void {
+    if (this.networkSources) {
+      for (const subEngine of this.networkSources.values()) subEngine.resumeSource(source);
+      return;
+    }
+
     if (!this.pausedSources.has(source)) {
       this.log.warn(`[pulse-core] resumeSource("${source}") called but source is not paused.`, {
         source,
@@ -788,20 +956,29 @@ export class EventEngine {
    * resolves (#636).
    */
   async stop(): Promise<void> {
-    this.stopGeneration++;
-    this.clearReconnectTimer();
-    this.pendingReconnectSuccessAttempt = null;
-    this.reconnectAttempt = 0;
-    this.lastEventAt = null;
-    this.closeStream();
-    this.isRunning = false;
-    this.horizonCursor = undefined;
-    this.pausedSources.clear();
+    if (this.networkSources) {
+      for (const subEngine of this.networkSources.values()) {
+        await subEngine.stop();
+      }
+    } else {
+      this.stopGeneration++;
+      this.clearReconnectTimer();
+      this.pendingReconnectSuccessAttempt = null;
+      this.reconnectAttempt = 0;
+      this.lastEventAt = null;
+      this.closeStream();
+      this.isRunning = false;
+      this.horizonCursor = undefined;
+      this.pausedSources.clear();
 
-    if (this.sorobanSubscriber) {
-      await this.sorobanSubscriber.stop();
+      if (this.sorobanSubscriber) {
+        await this.sorobanSubscriber.stop();
+      }
     }
 
+    // Shared regardless of mode: `this.registry`/`this.contractRegistry` hold
+    // the parent-facing watchers either way (composite ones in multi-network
+    // mode), so notifying and stopping them here is correct in both cases.
     this.notifyWatchers("engine.stopped", {
       type: "engine.stopped",
       attempt: 0,
@@ -819,6 +996,70 @@ export class EventEngine {
    * for both Horizon and Soroban subscribers.
    */
   status(): EngineStatus {
+    if (this.networkSources) {
+      const networks: NonNullable<EngineStatus["networks"]> = {};
+      let running = false;
+      let reconnectAttempt = 0;
+      let horizonRunning = false;
+      let sorobanRunning = false;
+      let horizonReconnectAttempt = 0;
+      const lastEventAt: string[] = [];
+      const horizonLastEventAt: string[] = [];
+      const sorobanLastEventAt: string[] = [];
+      const pausedSources = new Set<"horizon" | "soroban">();
+
+      for (const [network, subEngine] of this.networkSources) {
+        const subStatus = subEngine.status();
+        networks[network] = subStatus.sources;
+
+        running = running || subStatus.running;
+        reconnectAttempt = Math.max(reconnectAttempt, subStatus.reconnectAttempt);
+        if (subStatus.lastEventAt) lastEventAt.push(subStatus.lastEventAt);
+        subStatus.pausedSources?.forEach((source) => pausedSources.add(source));
+
+        horizonRunning = horizonRunning || subStatus.sources.horizon.running;
+        sorobanRunning = sorobanRunning || subStatus.sources.soroban.running;
+        horizonReconnectAttempt = Math.max(
+          horizonReconnectAttempt,
+          subStatus.sources.horizon.reconnectAttempt,
+        );
+        if (subStatus.sources.horizon.lastEventAt) {
+          horizonLastEventAt.push(subStatus.sources.horizon.lastEventAt);
+        }
+        if (subStatus.sources.soroban.lastEventAt) {
+          sorobanLastEventAt.push(subStatus.sources.soroban.lastEventAt);
+        }
+      }
+
+      return {
+        running,
+        watcherCount: this.registry.size,
+        contractWatcherCount: this.contractRegistry.size,
+        lastEventAt: lastEventAt.length
+          ? (lastEventAt.sort()[lastEventAt.length - 1] ?? null)
+          : null,
+        reconnectAttempt,
+        pausedSources: pausedSources.size > 0 ? Array.from(pausedSources) : undefined,
+        sources: {
+          horizon: {
+            running: horizonRunning,
+            lastEventAt: horizonLastEventAt.length
+              ? (horizonLastEventAt.sort()[horizonLastEventAt.length - 1] ?? null)
+              : null,
+            reconnectAttempt: horizonReconnectAttempt,
+          },
+          soroban: {
+            running: sorobanRunning,
+            lastEventAt: sorobanLastEventAt.length
+              ? (sorobanLastEventAt.sort()[sorobanLastEventAt.length - 1] ?? null)
+              : null,
+            reconnectAttempt: 0,
+          },
+        },
+        networks,
+      };
+    }
+
     const horizon = {
       running: this.isRunning,
       lastEventAt: this.lastEventAt,

--- a/packages/pulse-core/src/index.ts
+++ b/packages/pulse-core/src/index.ts
@@ -106,6 +106,13 @@ export type EngineStatus = {
     horizon: SourceStatus;
     soroban: SourceStatus;
   };
+  /**
+   * Present only when the engine was constructed with an array of network
+   * sources (`CoreConfig.network` as `NetworkSourceConfig[]`); per-network
+   * breakdown of `sources`. `sources` above is an aggregate across all
+   * configured networks for consumers that don't need the per-network detail.
+   */
+  networks?: Partial<Record<Network, { horizon: SourceStatus; soroban: SourceStatus }>>;
 };
 
 /** Passphrase strings for each supported Stellar network. */
@@ -423,6 +430,8 @@ export type NormalizedEvent = (
 ) & {
   /** Lazy, cached `Date` derived from `event.timestamp`. Non-enumerable; does not appear in JSON.stringify output. */
   readonly timestampDate: Date;
+  /** Which network this event came from. Only set when `EventEngine` was constructed with multiple network sources (`CoreConfig.network` as an array). */
+  network?: Network;
 };
 
 /**
@@ -510,23 +519,44 @@ export type SorobanConfig = {
   pageLimit?: number;
 };
 
-export type CoreConfig = {
-  /** The Stellar network to connect to. */
+/**
+ * One network's connection details in a multi-network `CoreConfig.network` array.
+ * Each source becomes an independent, internally-managed single-network
+ * `EventEngine` — same reconnect/cursor/decode behavior as a standalone engine,
+ * just fanned out and merged under one parent engine.
+ */
+export type NetworkSourceConfig = {
+  /** The Stellar network this source connects to. */
   network: Network;
-  /** Optional override for the Horizon server URL. When set, `network` is still used for chain context but the connection is made to this URL. Useful for private nodes, regional mirrors, or futurenet. */
+  /** Optional override for this source's Horizon server URL. See `CoreConfig.horizonUrl`. */
   horizonUrl?: string;
-  /** Optional reconnection configuration. */
+  /** Optional Soroban RPC configuration for this source. Each network typically needs its own `rpcUrl`. */
+  soroban?: SorobanConfig;
+};
+
+export type CoreConfig = {
+  /**
+   * The Stellar network to connect to. Pass an array of `NetworkSourceConfig`
+   * to run Horizon (+ optionally Soroban RPC) against multiple networks from
+   * one engine — e.g. mirroring testnet and mainnet simultaneously. Events
+   * from a multi-network engine carry a `network` field identifying their
+   * source, and `status()` reports a per-network breakdown via `networks`.
+   */
+  network: Network | NetworkSourceConfig[];
+  /** Optional override for the Horizon server URL. When set, `network` is still used for chain context but the connection is made to this URL. Useful for private nodes, regional mirrors, or futurenet. Ignored when `network` is an array — set `horizonUrl` per source instead. */
+  horizonUrl?: string;
+  /** Optional reconnection configuration. Applied to every source when `network` is an array. */
   reconnect?: ReconnectConfig;
   logger?: Logger;
-  /** Optional cursor store for resumable streams. */
+  /** Optional cursor store for resumable streams. Shared across sources when `network` is an array; each source's cursor key is still scoped independently. */
   cursorStore?: CursorStoreLike;
-  /** Key to use for cursor storage. Defaults to "pulse-core-cursor". */
+  /** Key to use for cursor storage. Defaults to "pulse-core-cursor". When `network` is an array, each source's key is derived as `${streamKey}:${network}`. */
   streamKey?: string;
   /** Number of consecutive cursor store failures before marking it unhealthy. Defaults to 5. */
   cursorFailureThreshold?: number;
   /** Optional ABI registry client used to enrich `contract.emitted` events with `decodedData`. */
   abiRegistry?: AbiRegistryClientLike;
-  /** Soroban RPC configuration. */
+  /** Soroban RPC configuration. Ignored when `network` is an array — set `soroban` per source instead. */
   soroban?: SorobanConfig;
 };
 

--- a/packages/pulse-core/test/EventEngine.multiNetwork.test.ts
+++ b/packages/pulse-core/test/EventEngine.multiNetwork.test.ts
@@ -1,0 +1,276 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+type StreamHandlers = {
+  onmessage: (record: unknown) => void;
+  onerror: (error: unknown) => void;
+};
+
+type MockStreamInstance = {
+  url: string;
+  handlers: StreamHandlers;
+  close: ReturnType<typeof vi.fn>;
+};
+
+const streamInstances: MockStreamInstance[] = [];
+
+vi.mock("@stellar/stellar-sdk", () => {
+  class MockServer {
+    constructor(private readonly url: string) {}
+    operations() {
+      const url = this.url;
+      return {
+        cursor() {
+          return {
+            stream(handlers: StreamHandlers) {
+              const close = vi.fn();
+              streamInstances.push({ url, handlers, close });
+              return close;
+            },
+          };
+        },
+      };
+    }
+  }
+
+  return {
+    Horizon: {
+      Server: MockServer,
+    },
+  };
+});
+
+import { EventEngine } from "../src/EventEngine.js";
+import type { NormalizedEvent } from "../src/index.js";
+
+const TESTNET_URL = "https://horizon-testnet.stellar.org";
+const MAINNET_URL = "https://horizon.stellar.org";
+
+function paymentRecord(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    type: "payment",
+    to: "GDEST",
+    from: "GSRC",
+    amount: "10.0000000",
+    asset_type: "native",
+    created_at: "2026-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function findStream(url: string): MockStreamInstance {
+  const stream = streamInstances.find((s) => s.url === url);
+  if (!stream) throw new Error(`No mock stream opened for ${url}`);
+  return stream;
+}
+
+beforeEach(() => {
+  streamInstances.length = 0;
+});
+
+describe("EventEngine — multi-network", () => {
+  it("constructs one independent sub-engine per network source", () => {
+    const engine = new EventEngine({
+      network: [{ network: "testnet" }, { network: "mainnet" }],
+    });
+    engine.start();
+
+    expect(streamInstances).toHaveLength(2);
+    expect(streamInstances.map((s) => s.url).sort()).toEqual([MAINNET_URL, TESTNET_URL].sort());
+  });
+
+  it("rejects an empty network source array", () => {
+    expect(() => new EventEngine({ network: [] })).toThrow(
+      "at least one network source is required",
+    );
+  });
+
+  it("rejects duplicate network sources", () => {
+    expect(
+      () =>
+        new EventEngine({
+          network: [{ network: "testnet" }, { network: "testnet" }],
+        }),
+    ).toThrow('duplicate network source "testnet"');
+  });
+
+  it("delivers events from both networks to one subscribe() watcher, tagged with their network", async () => {
+    const engine = new EventEngine({
+      network: [{ network: "testnet" }, { network: "mainnet" }],
+    });
+    const watcher = engine.subscribe("GDEST");
+    const received: NormalizedEvent[] = [];
+    watcher.on("payment.received", (e) => received.push(e));
+
+    engine.start();
+
+    findStream(TESTNET_URL).handlers.onmessage(paymentRecord({ amount: "1.0000000" }));
+    findStream(MAINNET_URL).handlers.onmessage(paymentRecord({ amount: "2.0000000" }));
+
+    expect(received).toHaveLength(2);
+    const byNetwork = Object.fromEntries(received.map((e) => [e.network, e]));
+    expect(byNetwork.testnet).toMatchObject({ amount: "1.0000000", network: "testnet" });
+    expect(byNetwork.mainnet).toMatchObject({ amount: "2.0000000", network: "mainnet" });
+  });
+
+  it("also delivers tagged events on the wildcard listener", () => {
+    const engine = new EventEngine({
+      network: [{ network: "testnet" }, { network: "mainnet" }],
+    });
+    const watcher = engine.subscribe("GDEST");
+    const received: NormalizedEvent[] = [];
+    watcher.on("*", (e) => received.push(e as NormalizedEvent));
+
+    engine.start();
+    findStream(TESTNET_URL).handlers.onmessage(paymentRecord());
+
+    expect(received).toHaveLength(1);
+    expect(received[0]).toMatchObject({ network: "testnet" });
+  });
+
+  it("subscribe() is idempotent by address, same as single-network mode", () => {
+    const engine = new EventEngine({
+      network: [{ network: "testnet" }, { network: "mainnet" }],
+    });
+
+    const first = engine.subscribe("GDEST");
+    const second = engine.subscribe("GDEST");
+
+    expect(first).toBe(second);
+  });
+
+  it("passes the filter option through to each sub-engine", () => {
+    const engine = new EventEngine({
+      network: [{ network: "testnet" }, { network: "mainnet" }],
+    });
+    const watcher = engine.subscribe("GDEST", {
+      filter: (e) => (e as { amount?: string }).amount === "5.0000000",
+    });
+    const received: NormalizedEvent[] = [];
+    watcher.on("payment.received", (e) => received.push(e));
+
+    engine.start();
+    findStream(TESTNET_URL).handlers.onmessage(paymentRecord({ amount: "1.0000000" }));
+    findStream(TESTNET_URL).handlers.onmessage(paymentRecord({ amount: "5.0000000" }));
+
+    expect(received).toHaveLength(1);
+    expect(received[0]).toMatchObject({ amount: "5.0000000" });
+  });
+
+  it("stops sub-watchers and removes the parent watcher on unsubscribe", () => {
+    const engine = new EventEngine({
+      network: [{ network: "testnet" }, { network: "mainnet" }],
+    });
+    const watcher = engine.subscribe("GDEST");
+    const received: NormalizedEvent[] = [];
+    watcher.on("payment.received", (e) => received.push(e));
+
+    engine.start();
+    engine.unsubscribe("GDEST");
+
+    findStream(TESTNET_URL).handlers.onmessage(paymentRecord());
+
+    expect(received).toHaveLength(0);
+    expect(engine.status().watcherCount).toBe(0);
+  });
+
+  it("status() reports both an aggregate and a per-network breakdown", () => {
+    const engine = new EventEngine({
+      network: [{ network: "testnet" }, { network: "mainnet" }],
+    });
+    engine.subscribe("GDEST");
+    engine.start();
+
+    findStream(TESTNET_URL).handlers.onmessage(paymentRecord());
+
+    const status = engine.status();
+    expect(status.running).toBe(true);
+    expect(status.watcherCount).toBe(1);
+    expect(status.networks?.testnet?.horizon.running).toBe(true);
+    expect(status.networks?.testnet?.horizon.lastEventAt).not.toBeNull();
+    expect(status.networks?.mainnet?.horizon.running).toBe(true);
+    expect(status.networks?.mainnet?.horizon.lastEventAt).toBeNull();
+    // Aggregate reflects the union across networks.
+    expect(status.sources.horizon.running).toBe(true);
+    expect(status.sources.horizon.lastEventAt).not.toBeNull();
+  });
+
+  it("start() opens every network's stream and returns true", () => {
+    const engine = new EventEngine({
+      network: [{ network: "testnet" }, { network: "mainnet" }],
+    });
+
+    const started = engine.start();
+
+    expect(started).toBe(true);
+    expect(streamInstances).toHaveLength(2);
+  });
+
+  it("stop() closes every network's stream and stops parent watchers", async () => {
+    const engine = new EventEngine({
+      network: [{ network: "testnet" }, { network: "mainnet" }],
+    });
+    const watcher = engine.subscribe("GDEST");
+    const stopped = vi.fn();
+    watcher.on("engine.stopped", stopped);
+
+    engine.start();
+    await engine.stop();
+
+    expect(findStream(TESTNET_URL).close).toHaveBeenCalledTimes(1);
+    expect(findStream(MAINNET_URL).close).toHaveBeenCalledTimes(1);
+    expect(stopped).toHaveBeenCalledTimes(1);
+    expect(watcher.stopped).toBe(true);
+  });
+
+  it("healthCheck() prefixes each sub-engine's reasons with its network", async () => {
+    const engine = new EventEngine({
+      network: [{ network: "testnet" }, { network: "mainnet" }],
+    });
+    // Neither sub-engine has been started, so both report unhealthy.
+    const result = await engine.healthCheck();
+
+    expect(result.ok).toBe(false);
+    expect(result.reasons.some((r) => r.startsWith("testnet: horizon source"))).toBe(true);
+    expect(result.reasons.some((r) => r.startsWith("mainnet: horizon source"))).toBe(true);
+  });
+
+  it("pauseSource()/resumeSource() fan out to every sub-engine", () => {
+    const engine = new EventEngine({
+      network: [{ network: "testnet" }, { network: "mainnet" }],
+    });
+    engine.subscribe("GDEST");
+    engine.start();
+
+    engine.pauseSource("horizon");
+    const status = engine.status();
+    expect(status.pausedSources).toEqual(["horizon"]);
+    expect(status.networks?.testnet).toBeDefined();
+
+    engine.resumeSource("horizon");
+    expect(engine.status().pausedSources).toBeUndefined();
+  });
+
+  it("subscribeContract(id) fans out to every sub-engine and dedupes by id", () => {
+    const engine = new EventEngine({
+      network: [{ network: "testnet" }, { network: "mainnet" }],
+    });
+
+    const first = engine.subscribeContract("sub1");
+    const second = engine.subscribeContract("sub1");
+
+    expect(first).toBe(second);
+    expect(engine.status().contractWatcherCount).toBe(1);
+  });
+
+  it("subscribeContract(config) fans out to every sub-engine and dedupes by filter shape", () => {
+    const engine = new EventEngine({
+      network: [{ network: "testnet" }, { network: "mainnet" }],
+    });
+
+    const config = { filters: [{ contractIds: ["CAAA"] }] };
+    const first = engine.subscribeContract(config);
+    const second = engine.subscribeContract({ filters: [{ contractIds: ["CAAA"] }] });
+
+    expect(first).toBe(second);
+  });
+});


### PR DESCRIPTION
## Summary
`EventEngine` was scoped to a single `network` config value — cross-network monitoring (e.g. mirroring testnet → mainnet for a staging pipeline) needed a separate engine per network with no way to merge output under one set of watchers.

**Design** — chosen to minimize risk to the existing single-network path (2300+ line class, 560+ existing tests, published npm package):
- `CoreConfig.network` now also accepts `NetworkSourceConfig[]` (`{ network, horizonUrl?, soroban? }` per source).
- When it's an array, the engine builds **one fully independent single-network `EventEngine` per source internally** — same reconnect/cursor/decode/Soroban behavior as a standalone engine, because it *is* one, constructed via the exact same (unmodified) single-network code path. Zero changes to any single-network internals.
- Every public method (`subscribe`, `subscribeContract`, `start`, `stop`, `status`, `healthCheck`, `pauseSource`/`resumeSource`) checks a new `networkSources` field first and fans out to the sub-engines instead of touching the single-network-only fields, which hold harmless placeholder values in this mode.
- `subscribe()`/`subscribeContract()` create one parent `Watcher` per address/id and forward every event from each sub-engine's watcher into it, tagging the copy with a new optional `NormalizedEvent.network` field. Filtering (`options.filter`) is passed through unchanged to each sub-engine, so it runs there exactly as it does today.
- `status()` adds a `networks: Partial<Record<Network, { horizon, soroban }>>` breakdown alongside the existing aggregate `sources` shape (union/max-aggregated across networks) for backward compatibility.
- Existing `unsubscribe`/`unsubscribeAll`/`unsubscribeContract`/`unsubscribeAllContracts` needed **no changes** — they already operate generically on `this.registry`/`this.contractRegistry`/`this.contractConfigRegistry`, which hold the parent-facing watchers in both modes.

## Test plan
- [x] New `test/EventEngine.multiNetwork.test.ts` — 15 tests: sub-engine construction, empty/duplicate source validation, event delivery + network tagging on both the typed and wildcard channels, subscribe idempotency, filter passthrough, unsubscribe stops sub-watchers, `status()` aggregate + per-network breakdown, `start()`/`stop()` fan-out (including watcher `engine.stopped` notification), `healthCheck()` reason prefixing, `pauseSource`/`resumeSource` fan-out, `subscribeContract` dedup for both overloads
- [x] `pnpm typecheck` clean
- [x] Full pulse-core suite: **578 passed / 7 skipped — zero regressions** against the pre-existing 563 single-network tests
- [x] Dependent packages (pulse-webhooks, pulse-notify, abi-registry) rebuild clean against the widened `CoreConfig`/`NormalizedEvent`/`EngineStatus` types (both changes are additive: a union widening and an optional field)

Closes #667