### PR TITLE
chore: frozen-scope labels, Wave Program eligibility note, template guard

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -6,6 +6,8 @@ labels: 'type:feature,needs-design'
 assignees: ''
 ---
 
+Before filing: check [`ROADMAP.md`](../../ROADMAP.md) — feature requests inside current phases are welcome; requests for items in the [Frozen section](../../ROADMAP.md#frozen--out-of-scope-until-the-core-thesis-is-proven) will be closed with a pointer to the roadmap.
+
 **Is this on the roadmap?**
 Check [`ROADMAP.md`](../../ROADMAP.md) first. If it is, link the relevant section and add context about your specific use case.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -146,6 +146,8 @@ Orbital participates in the [Drips Stellar Wave Program](https://drips.network).
 | `complexity:medium` | 150 |
 | `complexity:high` | 200 |
 
+**Frozen-scope eligibility.** Issues targeting scope frozen in [ROADMAP.md's Frozen section](./ROADMAP.md#frozen--out-of-scope-until-the-core-thesis-is-proven) — `@orbital-stellar/payments`, `@orbital-stellar/auth`, identity, `x402`, `agent-sdk`, the intent compiler, shadow-fork, reactor contracts, `@orbital-stellar/analytics`, and "10+ SEPs" meta-work — are not eligible for Wave points. In-flight frozen-scope work as of the 2026-07-16 roadmap refocus is honored in full per the `grace-window` comment on the affected issue or PR; new work against frozen scope will not be accepted. Going forward, the highest-point areas are the roadmap's Phase 2 items (SEP draft, `orbital codegen`, semantic layer, hosted registry) and Phase 3 (`@orbital-stellar/anchor-sdk`).
+
 **To claim an issue:**
 1. Comment on the issue to signal intent.
 2. A maintainer will assign it to you.


### PR DESCRIPTION
## What

- New \`frozen-scope\` (gray) and \`grace-window\` (yellow) GitHub labels.
- \`CONTRIBUTING.md\`: adds a paragraph to the Stellar Wave Program section stating that issues targeting scope frozen in [ROADMAP.md's Frozen section](https://github.com/determined-001/orbital_stellar/blob/main/ROADMAP.md#frozen--out-of-scope-until-the-core-thesis-is-proven) are not eligible for Wave points, that in-flight frozen-scope work as of the 2026-07-16 refocus is honored in full via the grace-window comments on those issues/PRs, and that Phase 2 (SEP draft, \`orbital codegen\`, semantic layer, hosted registry) and Phase 3 (\`anchor-sdk\`) are the highest-point areas going forward.
- \`.github/ISSUE_TEMPLATE/feature_request.md\`: adds a line near the top pointing contributors at \`ROADMAP.md\` before filing, and noting that Frozen-section requests will be closed with a pointer to the roadmap.

## Why

Follow-up tooling for the roadmap refocus merged in #879. This closes the gap between "the roadmap says X is frozen" and "the issue tracker and Wave Program actually enforce that" — without this, contributors have no signal before opening a frozen-scope issue or PR, and no shared vocabulary for the sweep that labels/closes existing ones.

## Test plan

- [x] Labels created and visible in the repo's label list
- [x] \`CONTRIBUTING.md\` and \`feature_request.md\` render correctly (checked with \`prettier --check\`)