### PR TITLE
fix(pulse-core): update type-exhaustiveness test for #850's notification

### DIFF
--- a/packages/pulse-core/test/types.exhaustive.test-d.ts
+++ b/packages/pulse-core/test/types.exhaustive.test-d.ts
@@ -1,6 +1,11 @@
 import type { NormalizedEvent } from "../src/index.js";
 import { Watcher } from "../src/Watcher.js";
-import type { PaymentEvent, WatcherNotification, DecodeFailedNotification } from "../src/index.js";
+import type {
+  PaymentEvent,
+  WatcherNotification,
+  DecodeFailedNotification,
+  UnrecognizedOperationTypeNotification,
+} from "../src/index.js";
 
 type Assert<T extends true> = T;
 type Equal<A, B> = [A] extends [B] ? ([B] extends [A] ? true : false) : false;
@@ -168,15 +173,35 @@ export function testWatcherOnInference() {
     const _error = e.error;
   });
 
+  watcher.on("engine.unrecognized_operation_type", (e) => {
+    type _IsUnrecognizedOperationTypeNotification = Assert<
+      Equal<typeof e, UnrecognizedOperationTypeNotification>
+    >;
+    const _operationType = e.operationType;
+    const _record = e.record;
+  });
+
   watcher.on("*", (_e) => {
     type _IsFullUnion = Assert<
-      Equal<typeof _e, NormalizedEvent | WatcherNotification | DecodeFailedNotification>
+      Equal<
+        typeof _e,
+        | NormalizedEvent
+        | WatcherNotification
+        | DecodeFailedNotification
+        | UnrecognizedOperationTypeNotification
+      >
     >;
   });
 
   watcher.on("unknown.event", (_e) => {
     type _IsFullUnion = Assert<
-      Equal<typeof _e, NormalizedEvent | WatcherNotification | DecodeFailedNotification>
+      Equal<
+        typeof _e,
+        | NormalizedEvent
+        | WatcherNotification
+        | DecodeFailedNotification
+        | UnrecognizedOperationTypeNotification
+      >
     >;
   });
 }


### PR DESCRIPTION
## Summary
`typecheck-packages` CI has been failing on main since the #850 merge (PR #861): `pnpm test:types` (`tsc -p tsconfig.typetest.json`) checks `test/types.exhaustive.test-d.ts`, a type-only exhaustiveness test for the `Watcher` event union. I verified locally with `vitest run`/`tsc --noEmit -p tsconfig.json` there, which don't run this separate check — so adding `UnrecognizedOperationTypeNotification` to the `"*"`/`unknown.event` `WatcherEvent` union went unreflected in this file's `Equal<>` assertions, and every merge since has carried the same failing CI forward.

## Fix
- Added `UnrecognizedOperationTypeNotification` to both `Equal<>` exhaustiveness checks (`"*"` and `"unknown.event"` handlers).
- Added a dedicated positive-case block for `watcher.on("engine.unrecognized_operation_type", ...)`, matching this file's existing per-notification-type pattern (one block per type, e.g. `event.decode_failed`).

## Test plan
- [x] `pnpm test` (== `pnpm test:types && vitest run`, the actual CI command) — clean: `test:types` passes, 578 passed / 7 skipped
- [x] Confirmed via `gh run view` that the only failing CI jobs on the last several merges were both `typecheck-packages` matrix legs, both failing on this exact file/reason