### PR TITLE
docs: align README, policy, proposal, and progress docs with refocused roadmap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,9 @@ Per-package changelogs live in each package directory.
   are frozen and moved to an explicit Frozen section in `ROADMAP.md` with
   per-item rationale and an unfreeze procedure. No shipped code is removed -
   planned scope only.
+- Docs aligned with the refocused roadmap: README reframed around the
+  decoding standard; open-source-policy and proposal forward-references
+  updated; frozen-scope references removed from forward-looking docs.
 
 ### Fixed
 

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,44 +1,17 @@
 # Orbital: Progress & Status Report
 
-**Last Updated:** 2026-07-06
+**Last Updated:** 2026-07-16
 **Project Status:** Core SDK family - Shipped ✅
 
 ---
 
-## Executive Summary
+## Status
 
-Orbital is **Stellar's open-source real-time event SDK family** - four MIT-licensed packages on npm that give any Stellar developer typed event subscriptions (Horizon and Soroban), signed webhook delivery with durable retry, typed ABI decoding, and React hooks, without re-implementing the plumbing.
+Orbital is **the typed event layer for Stellar** - four MIT-licensed packages on npm that give any Stellar developer typed event subscriptions (Horizon and Soroban), signed webhook delivery with durable retry, typed ABI decoding, and React hooks, without re-implementing the plumbing.
 
-**Current Status:** The full classic operation taxonomy, Soroban contract event subscription, cursor persistence, durable webhook retry queues, the ABI registry client, and edge-runtime webhook verification are all shipped and tested. Next up is the Phase 2 SDK family (`@orbital-stellar/hooks`, `@orbital-stellar/payments`, `@orbital-stellar/auth`) - see [`ROADMAP.md`](ROADMAP.md).
+For phase-by-phase status and release gates, see [`ROADMAP.md`](ROADMAP.md)'s [at-a-glance table](ROADMAP.md#at-a-glance). Short version: Phase 0 (Foundation) shipped 2026-05-29; Phase 1 (Production SDK) is in progress - `STABILITY.md` has merged, starter boilerplates and the `v1.0.0` tag are the only items left; Phase 2 (The Decoding Standard) and Phase 3 (Anchor Events) are next. What's explicitly out of scope while those phases are open - and why - lives in ROADMAP.md's [Frozen section](ROADMAP.md#frozen--out-of-scope-until-the-core-thesis-is-proven).
 
 **OSS posture:** SDKs are MIT and free indefinitely. Production hosting is the separately-built **Orbital Cloud** managed runtime, in development. Until Cloud ships, the SDKs run great in any Node.js or edge backend you operate.
