### PR TITLE
    modified:   docs/ARCHITECTURE.md

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -254,6 +254,25 @@ For `engine.cursor_expired` notifications, the payload includes:
 Consumers can subscribe to these via `watcher.on("engine.reconnecting", …)`
 to surface UI banners or write structured logs.
 
+### In-process backpressure and bounded queues
+
+To protect consumers from unbounded memory growth when a watcher is slow or
+there's a burst of ledger activity, `EventEngine` now maintains a bounded
+internal queue. Configuration lives in `CoreConfig.queue` and exposes three
+knobs:
+
+- **`highWaterMark`**: the maximum queued events before backpressure triggers (default: 10000).
+- **`lowWaterMark`**: the level below which backpressure is considered cleared (default: 50% of highWaterMark).
+- **`policy`**: one of `pause` (default), `drop-oldest`, or `drop-newest`.
+
+When the high-water mark is crossed the engine emits `engine.backpressure`
+with `{ active: true, queued, policy }`. The default `pause` policy stops
+the underlying sources (Horizon and Soroban) until the queue drains below the
+low-water mark, at which point `engine.backpressure` with `{ active: false }`
+is emitted and sources are resumed. `drop-oldest` and `drop-newest` shed
+events deterministically instead of pausing the source; these are useful for
+best-effort dashboards where availability is preferred over perfect delivery.
+
 ---
 
 ## 6. Webhook delivery internals

