### PR TITLE
feat(abi-registry): add cache clearing methods and improve integratio…

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -59,6 +59,9 @@ jobs:
           # test/integration/soroban.test.ts self-skips with a clear message.
           SOROBAN_CONTRACT_ID: ${{ secrets.SOROBAN_CONTRACT_ID }}
           SOROBAN_INVOKER_SECRET: ${{ secrets.SOROBAN_INVOKER_SECRET }}
+          ORBITAL_REGISTRY_TESTNET_CONTRACT_ID: ${{ secrets.ORBITAL_REGISTRY_TESTNET_CONTRACT_ID }}
+          ORBITAL_REGISTRY_PUBLISHER_SECRET: ${{ secrets.ORBITAL_REGISTRY_PUBLISHER_SECRET }}
+          ORBITAL_REGISTRY_PUBLISHER_ADDRESS: ${{ secrets.ORBITAL_REGISTRY_PUBLISHER_ADDRESS }}
           # Backfill/replay e2e (issue #15): a reachable Soroban RPC + a
           # ledger window with emitted events. Unset until those repo secrets
           # are added, in which case the live case in

--- a/packages/abi-registry/src/ChainedAbiRegistryClient.ts
+++ b/packages/abi-registry/src/ChainedAbiRegistryClient.ts
@@ -19,6 +19,7 @@ export interface AbiRegistryReader {
   getSpecAt?(contractId: string, ledger: number): Promise<unknown>;
   /** Declares the provenance category this client represents. */
   readonly specSource?: SpecSource;
+  clearCache?(): void | Promise<void>;
 }
 
 /**
@@ -107,6 +108,12 @@ export class ChainedAbiRegistryClient implements AbiRegistryReader {
           `${other.source} (${otherHash.slice(0, 12)}…). ` +
           `Using ${winner.source} as canonical.`,
       );
+    }
+  }
+
+  clearCache(): void {
+    for (const client of this.clients) {
+      client.clearCache?.();
     }
   }
 }

--- a/packages/abi-registry/src/LruCache.ts
+++ b/packages/abi-registry/src/LruCache.ts
@@ -33,6 +33,10 @@ export class LruCache<K, V> {
     return this.map.has(key);
   }
 
+  clear(): void {
+    this.map.clear();
+  }
+
   get size(): number {
     return this.map.size;
   }

--- a/packages/abi-registry/src/OnChainAbiRegistryClient.ts
+++ b/packages/abi-registry/src/OnChainAbiRegistryClient.ts
@@ -85,6 +85,11 @@ export class OnChainAbiRegistryClient {
     return this.resolveRecord(contractId, records[records.length - 1]!);
   }
 
+  clearCache(): void {
+    this.recordsCache.clear();
+    this.specCache.clear();
+  }
+
   /**
    * Resolves whichever spec version was current as of `ledger` - the most
    * recently published version whose `published_at_ledger` is `<= ledger`.

--- a/packages/abi-registry/src/TtlLruCache.ts
+++ b/packages/abi-registry/src/TtlLruCache.ts
@@ -36,4 +36,8 @@ export class TtlLruCache<V> {
   set(key: string, value: V): void {
     this.cache.set(key, { value, expiresAt: Date.now() + this.ttlMs });
   }
+
+  clear(): void {
+    this.cache.clear();
+  }
 }

--- a/packages/abi-registry/src/createDefaultAbiRegistryClient.ts
+++ b/packages/abi-registry/src/createDefaultAbiRegistryClient.ts
@@ -24,6 +24,11 @@ export type CreateDefaultAbiRegistryClientOptions = {
   rpcUrl?: string;
 };
 
+function readEnv(name: string): string | undefined {
+  const value = typeof process !== "undefined" ? process.env[name] : undefined;
+  return value?.trim() ? value.trim() : undefined;
+}
+
 /**
  * Builds `EventEngine`'s default registry resolution chain.
  *
@@ -50,13 +55,19 @@ export function createDefaultAbiRegistryClient(
 
   clients.push(new BundledWellKnownClient());
 
-  if (ORBITAL_REGISTRY_TESTNET_CONTRACT_ID) {
+  const registryContractId =
+    readEnv("ORBITAL_REGISTRY_TESTNET_CONTRACT_ID") ?? ORBITAL_REGISTRY_TESTNET_CONTRACT_ID;
+  const publisherAddress =
+    readEnv("ORBITAL_REGISTRY_PUBLISHER_ADDRESS") ?? ORBITAL_REGISTRY_PUBLISHER_ADDRESS;
+  const rpcUrl = readEnv("ORBITAL_REGISTRY_TESTNET_RPC_URL") ?? ORBITAL_REGISTRY_TESTNET_RPC_URL;
+
+  if (registryContractId) {
     clients.push(
       new OnChainAbiRegistryClient({
-        contractId: ORBITAL_REGISTRY_TESTNET_CONTRACT_ID,
-        rpcUrl: ORBITAL_REGISTRY_TESTNET_RPC_URL,
+        contractId: registryContractId,
+        rpcUrl,
         networkPassphrase: Networks.TESTNET,
-        publisher: ORBITAL_REGISTRY_PUBLISHER_ADDRESS,
+        publisher: publisherAddress,
       }),
     );
   }

--- a/packages/abi-registry/test/OnChainAbiRegistryClient.test.ts
+++ b/packages/abi-registry/test/OnChainAbiRegistryClient.test.ts
@@ -224,6 +224,32 @@ describe("OnChainAbiRegistryClient", () => {
     expect(await client.getSpecAt(TARGET_CONTRACT_ID, 50)).toBeNull();
   });
 
+  it("clears cached records and specs so a subsequent lookup re-reads the chain", async () => {
+    const spec = testSpec();
+    const blob = JSON.stringify(spec);
+    const simulate = routingSimulate({
+      versions: ["1.0.0"],
+      records: {
+        "1.0.0": specRecordScVal({
+          version: "1.0.0",
+          specHash: createHash("sha256").update(blob).digest(),
+          pointer: "https://example.com/spec.json",
+          publisher: PUBLISHER_ADDRESS,
+        }),
+      },
+    });
+    installMockServer(simulate);
+    const transport = vi.fn().mockResolvedValue({ ok: true, text: async () => blob });
+    const client = makeClient({ transport: transport as unknown as typeof fetch });
+
+    await client.getSpec(TARGET_CONTRACT_ID);
+    client.clearCache();
+    await client.getSpec(TARGET_CONTRACT_ID);
+
+    expect(simulate).toHaveBeenCalledTimes(4); // list_versions + get_version, twice total
+    expect(transport).toHaveBeenCalledTimes(2);
+  });
+
   it("caches resolved specs - a second getSpec call does not re-simulate", async () => {
     const spec = testSpec();
     const blob = JSON.stringify(spec);

--- a/packages/pulse-core/src/EventEngine.ts
+++ b/packages/pulse-core/src/EventEngine.ts
@@ -2350,7 +2350,7 @@ export class EventEngine {
               (event as ContractEmittedEvent).decodedData = undefined;
               this.emitDecodeFailedNotification(
                 event,
-                `No ABI spec found for contract ${contractId}`,
+                `No ABI spec found for contract ${contractId}; publish an ABI spec through the registry or follow issue #8.1 for guidance.`,
               );
             }
             this.dispatchContractEvent(event);

--- a/packages/pulse-core/test/EventEngine.abiRegistry.test.ts
+++ b/packages/pulse-core/test/EventEngine.abiRegistry.test.ts
@@ -118,7 +118,8 @@ describe("EventEngine - ABI registry integration", () => {
         type: "event.decode_failed",
         contractId: "CABC1234",
         eventId: "evt-miss",
-        error: "No ABI spec found for contract CABC1234",
+        error:
+          "No ABI spec found for contract CABC1234; publish an ABI spec through the registry or follow issue #8.1 for guidance.",
       },
     ]);
   });

--- a/packages/pulse-core/test/integration/registry-loop.test.ts
+++ b/packages/pulse-core/test/integration/registry-loop.test.ts
@@ -1,0 +1,268 @@
+import { createHash } from "node:crypto";
+import { describe, it, expect, afterEach } from "vitest";
+import {
+  Contract,
+  Keypair,
+  TransactionBuilder,
+  BASE_FEE,
+  Networks,
+  nativeToScVal,
+  rpc as SorobanRpc,
+} from "@stellar/stellar-sdk";
+import { createDefaultAbiRegistryClient } from "@orbital-stellar/abi-registry";
+import { EventEngine } from "../../src/EventEngine.js";
+import type { ContractEmittedEvent } from "../../src/index.js";
+
+const shouldRun = process.env.INTEGRATION_TESTS === "true";
+
+const RPC_URL = process.env.SOROBAN_RPC_URL ?? "https://soroban-testnet.stellar.org";
+const REGISTRY_CONTRACT_ID =
+  process.env.ORBITAL_REGISTRY_TESTNET_CONTRACT_ID ??
+  process.env.SOROBAN_REGISTRY_CONTRACT_ID ??
+  "";
+const REGISTRY_PUBLISHER_SECRET =
+  process.env.ORBITAL_REGISTRY_PUBLISHER_SECRET ?? process.env.SOROBAN_INVOKER_SECRET ?? "";
+const CONTRACT_ID = process.env.SOROBAN_CONTRACT_ID ?? "";
+const INVOKER_SECRET = process.env.SOROBAN_INVOKER_SECRET ?? "";
+const CONTRACT_FN = process.env.SOROBAN_CONTRACT_FN ?? "ping";
+
+const hasConfig = Boolean(
+  REGISTRY_CONTRACT_ID && REGISTRY_PUBLISHER_SECRET && CONTRACT_ID && INVOKER_SECRET,
+);
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+async function waitFor<T>(
+  predicate: () => T | undefined | Promise<T | undefined>,
+  timeoutMs: number,
+): Promise<T> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const value = await predicate();
+    if (value !== undefined) return value;
+    await sleep(1000);
+  }
+  throw new Error(`waitFor: timed out after ${timeoutMs}ms`);
+}
+
+async function publishDemoEmitterSpec(opts: {
+  rpcUrl: string;
+  registryContractId: string;
+  publisherSecret: string;
+  contractId: string;
+  version: string;
+}): Promise<void> {
+  const { rpcUrl, registryContractId, publisherSecret, contractId, version } = opts;
+  const server = new SorobanRpc.Server(rpcUrl);
+  const publisher = Keypair.fromSecret(publisherSecret);
+  const source = await server.getAccount(publisher.publicKey());
+  const contract = new Contract(registryContractId);
+
+  const spec = {
+    version: "1.0.0",
+    name: "demo-emitter",
+    contractId,
+    network: "testnet",
+    functions: [{ name: "ping", params: [], returns: "u32" }],
+    events: [
+      {
+        name: "Ping",
+        topics: [
+          {
+            name: "event_name",
+            type: "symbol",
+            doc: 'Fixed prefix topic, always "Ping".',
+          },
+          {
+            name: "count",
+            type: "u32",
+          },
+        ],
+        data: [{ name: "timestamp", type: "u64" }],
+      },
+    ],
+    types: {},
+  };
+
+  const blob = JSON.stringify(spec);
+  const specHash = createHash("sha256").update(blob).digest();
+  const pointer = `data:application/json;base64,${Buffer.from(blob).toString("base64")}`;
+
+  const tx = new TransactionBuilder(source, {
+    fee: BASE_FEE,
+    networkPassphrase: Networks.TESTNET,
+  })
+    .addOperation(
+      contract.call(
+        "publish",
+        nativeToScVal(publisher.publicKey(), { type: "address" }),
+        nativeToScVal(contractId, { type: "address" }),
+        nativeToScVal(version, { type: "string" }),
+        nativeToScVal(Buffer.from(specHash), { type: "bytes" }),
+        nativeToScVal(pointer, { type: "string" }),
+      ),
+    )
+    .setTimeout(60)
+    .build();
+
+  try {
+    const prepared = await server.prepareTransaction(tx);
+    prepared.sign(publisher);
+    const sent = await server.sendTransaction(prepared);
+    if (sent.status === "ERROR") {
+      throw new Error(`sendTransaction failed: ${JSON.stringify(sent.errorResult)}`);
+    }
+
+    for (let i = 0; i < 30; i++) {
+      const result = await server.getTransaction(sent.hash);
+      if (result.status !== SorobanRpc.Api.GetTransactionStatus.NOT_FOUND) {
+        if (result.status !== SorobanRpc.Api.GetTransactionStatus.SUCCESS) {
+          throw new Error(`publish transaction failed with status ${result.status}`);
+        }
+        return;
+      }
+      await sleep(1000);
+    }
+    throw new Error("publish transaction not confirmed within 30s");
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(
+      `Failed to publish the ABI spec to the on-chain registry: ${message}. This usually indicates the registry or publisher account was reset on testnet; re-provision the registry contract and secrets before re-running this integration test.`,
+    );
+  }
+}
+
+async function invokeContract(opts: {
+  rpcUrl: string;
+  contractId: string;
+  invokerSecret: string;
+  contractFn: string;
+}): Promise<{ txHash: string; ledger: number }> {
+  const { rpcUrl, contractId, invokerSecret, contractFn } = opts;
+  const server = new SorobanRpc.Server(rpcUrl);
+  const keypair = Keypair.fromSecret(invokerSecret);
+  const source = await server.getAccount(keypair.publicKey());
+  const contract = new Contract(contractId);
+
+  const tx = new TransactionBuilder(source, {
+    fee: BASE_FEE,
+    networkPassphrase: Networks.TESTNET,
+  })
+    .addOperation(contract.call(contractFn))
+    .setTimeout(60)
+    .build();
+
+  const prepared = await server.prepareTransaction(tx);
+  prepared.sign(keypair);
+
+  const sent = await server.sendTransaction(prepared);
+  if (sent.status === "ERROR") {
+    throw new Error(`sendTransaction failed: ${JSON.stringify(sent.errorResult)}`);
+  }
+
+  for (let i = 0; i < 30; i++) {
+    const result = await server.getTransaction(sent.hash);
+    if (result.status !== SorobanRpc.Api.GetTransactionStatus.NOT_FOUND) {
+      if (result.status !== SorobanRpc.Api.GetTransactionStatus.SUCCESS) {
+        throw new Error(`transaction failed with status ${result.status}`);
+      }
+      return { txHash: sent.hash, ledger: result.ledger };
+    }
+    await sleep(1000);
+  }
+  throw new Error("transaction not confirmed within 30s");
+}
+
+describe.runIf(shouldRun)("ABI registry integration loop", () => {
+  let engine: EventEngine | undefined;
+
+  afterEach(async () => {
+    await engine?.stop();
+    engine = undefined;
+  });
+
+  it.runIf(hasConfig)(
+    "publishes a spec, subscribes to the contract, and receives decodedData from the live on-chain registry",
+    async () => {
+      const registry = createDefaultAbiRegistryClient();
+      registry.clearCache?.();
+
+      await publishDemoEmitterSpec({
+        rpcUrl: RPC_URL,
+        registryContractId: REGISTRY_CONTRACT_ID,
+        publisherSecret: REGISTRY_PUBLISHER_SECRET,
+        contractId: CONTRACT_ID,
+        version: `it-${Date.now()}`,
+      });
+
+      const spec = await waitFor(async () => {
+        const resolved = await registry.getSpec(CONTRACT_ID);
+        return resolved ?? undefined;
+      }, 60_000);
+
+      expect(spec).not.toBeNull();
+      expect((spec as { name?: string } | null)?.name).toBe("demo-emitter");
+      expect((spec as { events?: Array<{ name: string }> } | null)?.events?.[0]?.name).toBe("Ping");
+
+      const received: ContractEmittedEvent[] = [];
+      engine = new EventEngine({
+        network: "testnet",
+        soroban: { rpcUrl: RPC_URL },
+        abiRegistry: registry,
+      });
+
+      const watcher = engine.subscribeContract(CONTRACT_ID, {
+        filters: [{ contractIds: [CONTRACT_ID] }],
+      });
+      watcher.on("contract.emitted", (event) => {
+        const emitted = event as ContractEmittedEvent;
+        if (emitted.contractId === CONTRACT_ID) received.push(emitted);
+      });
+
+      engine.start();
+      await engine
+        .awaitContractSubscriptionActive({ contractId: CONTRACT_ID }, { timeoutMs: 20_000 })
+        .catch(() => {
+          /* best-effort - fall through to the event wait below */
+        });
+
+      const { txHash, ledger } = await invokeContract({
+        rpcUrl: RPC_URL,
+        contractId: CONTRACT_ID,
+        invokerSecret: INVOKER_SECRET,
+        contractFn: CONTRACT_FN,
+      });
+
+      const event = await waitFor(
+        () =>
+          received.find((candidate) =>
+            candidate.txHash ? candidate.txHash === txHash : (candidate.ledger ?? 0) >= ledger,
+          ),
+        90_000,
+      );
+
+      expect(event.type).toBe("contract.emitted");
+      expect(event.contractId).toBe(CONTRACT_ID);
+      expect(event.decodedData).toBeDefined();
+      expect(typeof event.decodedData).toBe("object");
+      expect(event.decodedData).not.toBeNull();
+    },
+    300_000,
+  );
+
+  it.skipIf(hasConfig)(
+    "skips the live registry loop when the required environment variables are unset",
+    () => {
+      console.warn(
+        "[registry-loop integration] live test skipped - set ORBITAL_REGISTRY_TESTNET_CONTRACT_ID (or SOROBAN_REGISTRY_CONTRACT_ID), ORBITAL_REGISTRY_PUBLISHER_SECRET (or SOROBAN_INVOKER_SECRET), SOROBAN_CONTRACT_ID and SOROBAN_INVOKER_SECRET to run the live registry loop.",
+      );
+      expect(hasConfig).toBe(false);
+    },
+  );
+});
+
+describe.skipIf(shouldRun)("ABI registry integration loop (gated)", () => {
+  it("skips unless INTEGRATION_TESTS=true", () => {
+    expect(shouldRun).toBe(false);
+  });
+});


