### PR TITLE
feat: Generate typed event guards from a resolved spec

### DIFF
--- a/packages/abi-registry/src/generate.ts
+++ b/packages/abi-registry/src/generate.ts
@@ -5,6 +5,8 @@ import type { ContractSpec, EventSpec, FunctionSpec, TypeSpec, UserDefinedType }
 export type GeneratedContractArtifacts = {
   declarations: string;
   schemas: string;
+  guards?: string;
+  testDts?: string;
 };
 
 function toPascalCase(value: string): string {
@@ -146,6 +148,12 @@ function generateFromXdrContractSpec(spec: XdrContractSpec): GeneratedContractAr
   declarations.push('import { z } from "zod";');
   declarations.push("");
 
+  const guards: string[] = [];
+  const testDts: string[] = [];
+  const eventTypes: string[] = [];
+
+  declarations.unshift('import type { ContractEmittedEvent } from "@orbital-stellar/pulse-core";');
+
   for (const event of entries) {
     const eventName = String((event as any).name());
     const baseName = toPascalCase(eventName);
@@ -173,11 +181,65 @@ function generateFromXdrContractSpec(spec: XdrContractSpec): GeneratedContractAr
     );
     schemas.push("});");
     schemas.push("");
+
+    guards.push(
+      `export function is${interfaceName}(event: ContractEmittedEvent): event is ContractEmittedEvent & { decodedData: ${interfaceName} } {`,
+    );
+    guards.push(
+      `  return event.topics[0] === "${eventName}" && ${schemaName}.safeParse(event.decodedData).success;`,
+    );
+    guards.push(`}`);
+    guards.push("");
+
+    eventTypes.push(
+      `ContractEmittedEvent & { topics: ["${eventName}", ...string[]]; decodedData: ${interfaceName} }`,
+    );
   }
+
+  guards.push(
+    `export type ContractEventUnion = ${eventTypes.length > 0 ? eventTypes.join(" | ") : "never"};`,
+  );
+  guards.push("");
+
+  guards.push(`export function assertExhaustiveContractEvent(event: ContractEventUnion): string {`);
+  guards.push(`  switch (event.topics[0]) {`);
+  for (const event of entries) {
+    guards.push(`    case "${String((event as any).name())}":`);
+    guards.push(`      return event.topics[0];`);
+  }
+  if (entries.length > 0) {
+    guards.push(`    default: {`);
+    guards.push(`      const _exhaustive: never = event;`);
+    guards.push(`      return _exhaustive;`);
+    guards.push(`    }`);
+  }
+  guards.push(`  }`);
+  guards.push(`}`);
+  guards.push("");
+
+  testDts.push(`import type { ContractEventUnion } from "./generated.js";`);
+  testDts.push("");
+  testDts.push(`export function assertExhaustive(event: ContractEventUnion): string {`);
+  testDts.push(`  switch (event.topics[0]) {`);
+  for (const event of entries) {
+    testDts.push(`    case "${String((event as any).name())}":`);
+    testDts.push(`      return event.topics[0];`);
+  }
+  if (entries.length > 0) {
+    testDts.push(`    default: {`);
+    testDts.push(`      const _exhaustive: never = event;`);
+    testDts.push(`      return _exhaustive;`);
+    testDts.push(`    }`);
+  }
+  testDts.push(`  }`);
+  testDts.push(`}`);
+  testDts.push("");
 
   return {
     declarations: declarations.join("\n"),
     schemas: schemas.join("\n"),
+    guards: guards.join("\n"),
+    testDts: testDts.join("\n"),
   };
 }
 