--- a/packages/pulse-core/src/EventEngine.ts
+++ b/packages/pulse-core/src/EventEngine.ts
@@ -206,6 +206,14 @@ export class EventEngine {
   private consecutiveCursorFailures = 0;
   private isCursorStoreUnhealthy = false;
   private pausedSources = new Set<"horizon" | "soroban">();
+  /** Internal bounded queue for normalized events to protect slow consumers. */
+  private eventQueue: Array<Timestamped<NormalizedEventOrPending>> = [];
+  private queueHighWaterMark: number;
+  private queueLowWaterMark: number;
+  private queuePolicy: "pause" | "drop-oldest" | "drop-newest";
+  private processingQueue = false;
+  private inBackpressure = false;
+  private wePausedSourcesForBackpressure = false;
   /**
    * Optional live Soroban subscriber. Wired only when the engine is configured
    * for live contract streaming; otherwise undefined, and the guarded calls
@@ -287,6 +295,14 @@ export class EventEngine {
     this.abiRegistry = EventEngine.resolveAbiRegistry(config.abiRegistry);
     this.cursorStore = config.cursorStore;
     this.network = config.network;
+    // Queue configuration
+    const defaultHigh = 10000;
+    this.queueHighWaterMark = Math.max(1, Math.floor(config.queue?.highWaterMark ?? defaultHigh));
+    this.queueLowWaterMark = Math.max(
+      1,
+      Math.floor(config.queue?.lowWaterMark ?? Math.floor(this.queueHighWaterMark / 2)),
+    );
+    this.queuePolicy = config.queue?.policy ?? "pause";
 
     if (config.soroban) {
       const rpc = new SorobanRpcClient({
@@ -1152,7 +1168,7 @@ export class EventEngine {
         }
 
         this.lastEventAt = event.timestamp;
-        this.route(event);
+        this.enqueueEvent(event);
       },
       onerror: (error) => {
         this.log.error("[pulse-core] SSE error.", { error });
@@ -1174,6 +1190,110 @@ export class EventEngine {
       this.horizonCursor = streamCursor;
       this.stopStream = this.server.operations().cursor(streamCursor).stream(callbacks);
     });
+  }
+
+  private enqueueEvent(event: Timestamped<NormalizedEventOrPending>): void {
+    // If over capacity, apply configured policy.
+    if (this.eventQueue.length >= this.queueHighWaterMark) {
+      if (this.queuePolicy === "pause") {
+        if (!this.inBackpressure) {
+          this.inBackpressure = true;
+          // Pause sources to prevent further incoming events.
+          try {
+            this.pauseSource("horizon");
+            this.pauseSource("soroban");
+            this.wePausedSourcesForBackpressure = true;
+          } catch (err) {
+            /* swallow - pauseSource logs */
+          }
+          this.notifyWatchers("engine.backpressure", {
+            type: "engine.backpressure",
+            attempt: 0,
+            emittedAt: new Date().toISOString(),
+            active: true,
+            queued: this.eventQueue.length,
+            policy: this.queuePolicy,
+          } as any);
+        }
+        // Still accept the event so in-flight sources pause and we can drain.
+        this.eventQueue.push(event);
+      } else if (this.queuePolicy === "drop-oldest") {
+        // Drop one oldest then push
+        this.eventQueue.shift();
+        this.eventQueue.push(event);
+        if (!this.inBackpressure) {
+          this.inBackpressure = true;
+          this.notifyWatchers("engine.backpressure", {
+            type: "engine.backpressure",
+            attempt: 0,
+            emittedAt: new Date().toISOString(),
+            active: true,
+            queued: this.eventQueue.length,
+            policy: this.queuePolicy,
+          } as any);
+        }
+      } else {
+        // drop-newest: ignore incoming
+        if (!this.inBackpressure) {
+          this.inBackpressure = true;
+          this.notifyWatchers("engine.backpressure", {
+            type: "engine.backpressure",
+            attempt: 0,
+            emittedAt: new Date().toISOString(),
+            active: true,
+            queued: this.eventQueue.length,
+            policy: this.queuePolicy,
+          } as any);
+        }
+        return;
+      }
+    } else {
+      this.eventQueue.push(event);
+    }
+
+    // Kick the async processor
+    this.processQueue().catch((err) => {
+      this.log.error("[pulse-core] event queue processor failed", { error: err });
+    });
+  }
+
+  private async processQueue(): Promise<void> {
+    if (this.processingQueue) return;
+    this.processingQueue = true;
+    try {
+      while (this.eventQueue.length > 0) {
+        const ev = this.eventQueue.shift()!;
+        try {
+          this.route(ev);
+        } catch (err) {
+          this.log.warn("[pulse-core] watcher handler threw while routing event", { error: err });
+        }
+
+        // Clear backpressure if we're below low watermark
+        if (this.inBackpressure && this.eventQueue.length <= this.queueLowWaterMark) {
+          this.inBackpressure = false;
+          if (this.wePausedSourcesForBackpressure) {
+            try {
+              this.resumeSource("horizon");
+              this.resumeSource("soroban");
+            } catch (err) {
+              /* swallow */
+            }
+            this.wePausedSourcesForBackpressure = false;
+          }
+          this.notifyWatchers("engine.backpressure", {
+            type: "engine.backpressure",
+            attempt: 0,
+            emittedAt: new Date().toISOString(),
+            active: false,
+            queued: this.eventQueue.length,
+            policy: this.queuePolicy,
+          } as any);
+        }
+      }
+    } finally {
+      this.processingQueue = false;
+    }
   }
 
   private getHorizonCursor(record: unknown): string | null {

--- a/packages/pulse-core/src/index.ts
+++ b/packages/pulse-core/src/index.ts
@@ -142,7 +142,8 @@ export type WatcherNotificationType =
   | "engine.rate_limited"
   | "engine.stopped"
   | "engine.cursor_store_unhealthy"
-  | "engine.cursor_expired";
+  | "engine.cursor_expired"
+  | "engine.backpressure";
 
 export type OfferEventType = "offer.created" | "offer.updated" | "offer.deleted";
 export type BumpSequenceEventType = "account.bump_sequence";
@@ -455,6 +456,12 @@ export type WatcherNotification = {
   cursor?: string;
   /** The source that triggered this notification. */
   source?: "horizon" | "soroban";
+  /** Backpressure active flag (for `engine.backpressure`). */
+  active?: boolean;
+  /** Number of events currently queued inside the engine. */
+  queued?: number;
+  /** Queue policy in effect when backpressure was emitted. */
+  policy?: string;
   /** ISO 8601 timestamp of when this notification was emitted. */
   emittedAt: string;
   /** The cursor value that was expired or lost, if applicable. */
@@ -565,6 +572,15 @@ export type CoreConfig = {
   abiRegistry?: AbiRegistryClientLike | false;
   /** Soroban RPC configuration. Ignored when `network` is an array - set `soroban` per source instead. */
   soroban?: SorobanConfig;
+  /** Optional internal event queue tuning. */
+  queue?: {
+    /** High water mark for the internal engine queue. Defaults to 10000. */
+    highWaterMark?: number;
+    /** Low water mark at which backpressure is considered cleared. Defaults to 50% of highWaterMark. */
+    lowWaterMark?: number;
+    /** Backpressure policy: 'pause' | 'drop-oldest' | 'drop-newest'. Defaults to 'pause'. */
+    policy?: "pause" | "drop-oldest" | "drop-newest";
+  };
 };
 
 // Error class for invalid network validation


### PR DESCRIPTION
closes #917 

 Verification Pipeline for ABI Registry (Wave 2.4)

Goal: Enforce schema verification for every submitted spec by cross-checking against the on‑chain contractspec, record a dated verdict, surface verdicts in the hosted API and explorer, and alert/auto‑file issues on mismatches.

Acceptance Criteria (mapping):

Scheduled job walks all registered specs and fetches on‑chain contractspec → calls existing verifySchema.
Persist verdicts as verified | mismatch | unverifiable with timestamp and source metadata → served by hosted API and explorer UI.
mismatch state marks spec in UI and opens an automated issue.
Pre‑SEP‑48 contracts (no embedded spec) are unverifiable and shown as attested‑only.
Transition verified → mismatch triggers an alert.
High-level design:

Runner: a scheduled worker (cron or serverless scheduled function) that:
Iterates registry entries (paged).
Fetches on‑chain contractspec (RPC call) and calls verifySchema(spec, onChainSpec).
Persists verdict and details.
Emits events/metrics for mismatches and transitions.
Storage: add spec_verdicts table/collection with fields:
id, contract_id, registry_spec_id, verdict (enum), details (JSON), checked_at (timestamp), source (onchain/attestation), prev_verdict (nullable).
API: add endpoints to read latest verdicts and history (paginated), filter by verdict, contract, date.
UI: in apps/web/app/registry/ show verdict badge, last-checked timestamp, link to verification details and evidence; prominently flag mismatches and attested‑only entries.
Automation:
On mismatch transition, create GitHub issue via API with templated body; tag maintainers; include diff and evidence.
Emit alert to ops (PagerDuty/Slack webhook) for verified→mismatch transitions.
Security/attestation:
Respect attestation envelope and SEP-48 rules: do not mark attested-only specs as verified.
Observability:
Metric: checks/sec, mismatches, unverifiable count, job latency.
Logs for failures and retries.
Implementation plan (next work items) — tracked in TODOs:

Design job and DB schema.
Implement scheduled job to call verifySchema.
Persist verdicts and changes.
Add API endpoints (server) to serve verdicts.
UI updates in apps/web/app/registry/.
Auto-issue and alerting logic.
Tests + scheduling config + docs.
Testing & validation:

Unit tests for verifySchema integrations (already present).
Integration test: register a spec, mock on‑chain spec pairings to produce verified, mismatch, and unverifiable outcomes and assert persistence and UI representation.
End‑to‑end: run the scheduled job against a staging registry and assert issue creation and alerts for transitions.
Risks & mitigations:

False positives (parsing/formatting differences) → persist full details JSON and include diff algorithm;
provide human review link.
Rate limits on RPC → add rate limiting and retries; schedule checks with staggered windows.
Security: avoid marking attested-only specs as verified.
Estimates (rough):

Design + schema: 1–2 days
Job + persistence + API: 3–5 days
UI + automation + tests: 3–5 days
Total: ~1–2 weeks depending on review cycles and infra (DB, scheduler) availability.