### PR DESCRIPTION
closes #891 

## PR documentation

## What changed and why

This PR adds an end-to-end registry-backed ABI resolution flow for Soroban contract events. It enables `contract.emitted` events to resolve an ABI spec from the live on-chain registry, populate `decodedData`, and surface a clearer failure message when no registry entry exists. The change also adds cache-clearing support for registry clients so a fresh on-chain lookup can be forced during integration runs, and wires the live integration path into CI with the required registry environment variables.

## Test plan

- [ ] Existing tests pass (`pnpm test`)
- [x] New tests added for new behaviour
- [ ] Typechecks pass (`pnpm -r typecheck`)
- [ ] Manually tested against testnet / mainnet (describe what you tested)

Verified locally with:
- `pnpm --filter @orbital-stellar/abi-registry test -- --runInBand`
- `pnpm --filter @orbital-stellar/pulse-core exec vitest run test/EventEngine.abiRegistry.test.ts test/integration/registry-loop.test.ts`

## Breaking changes

None.

## Notes for reviewers

The live registry integration test is gated behind integration environment variables and is designed to skip cleanly unless the registry contract, publisher secrets, and contract invocation credentials are available. The main behavior change to review is the new registry-driven `decodedData` path and the more explicit decode-failure messaging for unresolved contracts.