@@ -362,10 +424,15 @@ function generateFunctionDeclarations(functions: ReadonlyArray<FunctionSpec>): s
 function generateEventDeclarations(events: ReadonlyArray<EventSpec>): {
   declarations: string[];
   schemas: string[];
+  guards: string[];
+  testDts: string[];
 } {
   const usedNames = new Set<string>();
   const declarations: string[] = [];
   const schemas: string[] = [];
+  const guards: string[] = [];
+  const testDts: string[] = [];
+  const eventTypes: string[] = [];
 
   for (const event of events) {
     const baseName = toPascalCase(event.name);
@@ -385,9 +452,61 @@ function generateEventDeclarations(events: ReadonlyArray<EventSpec>): {
     );
     schemas.push("});");
     schemas.push("");
+
+    guards.push(
+      `export function is${interfaceName}(event: ContractEmittedEvent): event is ContractEmittedEvent & { decodedData: ${interfaceName} } {`,
+    );
+    guards.push(
+      `  return event.topics[0] === "${event.name}" && ${schemaName}.safeParse(event.decodedData).success;`,
+    );
+    guards.push(`}`);
+    guards.push("");
+
+    eventTypes.push(
+      `ContractEmittedEvent & { topics: ["${event.name}", ...string[]]; decodedData: ${interfaceName} }`,
+    );
   }
 
-  return { declarations, schemas };
+  guards.push(
+    `export type ContractEventUnion = ${eventTypes.length > 0 ? eventTypes.join(" | ") : "never"};`,
+  );
+  guards.push("");
+
+  guards.push(`export function assertExhaustiveContractEvent(event: ContractEventUnion): string {`);
+  guards.push(`  switch (event.topics[0]) {`);
+  for (const event of events) {
+    guards.push(`    case "${event.name}":`);
+    guards.push(`      return event.topics[0];`);
+  }
+  if (events.length > 0) {
+    guards.push(`    default: {`);
+    guards.push(`      const _exhaustive: never = event;`);
+    guards.push(`      return _exhaustive;`);
+    guards.push(`    }`);
+  }
+  guards.push(`  }`);
+  guards.push(`}`);
+  guards.push("");
+
+  testDts.push(`import type { ContractEventUnion } from "./generated.js";`);
+  testDts.push("");
+  testDts.push(`export function assertExhaustive(event: ContractEventUnion): string {`);
+  testDts.push(`  switch (event.topics[0]) {`);
+  for (const event of events) {
+    testDts.push(`    case "${event.name}":`);
+    testDts.push(`      return event.topics[0];`);
+  }
+  if (events.length > 0) {
+    testDts.push(`    default: {`);
+    testDts.push(`      const _exhaustive: never = event;`);
+    testDts.push(`      return _exhaustive;`);
+    testDts.push(`    }`);
+  }
+  testDts.push(`  }`);
+  testDts.push(`}`);
+  testDts.push("");
+
+  return { declarations, schemas, guards, testDts };
 }
 
 function generateFromContractSpec(spec: ContractSpec): GeneratedContractArtifacts {
@@ -407,6 +526,8 @@ function generateFromContractSpec(spec: ContractSpec): GeneratedContractArtifact
   return {
     declarations: declarations.join("\n"),
     schemas: schemas.join("\n"),
+    guards: events.guards.join("\n"),
+    testDts: events.testDts.join("\n"),
   };
 }
 
@@ -420,5 +541,5 @@ export function generateContractArtifacts(
 
 export function generateContractTypes(spec: XdrContractSpec | ContractSpec): string {
   const artifacts = generateContractArtifacts(spec);
-  return [artifacts.declarations, artifacts.schemas].filter(Boolean).join("\n\n");
+  return [artifacts.declarations, artifacts.schemas, artifacts.guards].filter(Boolean).join("\n\n");
 }


### PR DESCRIPTION
Closes #904

## Linked issue

Closes #

## What changed and why

<!-- One paragraph. What does this PR do, and why is the change needed? -->

## Test plan

<!-- How did you verify this works? Check everything that applies. -->

- [ ] Existing tests pass (`pnpm test`)
- [ ] New tests added for new behaviour
- [ ] Typechecks pass (`pnpm -r typecheck`)
- [ ] Manually tested against testnet / mainnet (describe what you tested)

## Breaking changes

<!-- Does this change any public API? If yes, describe the migration path. -->

None / Yes (describe below)

## Notes for reviewers

<!-- Anything the reviewer should pay special attention to, or context that isn't obvious from the diff. -->