-
----
-
-## What Has Been Completed
-
-### Core SDK family ✅
-
-All four packages are feature-complete and ready for use against testnet and mainnet today:
-
-| Component | Status | Details |
-|---|---|---|
-| Classic operation event streaming via Horizon SSE | ✅ Done | Horizon subscription, automatic reconnection with AWS Full Jitter backoff |
-| Full classic operation taxonomy | ✅ Done | Payments (received/sent/self), account create/merge/bump-sequence, trustlines (change/allow/set_flags), DEX offers (created/updated/deleted), claimable balances (created/claimed), liquidity pools (deposit/withdraw), `manage_data` (set/cleared) |
-| Soroban contract event subscription | ✅ Done | `engine.subscribeContract({ contractId, topics })` via Stellar RPC, `contract.invoked` / `contract.emitted` normalized events |
-| Cursor persistence | ✅ Done | Pluggable `CursorStore` adapters - memory, file, Postgres, Redis, S3 - for resumable streams across restarts |
-| ABI registry client | ✅ Done | `AbiRegistryClient` / `LocalAbiRegistryClient`, typed `decodedData` enrichment on `contract.emitted`, schema validation |
-| HMAC-signed webhook delivery | ✅ Done | Retry, exponential backoff, concurrent-retry caps, configurable timeout |
-| Durable webhook retry queues | ✅ Done | Pluggable `RetryQueue` adapters - memory, Redis, SQS - survive process restarts |
-| Edge-runtime webhook verification | ✅ Done | `verifyWebhookEdge` for Cloudflare Workers and Vercel Edge (Web Crypto API) |
-| React hooks (`useStellarEvent`, `useContractEvent`, `useStellarPayment`, `useStellarActivity`, `useStellarAddresses`, `useStellarHistory`) | ✅ Done | Type-narrowing generic on `useStellarEvent`, multi-event subscription, stable config rules |
-| Custom Horizon URL override | ✅ Done | `CoreConfig.horizonUrl` for self-hosted nodes / regional mirrors / futurenet |
-| Engine lifecycle notifications | ✅ Done | `engine.reconnecting`, `engine.reconnected`, `engine.rate_limited`, `engine.stopped` |
-| Public marketing + documentation site (`apps/web`) | ✅ Done | Next.js 16, Tailwind CSS 4. Hosts the docs, the sandboxed `/api/events/[address]` SSE demo, and the `/api/webhook-sample` signing demo. |
-| Testnet + mainnet support | ✅ Done | Network selector via `network: "mainnet" \| "testnet"` |
-| CI/CD pipeline | ✅ Done | GitHub Actions on Node 20 and 22, CodeQL, Dependabot |
-| npm publish | ✅ Done | All four packages live under the `@orbital-stellar` scope |
-| MIT License & open-source setup | ✅ Done | `LICENSE`, `CONTRIBUTING.md`, `SECURITY.md` |
 
 ---
 
@@ -171,27 +144,9 @@ Edge-runtime verify       useStellarPayment / useStellarActivity    for contract
 
 ---
 
-## Scope Boundaries
+## Scope boundaries and what's next
 
-Not yet in this repository, tracked for later phases:
-
-1. **Production hosting** - multi-region orchestration, persistent registries, leader election. Belongs in **Orbital Cloud** (separate closed product), not in this repository.
-2. **`@orbital-stellar/hooks`, `@orbital-stellar/payments`, `@orbital-stellar/auth`** - Phase 2 SDK family. See [`ROADMAP.md`](./ROADMAP.md).
-3. **`@orbital-stellar/x402`, `@orbital-stellar/agent-sdk`** - Phase 3. See [`ROADMAP.md`](./ROADMAP.md).
-4. **`v1.0` stability pledge** - formal semver contract, tracked in [`ROADMAP.md`](./ROADMAP.md).
-
----
-
-## Next Steps: Phase 2
-
-| Milestone | Target |
-|---|---|
-| **SDKs** | `@orbital-stellar/hooks`, `@orbital-stellar/payments`, `@orbital-stellar/auth` |
-| **Standards** | First SEP submission |
-| **Distribution** | Starter boilerplates (`next`, `express`, `anchor`) |
-| **Stability** | `v1.0` stability pledge - formal semver contract |
-
-See [`ROADMAP.md`](./ROADMAP.md) for the full multi-year vision and [`docs/proposal.md`](./docs/proposal.md) for the current SCF funding proposal.
+Production hosting - multi-region orchestration, persistent registries, leader election - belongs in **Orbital Cloud** (separate closed product), not in this repository. Everything else about what's shipped, in progress, planned, or explicitly frozen is tracked in [`ROADMAP.md`](./ROADMAP.md), including the [Frozen section](./ROADMAP.md#frozen--out-of-scope-until-the-core-thesis-is-proven) for items intentionally out of scope. See [`docs/proposal.md`](./docs/proposal.md) for the current SCF funding proposal.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@
 
 > **Status**: `v0.1.0` on npm &nbsp;·&nbsp; **Networks**: testnet + mainnet &nbsp;·&nbsp; **License**: MIT
 
-**Stellar's biggest developer-experience gap isn't a missing API - it's that Horizon's firehose still requires every team to build their own event delivery.**
+**Stellar's biggest developer-experience gap is that Soroban events arrive as raw, untyped payloads with no shared vocabulary - every team invents its own decoding, and no two teams agree on what a `swap` or a `liquidation` even is.**
 
