### PR TITLE
feat: add deployment provenance verification to CI

### DIFF
--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -53,3 +53,79 @@ jobs:
       - name: cargo build (release, wasm32v1-none)
         working-directory: contracts
         run: cargo build --release --target wasm32v1-none
+
+  verify-provenance:
+    needs: test
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32v1-none
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: contracts
+
+      - uses: cargo-bins/cargo-binstall@main
+
+      - name: Install stellar-cli
+        run: cargo binstall -y stellar-cli@25.2.0
+
+      - name: cargo build (release, wasm32v1-none)
+        working-directory: contracts
+        run: cargo build --release --target wasm32v1-none
+
+      - name: Verify deployed provenance
+        working-directory: contracts
+        run: |
+          set -euo pipefail
+          
+          if [ ! -f deployed.testnet.json ]; then
+            echo "No deployed.testnet.json found. Skipping provenance verification."
+            exit 0
+          fi
+
+          REGISTRY_WASM="target/wasm32v1-none/release/orbital_abi_registry.wasm"
+          DEMO_WASM="target/wasm32v1-none/release/orbital_demo_emitter.wasm"
+
+          REGISTRY_ID=$(jq -r '.contracts.registry.contractId' deployed.testnet.json)
+          EXPECTED_HASH=$(jq -r '.contracts.registry.wasmHash' deployed.testnet.json)
+          DEMO_ID=$(jq -r '.contracts.demoEmitter.contractId' deployed.testnet.json)
+          EXPECTED_DEMO_HASH=$(jq -r '.contracts.demoEmitter.wasmHash' deployed.testnet.json)
+
+          ACTUAL_HASH=$(sha256sum "$REGISTRY_WASM" | awk '{print $1}')
+          ACTUAL_DEMO_HASH=$(sha256sum "$DEMO_WASM" | awk '{print $1}')
+
+          echo "registry: $EXPECTED_HASH" > expected_hashes.txt
+          echo "demoEmitter: $EXPECTED_DEMO_HASH" >> expected_hashes.txt
+
+          echo "registry: $ACTUAL_HASH" > actual_hashes.txt
+          echo "demoEmitter: $ACTUAL_DEMO_HASH" >> actual_hashes.txt
+
+          echo "==> Comparing local build against deployed.testnet.json..."
+          if ! diff -u expected_hashes.txt actual_hashes.txt; then
+            echo "::error::WASM hashes do not match deployed.testnet.json! Did you modify contracts without updating the deployment?"
+            exit 1
+          fi
+
+          echo "==> Fetching on-chain WASMs to verify they match..."
+          stellar contract fetch --id "$REGISTRY_ID" --network testnet --out-file onchain_registry.wasm
+          stellar contract fetch --id "$DEMO_ID" --network testnet --out-file onchain_demo.wasm
+
+          ONCHAIN_HASH=$(sha256sum onchain_registry.wasm | awk '{print $1}')
+          ONCHAIN_DEMO_HASH=$(sha256sum onchain_demo.wasm | awk '{print $1}')
+
+          echo "registry: $ONCHAIN_HASH" > onchain_hashes.txt
+          echo "demoEmitter: $ONCHAIN_DEMO_HASH" >> onchain_hashes.txt
+
+          echo "==> Comparing local build against on-chain network..."
+          if ! diff -u actual_hashes.txt onchain_hashes.txt; then
+            echo "::error::On-chain WASM hashes do not match local build! The network state has drifted or was maliciously altered."
+            exit 1
+          fi
+
+          echo "Provenance verification passed! (All hashes match)"

--- a/contracts/README.md
+++ b/contracts/README.md
@@ -59,3 +59,14 @@ resulting contract IDs. See that script's header comment and the maintainer
 plan's "manual/gated steps" section for the secret-provisioning steps that
 follow (GitHub repo secrets for the nightly integration test, Vercel env vars
 for the demo's "Fire test event" route).
+
+## Deployment Provenance & Reproducible Builds
+
+`contracts/deployed.testnet.json` serves as the trust anchor for the whole registry: consumers resolve specs through the contract ID it names. To prevent this file from drifting from the source in `contracts/registry`, CI enforces deployment provenance on every PR and push.
+
+The procedure:
+1. CI builds the contracts reproducibly using the pinned `rust-toolchain.toml` (ensuring byte-for-byte identical WASM across environments).
+2. The `wasmHash` values recorded in `deployed.testnet.json` are compared against the newly built WASM hashes. A mismatch fails the job with a diff of expected vs actual.
+3. The deployed WASM bytecodes are fetched directly from the Stellar testnet and hashed to ensure they exactly match the local build.
+
+Changing contract source without redeploying turns the CI job red. If you intentionally modify a contract, you must rebuild, redeploy (which updates `deployed.testnet.json`), and commit both the source changes and the updated JSON file together.


### PR DESCRIPTION
## Linked issue

Closes #894

## What changed and why

This PR adds deployment provenance verification to the contracts CI pipeline to ensure the deployed registry contract is reproducibly built from the committed source. The workflow now builds the contracts using the pinned Rust toolchain, compares the locally generated WASM hash against the committed `wasmHash` in `contracts/deployed.testnet.json`, and verifies that the deployed WASM retrieved from the testnet matches the local build. Any mismatch causes the workflow to fail with a clear diff, preventing contract metadata from drifting away from the reviewed source. The reproducible build process has also been documented in `contracts/README.md`.

## Test plan

* [ ] Existing tests pass (`pnpm test`)
* [ ] New tests added for new behaviour
* [ ] Typechecks pass (`pnpm -r typecheck`)
* [x] Verified the contracts workflow builds using the pinned toolchain from `contracts/rust-toolchain.toml`.
* [x] Confirmed the locally built WASM hash is compared against `contracts/deployed.testnet.json`.
* [x] Confirmed the workflow fetches the deployed WASM hash from testnet and verifies it matches the local build.
* [x] Verified the workflow fails with an expected vs. actual hash diff when hashes do not match.
* [x] Confirmed modifying contract source without updating the deployment metadata causes the provenance check to fail.
* [x] Reviewed `contracts/README.md` to ensure the reproducible build procedure is documented.

## Breaking changes

None.

## Notes for reviewers

The primary review focus should be the reproducibility guarantees in the CI workflow. In particular, verify that the toolchain is fully pinned, the hash comparison uses the same hashing method as `contracts/deployed.testnet.json`, and the network verification step validates the deployed WASM rather than relying solely on the committed metadata. The intent is to make `contracts/deployed.testnet.json` a trustworthy deployment artifact that cannot silently drift from the reviewed source.
