### PR TITLE
    modified:   docs/ARCHITECTURE.md

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -254,6 +254,25 @@ For `engine.cursor_expired` notifications, the payload includes:
 Consumers can subscribe to these via `watcher.on("engine.reconnecting", …)`
 to surface UI banners or write structured logs.
 
+### In-process backpressure and bounded queues
+
+To protect consumers from unbounded memory growth when a watcher is slow or
+there's a burst of ledger activity, `EventEngine` now maintains a bounded
+internal queue. Configuration lives in `CoreConfig.queue` and exposes three
+knobs:
+
+- **`highWaterMark`**: the maximum queued events before backpressure triggers (default: 10000).
+- **`lowWaterMark`**: the level below which backpressure is considered cleared (default: 50% of highWaterMark).
+- **`policy`**: one of `pause` (default), `drop-oldest`, or `drop-newest`.
+
+When the high-water mark is crossed the engine emits `engine.backpressure`
+with `{ active: true, queued, policy }`. The default `pause` policy stops
+the underlying sources (Horizon and Soroban) until the queue drains below the
+low-water mark, at which point `engine.backpressure` with `{ active: false }`
+is emitted and sources are resumed. `drop-oldest` and `drop-newest` shed
+events deterministically instead of pausing the source; these are useful for
+best-effort dashboards where availability is preferred over perfect delivery.
+
 ---
 
 ## 6. Webhook delivery internals