-Orbital ships that delivery layer once, openly: a typed event engine that normalizes Horizon output into application-shaped events, HMAC-signed webhook delivery with retry and edge-runtime verification, a shared ABI registry for Soroban schemas, and React hooks for live data in the browser. Four MIT-licensed packages, designed to be composed.
+Orbital ships the typed event layer once, openly: an open ABI/event-schema registry that makes decoding canonical, a typed event engine that normalizes Horizon and Soroban output into application-shaped events, codegen that puts those types into your codebase, plus composable webhook delivery and React hooks. Four MIT-licensed packages, designed to be composed.
 
 ---
 
@@ -35,12 +35,13 @@ Orbital ships that delivery layer once, openly: a typed event engine that normal
 
 Stellar's official APIs give you the raw firehose - and not much else:
 
-- **Horizon SSE** drops on idle, requires backoff, surfaces raw operations rather than application-friendly events - and is [deprecated in favor of Stellar RPC](https://developers.stellar.org/docs/data/apis/migrate-from-horizon-to-rpc).
-- **Stellar RPC** keeps only ~7 days of history and has no native subscription model - even with Protocol 23's unified event stream, delivery is still yours to build.
+- **Soroban contract events** decode to raw topic/value XDR with no shared schema - every team writes its own one-off decoder, and there's no canonical place to look up what a given contract's events mean.
+- **Horizon SSE** drops on idle, requires backoff, and surfaces raw operations rather than application-friendly events.
+- **Stellar RPC** keeps only ~7 days of Soroban history and has no native subscription model.
 - **Webhooks** aren't part of the platform - every project rebuilds HMAC signing, retry, SSRF guards, and edge-runtime verification from scratch.
 - **React integration** doesn't exist - every dashboard rebuilds SSE plumbing and lifecycle management.
 
-Every serious Stellar app - wallet, dashboard, anchor integration, agent - re-solves the same problem. Orbital ships those primitives once so you can `pnpm add` them instead of rebuilding them.
+Every serious Stellar app - wallet, dashboard, anchor integration, analytics tool - re-solves the same problem. Orbital ships those primitives once, and the registry that makes decoding canonical, so you can `pnpm add` them instead of rebuilding them.
 
 The longer-form thesis, the multi-year vision, and the SCF grant case live in [`PROGRESS.md`](PROGRESS.md), [`ROADMAP.md`](ROADMAP.md), and `docs/proposal.md` (in progress).
 
@@ -183,7 +184,8 @@ The reference composition - a Next.js route handler that subscribes to an addres
 | Document | What it covers |
 |---|---|
 | [`PROGRESS.md`](PROGRESS.md) | Phase 0 completion status, project structure, architecture overview |
-| [`ROADMAP.md`](ROADMAP.md) | Multi-year plan (Phase 0 → Phase 3): the decoding standard, SEP draft, anchor events |
+| [`ROADMAP.md`](ROADMAP.md) | The decoding-standard thesis, Phase 0 → Phase 3 plan, and the Frozen section for out-of-scope items |
+| [`STABILITY.md`](STABILITY.md) | The `v1.0` semver pledge - covered API surface, wire/data contracts, deprecation policy |
 | [`CHANGELOG.md`](CHANGELOG.md) | Release notes (top-level; per-package changelogs roll up) |
 | [`CONTRIBUTING.md`](CONTRIBUTING.md) | Setup, coding standards, PR process, Drips Wave Program |
 | [`SECURITY.md`](SECURITY.md) | Vulnerability disclosure policy |
@@ -207,11 +209,11 @@ Two paths:
 ## Roadmap
 
 - **Shipped** - Full classic operation taxonomy, edge-runtime webhook verification, React hooks, Soroban event subscription, ABI registry client, cursor persistence, durable retry queues, npm publish ✅
-- **v1.1.0** - Unified event ingestion via Stellar RPC (CAP-67 / Protocol 23), Horizon SSE demoted to fallback transport
-- **2026 H2 (Phase 2)** - The decoding standard: SEP draft building on SEP-48, `orbital codegen`, semantic taxonomy + entity labels as open data, hosted registry
-- **2027 H1 (Phase 3)** - `@orbital-stellar/anchor-sdk`, SEP-24/31 lifecycle events
+- **In progress (Phase 1)** - `STABILITY.md` v1.0 semver pledge merged; starter boilerplates and the `v1.0.0` tag outstanding
+- **2026 H2 (Phase 2 - The Decoding Standard)** - SEP draft for a standardized Soroban event schema, `orbital codegen`, the semantic layer (event taxonomy + entity labels), hosted registry
+- **2027 H1 (Phase 3 - Anchor Events)** - `@orbital-stellar/anchor-sdk`, SEP-24/31 lifecycle events normalized into the standard taxonomy
 
-Full multi-year plan in [`ROADMAP.md`](ROADMAP.md).
+Full multi-year plan, plus what's explicitly frozen out of scope, in [`ROADMAP.md`](ROADMAP.md).
 
 ---
 

--- a/docs/open-source-policy.md
+++ b/docs/open-source-policy.md
@@ -56,8 +56,9 @@ Everything below is in `packages/` or `apps/` today, or will be added to one of 
 ### Remaining Phase 1 work
 
 - Starter boilerplates (`orbital-next-starter`, `orbital-express-starter`, `orbital-anchor-starter`)
-- `v1.0` stability pledge (`STABILITY.md` - semver contract, deprecation window)
-- ABI Registry schema published as a draft SEP; hosted registry service (see [ABI Registry](#abi-registry) below)
+- `v1.0.0` git tag with full release notes
+
+`v1.0` stability pledge (`STABILITY.md`) has shipped - see [`STABILITY.md`](../STABILITY.md). The ABI Registry schema SEP draft and hosted registry service moved to Phase 2 (below) as of the roadmap refocus - see [ROADMAP.md](../ROADMAP.md).
 
 ### ABI Registry
 
@@ -68,23 +69,31 @@ Everything below is in `packages/` or `apps/` today, or will be added to one of 
 
 The hosted verification / publishing service remains a separate Cloud product. The schema, client, and decoder helpers in this repository stay open.
 
-### Phase 2 (2027)
+### Phase 2 - The Decoding Standard (2026 H2)
 
-- `@orbital-stellar/hooks` - `useAccount`, `useBalance`, `useTransaction`, `useOrderBook`
-- `@orbital-stellar/payments` - send, receive, path-payment, payroll-batch primitives
-- `@orbital-stellar/auth` - WebAuthn / passkey embedded wallet SDK
-- `@orbital-stellar/analytics` - client library + event-volume reference dashboards
-- First SEP submission - formalized event normalization format
-- Reference reactor contracts (Soroban Rust, open for anyone to fork)
+- SEP draft - standardized Soroban event schema + registry verification spec, submitted to `stellar/stellar-protocol`
+- `orbital codegen` - CLI + `orbital.config.ts` manifest that emits TypeScript types, typed event guards, and `useContractEvent<T>` hooks from the registry schema
+- Semantic layer - event taxonomy (`swap.executed`, `loan.liquidated`, …) and entity labels, published as **open data**; the hosted read API that serves them is the operated product (see [Hosted ABI Registry](#what-orbital-monetizes-never-open-sourced) below)
 
-### Phase 3 (2028+)
+### Phase 3 - Anchor Events (2027 H1)
 
-- `@orbital-stellar/x402` - Express / Next.js middleware for payment-gated API access
-- `@orbital-stellar/agent-sdk` - payment client for autonomous AI agents
-- `@orbital-stellar/anchor-sdk` - SEP-24 / SEP-31 lifecycle client
-- Intent compiler - at maturity, the DSL + graph runtime become OSS
-- Shadow-fork simulator OSS core
-- ZK-proof generation library (Noir / RiscZero circuits) - runnable locally
+- `@orbital-stellar/anchor-sdk` - typed client for SEP-24 / SEP-31 lifecycle events
+
+### Frozen - not scheduled while Phases 1–3 are open
+
+These were previously listed as future MIT packages. They remain MIT-eligible in principle (the rule of thumb below still applies if they are ever unfrozen), but they are not on the active roadmap - see [ROADMAP.md's Frozen section](../ROADMAP.md#frozen--out-of-scope-until-the-core-thesis-is-proven) for the rationale and the unfreeze procedure.
+
+- `@orbital-stellar/payments` - send, receive, path-payment, payroll-batch primitives *(frozen - see ROADMAP.md)*
+- `@orbital-stellar/auth` - WebAuthn / passkey embedded wallet SDK *(frozen - see ROADMAP.md)*
+- `@orbital-stellar/analytics` - client library + event-volume reference dashboards *(frozen - see ROADMAP.md)*
+- `@orbital-stellar/x402` - Express / Next.js middleware for payment-gated API access *(frozen - see ROADMAP.md)*
+- `@orbital-stellar/agent-sdk` - payment client for autonomous AI agents *(frozen - see ROADMAP.md)*
+- Identity layer - passkey-based embedded wallets, federated Stellar addresses *(frozen - see ROADMAP.md)*
+- Intent compiler - DSL + graph runtime *(frozen - see ROADMAP.md)*
+- Shadow-fork simulator *(frozen - see ROADMAP.md)*
+- Reference reactor contracts (Soroban Rust) *(frozen - see ROADMAP.md)*
+
+Two items from the prior list are not addressed by the current roadmap at all (neither active nor frozen) - `@orbital-stellar/hooks` (`useAccount`, `useBalance`, `useTransaction`, `useOrderBook`) and the ZK-proof generation library (Noir / RiscZero circuits). They are paused pending a future roadmap decision.
 
 **Rule of thumb for what lands here:** if a competent engineer would expect to `pnpm add` it and use it in a private project, it's MIT.
 
@@ -153,11 +162,14 @@ A short decision aid before you open a PR.
 - Hosted dashboards beyond the marketing-demo sandbox
 - Anything that would require Orbital to operate infrastructure on the contributor's behalf
 
-### Uncertain - please discuss in an issue first
+### Frozen - not accepted while Phases 1–3 are open
 
-- Intent DSL / graph compiler interfaces (Phase 3; the **runtime** is OSS at maturity, the **hosted compilation service** is not)
-- Shadow-fork simulator extensions (Phase 3; OSS core, hosted SaaS version closed)
-- Reactor contract reference library (Phase 2; reference contracts are OSS, the certification / accreditation service is closed)
+- Intent DSL / graph compiler interfaces
+- Shadow-fork simulator extensions
+- Reactor contract reference library
+- `@orbital-stellar/payments`, `@orbital-stellar/auth`, identity layer, `@orbital-stellar/x402`, `@orbital-stellar/agent-sdk`, `@orbital-stellar/analytics`
+
+These are frozen per [ROADMAP.md](../ROADMAP.md#frozen--out-of-scope-until-the-core-thesis-is-proven), not merely deprioritized - PRs against them will be closed with a pointer to that section rather than reviewed.
 
 If you are not sure where a PR falls, open an issue with the `policy-question` label before investing time. We will tell you in 48 hours.
 
@@ -180,9 +192,9 @@ These are honest uncertainties as of `v0.1.0`. They will be resolved in writing 
 
 | Question | Status |
 |---|---|
-| Will the Soroban ABI Registry **data** (the published contract schemas) be a public good or a paid dataset? | The **client** and **schema** are MIT. The **hosted service** is currently planned as a free public good, with a paid tier for high-volume integrators. Final structure TBD by Phase 1 close. |
-| Will the intent compiler ship as runnable-locally OSS at maturity (Phase 3)? | Current intent is yes - see [`ROADMAP.md`](../ROADMAP.md) Phase 3. Subject to scope decomposition closer to Phase 2 close. |
-| Will the reactor-contract certification service be Orbital-operated or community-governed? | TBD. The contracts themselves are MIT; the certification service may be operated commercially or via an Orbital Foundation. |
+| Will the Soroban ABI Registry **data** (schemas, taxonomy, labels) be a public good or a paid dataset? | The **client**, **schema**, and **taxonomy/label data** are committed as open data under Phase 2 (Wave 2.3). The **hosted read API** is currently planned as a free-tier public good, with a paid tier for high-volume integrators. Final structure TBD by Phase 2 close. |
+| Will the intent compiler ship as runnable-locally OSS at maturity? | Frozen - not scheduled. See [ROADMAP.md's Frozen section](../ROADMAP.md#frozen--out-of-scope-until-the-core-thesis-is-proven). Revisit only if unfrozen per that section's procedure. |
+| Will the reactor-contract certification service be Orbital-operated or community-governed? | Frozen - not scheduled. See [ROADMAP.md's Frozen section](../ROADMAP.md#frozen--out-of-scope-until-the-core-thesis-is-proven). |
 
 When these resolve, the row will be moved to §2 or §3 as appropriate.
 

--- a/docs/proposal.md
+++ b/docs/proposal.md
@@ -60,7 +60,7 @@ The cost: every Stellar team - anchors, payment apps, DEX frontends, wallet team
 
 ## Solution
 
-Orbital ships the primitives once, openly, with a multi-year commitment to keep the SDK surface stable and grow it in lockstep with the network (Soroban events, x402, future SEPs).
+Orbital ships the primitives once, openly, with a multi-year commitment to keep the SDK surface stable and grow it in lockstep with the network (Soroban events, the decoding standard, future SEPs).
 
 ### Architecture
 
@@ -194,7 +194,7 @@ The SDKs remain MIT and free indefinitely. Maintenance funding comes from:
 
 1. **Orbital Cloud** - a separate closed-source managed runtime built on these SDKs, billed in USDC-on-Stellar (dogfooding the SDKs). Out of scope for this grant; mentioned only to explain why the OSS is sustainable without recurring grant ask.
 2. **Drips network donations** - Orbital is registered for Stellar Wave Program issue rewards, with `Stellar Wave`–tagged issues pricing in 100/150/200-point complexity tiers.
-3. **Future SCF Adopt/Audit grants** - for specific Phase 2/3 deliverables (first SEP submission, x402 reference implementation, security audit).
+3. **Future SCF Adopt/Audit grants** - for specific Phase 2/3 deliverables (SEP draft, `orbital codegen`, `@orbital-stellar/anchor-sdk`, security audit).
 
 The grant funds the milestone, not the team's salary in perpetuity.
 
@@ -212,9 +212,10 @@ Phase 1 will be delivered by the same founder with the same commit transparency.
 
 Reproduced from [`ROADMAP.md`](../ROADMAP.md) for context only - these are not Phase 1 deliverables and not part of this funding ask:
 
-- **Phase 2 (2027)** - `@orbital-stellar/hooks` data hook library, `@orbital-stellar/payments` transaction primitives, `@orbital-stellar/auth` passkey embedded wallets, `@orbital-stellar/analytics`, **first SEP submission** formalizing the event normalization format.
-- **Phase 3 (2028+)** - `@orbital-stellar/x402` payment-gated middleware, `@orbital-stellar/agent-sdk` for autonomous AI agent payments on Stellar, `@orbital-stellar/anchor-sdk` for SEP-24/SEP-31, intent compiler, shadow-fork simulator.
-- **Phase 4 (long-term)** - identity layer, reactor-contract library, 10+ SEPs.
+- **Phase 2 - The Decoding Standard (2026 H2)** - a SEP draft for a standardized Soroban event schema and registry verification spec; `orbital codegen` (CLI that emits TypeScript types, event guards, and hooks from the registry schema); a semantic layer (human-readable event taxonomy + entity labels, published as open data); a hosted registry read API.
+- **Phase 3 - Anchor Events (2027 H1)** - `@orbital-stellar/anchor-sdk` normalizing SEP-24 and SEP-31 lifecycle events into the standard taxonomy.
+
+Everything previously slated for the old Phase 2–4 wish list - `@orbital-stellar/payments`, `@orbital-stellar/auth`, an identity layer, `@orbital-stellar/x402`, `@orbital-stellar/agent-sdk`, an intent compiler, a shadow-fork simulator, reactor contracts, `@orbital-stellar/analytics`, and "10+ SEPs" as a target - is now frozen per [ROADMAP.md's Frozen section](../ROADMAP.md#frozen--out-of-scope-until-the-core-thesis-is-proven); none of it is part of this or any near-term funding ask.
 
 Each future phase will be a separate proposal if grant support is sought.
 


### PR DESCRIPTION
## What

- **README.md** — lead thesis reframed around the decoding standard rather than webhook delivery; the "Why this exists" bullets add the schema/decoding gap; the Roadmap section now shows Phase 2 (The Decoding Standard) and Phase 3 (Anchor Events) instead of the old wish-list; the documentation table points at `STABILITY.md` and the refocused `ROADMAP.md`.
- **docs/open-source-policy.md** — the old "Phase 2 (2027)" / "Phase 3 (2028+)" MIT-package lists are replaced with the actual new Phase 2/3 scope (SEP draft, `orbital codegen`, semantic layer, `anchor-sdk`). Payments, auth, x402, agent-sdk, analytics, identity, the intent compiler, shadow-fork, and reactor contracts are now marked `(frozen — see ROADMAP.md)` instead of listed as upcoming MIT packages. The contributor-guidance "Uncertain" section and the "what is not yet decided" table are updated to match. Core model (open SDKs/standards/data, closed operated Cloud) is untouched.
- **docs/proposal.md** — the M1–M6 milestone definitions are untouched (they're referenced by the Phase 1 release gate). Only forward-looking narrative changed: the "x402" mention in the Solution section, the Sustainability section's Phase 2/3 grant example, and the "Roadmap context" recap at the end now point at the new Phase 2/3 and the Frozen section.
- **PROGRESS.md** — I judged this file substantially duplicates `ROADMAP.md`'s phase/status tracking: the "What Has Been Completed" table restated Phase 0/1 checkboxes, and "Scope Boundaries" / "Next Steps: Phase 2" were verbatim (and now stale) restatements of the old roadmap's Phase 2. I replaced those with a short pointer to `ROADMAP.md`'s at-a-glance table and Frozen section, and kept what's genuinely unique to a progress snapshot — project structure, per-package descriptions, the architecture diagram, security posture, dev setup, and repo health.
- **CHANGELOG.md** — `Unreleased` → `### Changed` entry for this doc alignment.

## Why

Repo-wide grep for `x402`, `agent-sdk`, `intent compiler`, `shadow-fork`, `identity layer`, `programmable runtime`, and `reactor` (excluding `node_modules`, `.git`, and CHANGELOG history) turned up exactly two places these were still described as active/upcoming scope: this set of docs, and nowhere else — `apps/web`'s marketing content was already clean. Fixing it here closes the loop opened by #879: the roadmap says what's frozen, but the docs that pitch the project (README, the SCF proposal, the OSS policy) still described frozen scope as coming soon.

No shipped code changes.

## Files changed vs. hits deliberately left alone

- Changed: `README.md`, `docs/open-source-policy.md`, `docs/proposal.md`, `PROGRESS.md`, `CHANGELOG.md`.
- Left alone (correctly historical or already-frozen framing, not forward-looking): `CHANGELOG.md`'s existing `Unreleased` entry from #879 describing what was frozen and why; `ROADMAP.md`'s own Frozen section, which is the canonical source these docs now point back to.