--- a/packages/pulse-core/src/EventEngine.ts
+++ b/packages/pulse-core/src/EventEngine.ts
@@ -206,6 +206,14 @@ export class EventEngine {
   private consecutiveCursorFailures = 0;
   private isCursorStoreUnhealthy = false;
   private pausedSources = new Set<"horizon" | "soroban">();
+  /** Internal bounded queue for normalized events to protect slow consumers. */
+  private eventQueue: Array<Timestamped<NormalizedEventOrPending>> = [];
+  private queueHighWaterMark: number;
+  private queueLowWaterMark: number;
+  private queuePolicy: "pause" | "drop-oldest" | "drop-newest";
+  private processingQueue = false;
+  private inBackpressure = false;
+  private wePausedSourcesForBackpressure = false;
   /**
    * Optional live Soroban subscriber. Wired only when the engine is configured
    * for live contract streaming; otherwise undefined, and the guarded calls
@@ -287,6 +295,14 @@ export class EventEngine {
     this.abiRegistry = EventEngine.resolveAbiRegistry(config.abiRegistry);
     this.cursorStore = config.cursorStore;
     this.network = config.network;
+    // Queue configuration
+    const defaultHigh = 10000;
+    this.queueHighWaterMark = Math.max(1, Math.floor(config.queue?.highWaterMark ?? defaultHigh));
+    this.queueLowWaterMark = Math.max(
+      1,
+      Math.floor(config.queue?.lowWaterMark ?? Math.floor(this.queueHighWaterMark / 2)),
+    );
+    this.queuePolicy = config.queue?.policy ?? "pause";
 
     if (config.soroban) {
       const rpc = new SorobanRpcClient({
@@ -1152,7 +1168,7 @@ export class EventEngine {
         }
 
         this.lastEventAt = event.timestamp;
-        this.route(event);
+        this.enqueueEvent(event);
       },
       onerror: (error) => {
         this.log.error("[pulse-core] SSE error.", { error });
@@ -1174,6 +1190,110 @@ export class EventEngine {
       this.horizonCursor = streamCursor;
       this.stopStream = this.server.operations().cursor(streamCursor).stream(callbacks);
     });
+  }
+
+  private enqueueEvent(event: Timestamped<NormalizedEventOrPending>): void {
+    // If over capacity, apply configured policy.
+    if (this.eventQueue.length >= this.queueHighWaterMark) {
+      if (this.queuePolicy === "pause") {
+        if (!this.inBackpressure) {
+          this.inBackpressure = true;
+          // Pause sources to prevent further incoming events.
+          try {
+            this.pauseSource("horizon");
+            this.pauseSource("soroban");
+            this.wePausedSourcesForBackpressure = true;
+          } catch (err) {
+            /* swallow - pauseSource logs */
+          }
+          this.notifyWatchers("engine.backpressure", {
+            type: "engine.backpressure",
+            attempt: 0,
+            emittedAt: new Date().toISOString(),
+            active: true,
+            queued: this.eventQueue.length,
+            policy: this.queuePolicy,
+          } as any);
+        }
+        // Still accept the event so in-flight sources pause and we can drain.
+        this.eventQueue.push(event);
+      } else if (this.queuePolicy === "drop-oldest") {
+        // Drop one oldest then push
+        this.eventQueue.shift();
+        this.eventQueue.push(event);
+        if (!this.inBackpressure) {
+          this.inBackpressure = true;
+          this.notifyWatchers("engine.backpressure", {
+            type: "engine.backpressure",
+            attempt: 0,
+            emittedAt: new Date().toISOString(),
+            active: true,
+            queued: this.eventQueue.length,
+            policy: this.queuePolicy,
+          } as any);
+        }
+      } else {
+        // drop-newest: ignore incoming
+        if (!this.inBackpressure) {
+          this.inBackpressure = true;
+          this.notifyWatchers("engine.backpressure", {
+            type: "engine.backpressure",
+            attempt: 0,
+            emittedAt: new Date().toISOString(),
+            active: true,
+            queued: this.eventQueue.length,
+            policy: this.queuePolicy,
+          } as any);
+        }
+        return;
+      }
+    } else {
+      this.eventQueue.push(event);
+    }
+
+    // Kick the async processor
+    this.processQueue().catch((err) => {
+      this.log.error("[pulse-core] event queue processor failed", { error: err });
+    });
+  }
+
+  private async processQueue(): Promise<void> {
+    if (this.processingQueue) return;
+    this.processingQueue = true;
+    try {
+      while (this.eventQueue.length > 0) {
+        const ev = this.eventQueue.shift()!;
+        try {
+          this.route(ev);
+        } catch (err) {
+          this.log.warn("[pulse-core] watcher handler threw while routing event", { error: err });
+        }
+
+        // Clear backpressure if we're below low watermark
+        if (this.inBackpressure && this.eventQueue.length <= this.queueLowWaterMark) {
+          this.inBackpressure = false;
+          if (this.wePausedSourcesForBackpressure) {
+            try {
+              this.resumeSource("horizon");
+              this.resumeSource("soroban");
+            } catch (err) {
+              /* swallow */
+            }
+            this.wePausedSourcesForBackpressure = false;
+          }
+          this.notifyWatchers("engine.backpressure", {
+            type: "engine.backpressure",
+            attempt: 0,
+            emittedAt: new Date().toISOString(),
+            active: false,
+            queued: this.eventQueue.length,
+            policy: this.queuePolicy,
+          } as any);
+        }
+      }
+    } finally {
+      this.processingQueue = false;
+    }
   }
 
   private getHorizonCursor(record: unknown): string | null {

--- a/packages/pulse-core/src/index.ts
+++ b/packages/pulse-core/src/index.ts
@@ -142,7 +142,8 @@ export type WatcherNotificationType =
   | "engine.rate_limited"
   | "engine.stopped"
   | "engine.cursor_store_unhealthy"
-  | "engine.cursor_expired";
+  | "engine.cursor_expired"
+  | "engine.backpressure";
 
 export type OfferEventType = "offer.created" | "offer.updated" | "offer.deleted";
 export type BumpSequenceEventType = "account.bump_sequence";
@@ -455,6 +456,12 @@ export type WatcherNotification = {
   cursor?: string;
   /** The source that triggered this notification. */
   source?: "horizon" | "soroban";
+  /** Backpressure active flag (for `engine.backpressure`). */
+  active?: boolean;
+  /** Number of events currently queued inside the engine. */
+  queued?: number;
+  /** Queue policy in effect when backpressure was emitted. */
+  policy?: string;
   /** ISO 8601 timestamp of when this notification was emitted. */
   emittedAt: string;
   /** The cursor value that was expired or lost, if applicable. */
@@ -565,6 +572,15 @@ export type CoreConfig = {
   abiRegistry?: AbiRegistryClientLike | false;
   /** Soroban RPC configuration. Ignored when `network` is an array - set `soroban` per source instead. */
   soroban?: SorobanConfig;
+  /** Optional internal event queue tuning. */
+  queue?: {
+    /** High water mark for the internal engine queue. Defaults to 10000. */
+    highWaterMark?: number;
+    /** Low water mark at which backpressure is considered cleared. Defaults to 50% of highWaterMark. */
+    lowWaterMark?: number;
+    /** Backpressure policy: 'pause' | 'drop-oldest' | 'drop-newest'. Defaults to 'pause'. */
+    policy?: "pause" | "drop-oldest" | "drop-newest";
+  };
 };
 
 // Error class for invalid network validation


### PR DESCRIPTION
closes #921 

Bounded-Queue & Backpressure (Pulse Core / Webhooks)

Goal: Prevent unbounded memory growth in EventEngine and webhook delivery under high ledger throughput or slow consumers by adding a bounded in-process queue and clear backpressure semantics.

Background: Horizon/Soroban bursts and slow watcher/consumer handlers can grow internal queues without limits, causing OOMs long after the root cause. Consumers need a safe, documented default plus knobs to tune trade-offs.

Scope (implemented):

Core engine: internal bounded queue, backpressure events, pause/resume behavior.
Public config: queue tuning exposed on CoreConfig.queue.
Docs: architecture guidance and tuning knobs.
Files changed:

Core config & types: index.ts — added CoreConfig.queue, engine.backpressure notification fields.
Engine implementation: EventEngine.ts — added bounded eventQueue, enqueueEvent(), processQueue(), backpressure emission and automatic pause/resume of sources.
Docs: ARCHITECTURE.md — documented high/low water marks, policies, and notifications.
Behavior & API:

Config (new): CoreConfig.queue = { highWaterMark?: number, lowWaterMark?: number, policy?: 'pause'|'drop-oldest'|'drop-newest' }.
Defaults: highWaterMark = 10000, lowWaterMark = 50% of highWaterMark, policy = 'pause'.
When queue length >= highWaterMark:
Emit engine.backpressure to all watchers with { active: true, queued, policy }.
pause policy: engine calls pauseSource('horizon') and pauseSource('soroban') to stop accepting new events untilqueue <= lowWaterMark, then emit engine.backpressure with { active: false } and resume sources.
drop-oldest: drop oldest queued events to accept new ones.
drop-newest: drop incoming event(s) when full.
Event delivery from the queue is processed asynchronously; each routed event is delivered exactly as before (same route() semantics) unless shed by policy.
Observability & Notifications:

New notification: engine.backpressure (watchers receive it).
Payload includes active (bool), queued (number), and policy (string).
Existing lifecycle events (engine.reconnecting, engine.rate_limited, etc.) are unchanged.
Docs & Guidance:

ARCHITECTURE.md updated with rationale, knobs, and policy descriptions and recommended defaults.
Guidance: use pause for correctness-critical consumers; drop-* for best-effort dashboards.
What’s NOT done yet (next work items):

Bounded retry-queue enforcement across adapters / ensure durable retry queues respect a configured cap (task: update RetryQueue.ts adapters).
Load test: add a 10k synthetic-event test that exercises a deliberately slow watcher and asserts memory remains bounded.
Run full typecheck and test suite and fix any fallout from the changes.
Rollout & Migration notes:

Backward-compatible: default behavior is safe (pause) and does not change event shapes.
Consumers that previously relied on unbounded ingestion should test for paused sources and consider drop-* policies if they prefer availability over perfect delivery.
To opt-in or tune, pass queue settings to EventEngine via CoreConfig.
Risks & mitigations:

Risk: pause can delay downstream delivery for correctness-first apps — mitigated by clear notification (engine.backpressure) and tunable watermarks.
Risk: drop-* policies lose events; documented trade-off and intended for non-critical consumers.
Operational: recommend observability on engine.backpressure and queue metric (queued count) to detect tuning needs.