### PR TITLE
feat(abi-registry): add entity label schema, resolver, and seed data (#910)

### DIFF
--- a/data/labels/aqua.json
+++ b/data/labels/aqua.json
@@ -1,0 +1,15 @@
+{
+  "schemaVersion": "1.0.0",
+  "contractId": "CAUIKL3IYGMERDRUN5QQVPKPLZTRNVXV27LFCWQIRNOHSNGB3ZXAEFBX",
+  "label": "Aquarius DAO (AQUA Issuer)",
+  "entityType": "issuer",
+  "confidence": 1.0,
+  "sources": [
+    "https://aqua.network",
+    "https://stellar.expert/explorer/public/contract/CAUIKL3IYGMERDRUN5QQVPKPLZTRNVXV27LFCWQIRNOHSNGB3ZXAEFBX",
+    "https://docs.aqua.network/developers/code-examples/prerequisites-and-basics"
+  ],
+  "verifiedAt": "2025-02-01T00:00:00.000Z",
+  "submittedBy": "orbital-maintainers",
+  "notes": "AQUA is the governance and liquidity incentive token of the Aquarius protocol on Stellar mainnet. The admin account is controlled by the Aquarius DAO."
+}

--- a/data/labels/circle-eurc.json
+++ b/data/labels/circle-eurc.json
@@ -1,0 +1,14 @@
+{
+  "schemaVersion": "1.0.0",
+  "contractId": "CDTKPWPLOURQA2SGTKTUQOWRCBZEORB4BWBOMJ3D3ZTQQSGE5F6JBQLV",
+  "label": "Circle (EURC Issuer)",
+  "entityType": "issuer",
+  "confidence": 1.0,
+  "sources": [
+    "https://developers.circle.com/stablecoins/eurc-contract-addresses",
+    "https://stellar.expert/explorer/public/contract/CDTKPWPLOURQA2SGTKTUQOWRCBZEORB4BWBOMJ3D3ZTQQSGE5F6JBQLV"
+  ],
+  "verifiedAt": "2025-01-15T00:00:00.000Z",
+  "submittedBy": "orbital-maintainers",
+  "notes": "EURC is Circle's EUR-backed stablecoin on Stellar mainnet, deployed as a Stellar Asset Contract (SAC). MiCA-compliant since September 2023."
+}

--- a/data/labels/circle-usdc.json
+++ b/data/labels/circle-usdc.json
@@ -1,0 +1,14 @@
+{
+  "schemaVersion": "1.0.0",
+  "contractId": "CCW67TSZV3SSS2HXMBQ5JFGCKJNXKZM7UQUWUZPUTHXSTZLEO7SJMI75",
+  "label": "Circle (USDC Issuer)",
+  "entityType": "issuer",
+  "confidence": 1.0,
+  "sources": [
+    "https://developers.circle.com/stablecoins/usdc-contract-addresses",
+    "https://stellar.expert/explorer/public/contract/CCW67TSZV3SSS2HXMBQ5JFGCKJNXKZM7UQUWUZPUTHXSTZLEO7SJMI75"
+  ],
+  "verifiedAt": "2025-01-15T00:00:00.000Z",
+  "submittedBy": "orbital-maintainers",
+  "notes": "USDC is Circle's USD-backed stablecoin on Stellar mainnet, deployed as a Stellar Asset Contract (SAC). The admin account is controlled by Circle."
+}

--- a/data/labels/index.json
+++ b/data/labels/index.json
@@ -1,0 +1,41 @@
+{
+  "schemaVersion": "1.0.0",
+  "labels": [
+    {
+      "contractId": "CCW67TSZV3SSS2HXMBQ5JFGCKJNXKZM7UQUWUZPUTHXSTZLEO7SJMI75",
+      "label": "Circle (USDC Issuer)",
+      "entityType": "issuer",
+      "file": "circle-usdc.json"
+    },
+    {
+      "contractId": "CDTKPWPLOURQA2SGTKTUQOWRCBZEORB4BWBOMJ3D3ZTQQSGE5F6JBQLV",
+      "label": "Circle (EURC Issuer)",
+      "entityType": "issuer",
+      "file": "circle-eurc.json"
+    },
+    {
+      "contractId": "CAUIKL3IYGMERDRUN5QQVPKPLZTRNVXV27LFCWQIRNOHSNGB3ZXAEFBX",
+      "label": "Aquarius DAO (AQUA Issuer)",
+      "entityType": "issuer",
+      "file": "aqua.json"
+    },
+    {
+      "contractId": "CAS3J7GYLGXMF6TDJBBYYSE3HQ6BBSMLNUQ34T6TZMYMW2EVH34XOWMA",
+      "label": "Stellar Native (XLM SAC)",
+      "entityType": "issuer",
+      "file": "xlm-native.json"
+    },
+    {
+      "contractId": "CCB6TKA2DJJBWNOD72VFG5FJIBX3ZRAJ7X43SF7XPI46SPXMX5OYNKRG",
+      "label": "Soroswap Router",
+      "entityType": "protocol",
+      "file": "soroswap-router.json"
+    },
+    {
+      "contractId": "CDFB27PIVZ4XMGD2QT6W3PZ2GFLEZ34QPRS3OJKFIZH2BLOJGGFAHKKM",
+      "label": "Phoenix Pool Factory",
+      "entityType": "protocol",
+      "file": "phoenix-pool-factory.json"
+    }
+  ]
+}

--- a/data/labels/phoenix-pool-factory.json
+++ b/data/labels/phoenix-pool-factory.json
@@ -1,0 +1,14 @@
+{
+  "schemaVersion": "1.0.0",
+  "contractId": "CDFB27PIVZ4XMGD2QT6W3PZ2GFLEZ34QPRS3OJKFIZH2BLOJGGFAHKKM",
+  "label": "Phoenix Pool Factory",
+  "entityType": "protocol",
+  "confidence": 0.9,
+  "sources": [
+    "https://phoenix-lab.gitbook.io/phoenix-protocol",
+    "https://stellar.expert/explorer/public/contract/CDFB27PIVZ4XMGD2QT6W3PZ2GFLEZ34QPRS3OJKFIZH2BLOJGGFAHKKM"
+  ],
+  "verifiedAt": "2025-03-15T00:00:00.000Z",
+  "submittedBy": "orbital-maintainers",
+  "notes": "Phoenix is a concentrated liquidity AMM and lending protocol on Soroban. The pool factory deploys individual liquidity pool contracts. Confidence 0.9 pending on-chain admin verification."
+}

--- a/data/labels/soroswap-router.json
+++ b/data/labels/soroswap-router.json
@@ -1,0 +1,15 @@
+{
+  "schemaVersion": "1.0.0",
+  "contractId": "CCB6TKA2DJJBWNOD72VFG5FJIBX3ZRAJ7X43SF7XPI46SPXMX5OYNKRG",
+  "label": "Soroswap Router",
+  "entityType": "protocol",
+  "confidence": 0.9,
+  "sources": [
+    "https://soroswap.finance",
+    "https://github.com/soroswap/core",
+    "https://stellar.expert/explorer/public/contract/CCB6TKA2DJJBWNOD72VFG5FJIBX3ZRAJ7X43SF7XPI46SPXMX5OYNKRG"
+  ],
+  "verifiedAt": "2025-03-10T00:00:00.000Z",
+  "submittedBy": "orbital-maintainers",
+  "notes": "Soroswap is the leading automated market maker (AMM) DEX on Soroban. The router contract facilitates token swaps and liquidity management. Confidence 0.9 pending on-chain admin verification."
+}

--- a/data/labels/xlm-native.json
+++ b/data/labels/xlm-native.json
@@ -1,0 +1,14 @@
+{
+  "schemaVersion": "1.0.0",
+  "contractId": "CAS3J7GYLGXMF6TDJBBYYSE3HQ6BBSMLNUQ34T6TZMYMW2EVH34XOWMA",
+  "label": "Stellar Native (XLM SAC)",
+  "entityType": "issuer",
+  "confidence": 1.0,
+  "sources": [
+    "https://developers.stellar.org/docs/learn/fundamentals/stellar-native-asset",
+    "https://stellar.expert/explorer/public/contract/CAS3J7GYLGXMF6TDJBBYYSE3HQ6BBSMLNUQ34T6TZMYMW2EVH34XOWMA"
+  ],
+  "verifiedAt": "2025-02-01T00:00:00.000Z",
+  "submittedBy": "orbital-maintainers",
+  "notes": "The Stellar Asset Contract (SAC) wrapping the native XLM asset. The Stellar network itself is the 'issuer' of XLM."
+}

--- a/packages/abi-registry/schemas/label.schema.json
+++ b/packages/abi-registry/schemas/label.schema.json
@@ -1,0 +1,79 @@
+{
+  "title": "OrbitalEntityLabel",
+  "description": "Schema for a single entity label record in the Orbital ABI Registry. Labels attach human-readable identity to otherwise opaque contract addresses — \"this is Soroswap's router\", \"this issuer is Circle\" — making event streams readable. Labels are advisory metadata, never load-bearing for correctness.",
+  "type": "object",
+  "required": [
+    "schemaVersion",
+    "contractId",
+    "label",
+    "entityType",
+    "confidence",
+    "sources",
+    "verifiedAt",
+    "submittedBy"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "schemaVersion": {
+      "type": "string",
+      "description": "Schema revision this record conforms to, in MAJOR.MINOR.PATCH semver format.",
+      "pattern": "^\\d+\\.\\d+\\.\\d+$"
+    },
+    "contractId": {
+      "type": "string",
+      "description": "Canonical mainnet Soroban contract address (C-prefixed strkey, 56 characters) that this label describes.",
+      "pattern": "^C[A-Z2-7]{55}$"
+    },
+    "label": {
+      "type": "string",
+      "description": "Human-readable entity name (e.g. 'Circle', 'Soroswap Router', 'Aquarius DAO').",
+      "minLength": 1,
+      "maxLength": 120
+    },
+    "entityType": {
+      "type": "string",
+      "description": "Classification of what the labeled address represents. 'protocol' for a smart-contract protocol (DEX, lending market, etc.), 'issuer' for a token issuer (Circle, Aquarius DAO, etc.), 'deployer' for the account that deployed the contract, 'bridge' for a cross-chain bridge contract, 'unknown' when the type is not yet determined.",
+      "enum": ["protocol", "issuer", "deployer", "bridge", "unknown"]
+    },
+    "confidence": {
+      "type": "number",
+      "description": "Certainty of this label attribution, expressed as a floating-point value between 0.0 (no confidence) and 1.0 (verified). Values: 1.0 = verified on-chain or via signed attestation, 0.9 = confirmed via multiple independent off-chain sources, 0.7 = single authoritative source, 0.5 = community consensus with partial evidence, 0.3 = heuristic inference.",
+      "minimum": 0.0,
+      "maximum": 1.0
+    },
+    "sources": {
+      "type": "array",
+      "description": "Verifiable source URLs supporting this label attribution. At least one entry is required — CI rejects any record without a verifiable source URL.",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "description": "URL pointing to evidence for this label (e.g. official project documentation, explorer link, signed attestation, or published audit).",
+        "minLength": 1,
+        "maxLength": 2048
+      }
+    },
+    "verifiedAt": {
+      "type": "string",
+      "description": "ISO 8601 UTC timestamp of when this label was last verified against the listed sources.",
+      "minLength": 1,
+      "maxLength": 30
+    },
+    "submittedBy": {
+      "type": "string",
+      "description": "GitHub username or entity identifier of the person or process that submitted this label record.",
+      "minLength": 1,
+      "maxLength": 100
+    },
+    "parentContractId": {
+      "type": "string",
+      "description": "Optional reference to a parent label record. Used when a contract is a sub-deployment of a larger protocol (e.g. a specific pool contract parented by a factory).",
+      "pattern": "^C[A-Z2-7]{55}$"
+    },
+    "notes": {
+      "type": "string",
+      "description": "Optional free-text notes providing context for the attribution, such as how the label was determined or caveats about confidence.",
+      "maxLength": 2000
+    }
+  }
+}

--- a/packages/abi-registry/src/LabelResolver.ts
+++ b/packages/abi-registry/src/LabelResolver.ts
@@ -1,0 +1,243 @@
+/**
+ * Entity Label Resolver for the Orbital ABI Registry.
+ *
+ * Labels attach human-readable identity to opaque contract addresses — making
+ * event streams like `transfer(GB..., GC..., 1000000)` readable as
+ * `transfer(Circle→Alice, 1000000)`.
+ *
+ * Labels are **advisory metadata**, never load-bearing for correctness.
+ * Every consumer that reads labels must gate the resolution behind an opt-in
+ * flag (`enableLabels: true`).
+ *
+ * ## Data layout
+ *
+ * Labels live as one JSON file per entity under `data/labels/` at the repo
+ * root. Each file conforms to `packages/abi-registry/schemas/label.schema.json`.
+ *
+ * ```
+ * data/labels/
+ * ├── circle-usdc.json
+ * ├── circle-eurc.json
+ * ├── aqua.json
+ * ├── soroswap-router.json
+ * └── phoenix-pool-factory.json
+ * ```
+ *
+ * ## Usage
+ *
+ * ```ts
+ * const resolver = new LabelResolver({ enabled: true });
+ *
+ * // Resolve a single contract ID
+ * const label = resolver.resolve(
+ *   "CCW67TSZV3SSS2HXMBQ5JFGCKJNXKZM7UQUWUZPUTHXSTZLEO7SJMI75",
+ * );
+ * // → { label: "Circle (USDC Issuer)", entityType: "issuer", ... }
+ * ```
+ */
+
+import { readFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/**
+ * Classification of what a labeled address represents.
+ * - `protocol`: a smart-contract protocol (DEX, lending market, etc.)
+ * - `issuer`: a token issuer (Circle, Aquarius DAO, etc.)
+ * - `deployer`: the account that deployed the contract
+ * - `bridge`: a cross-chain bridge contract
+ * - `unknown`: type not yet determined
+ */
+export type EntityType = "protocol" | "issuer" | "deployer" | "bridge" | "unknown";
+
+/**
+ * A single entity label record, conforming to `label.schema.json`.
+ */
+export type LabelRecord = {
+  /** Schema revision this record conforms to, in MAJOR.MINOR.PATCH semver. */
+  schemaVersion: string;
+  /** Canonical mainnet Soroban contract address (C-prefixed strkey). */
+  contractId: string;
+  /** Human-readable entity name (e.g. "Circle", "Soroswap Router"). */
+  label: string;
+  /** Classification of what the labeled address represents. */
+  entityType: EntityType;
+  /** Certainty between 0.0 (none) and 1.0 (verified). */
+  confidence: number;
+  /** Verifiable source URLs supporting this attribution. */
+  sources: string[];
+  /** ISO 8601 UTC timestamp of last verification. */
+  verifiedAt: string;
+  /** GitHub username or entity identifier that submitted this record. */
+  submittedBy: string;
+  /** Optional reference to a parent label record. */
+  parentContractId?: string;
+  /** Optional free-text notes providing context. */
+  notes?: string;
+};
+
+/**
+ * Configuration for the label resolver.
+ */
+export type LabelResolverConfig = {
+  /**
+   * Whether label resolution is enabled. When `false`, all label operations
+   * silently return `null` — labels are **advisory** and never load-bearing
+   * for correctness.
+   *
+   * @default false
+   */
+  enabled: boolean;
+};
+
+/**
+ * Resolved label attached to a decoded event or contract address.
+ */
+export type ResolvedLabel = {
+  /** The human-readable label (e.g. "Circle"). */
+  label: string;
+  /** Entity classification type. */
+  entityType: EntityType;
+  /** Confidence of this attribution (0.0–1.0). */
+  confidence: number;
+};
+
+// ---------------------------------------------------------------------------
+// Label directory resolution
+// ---------------------------------------------------------------------------
+
+/** Absolute path to `data/labels/` relative to the repo root. */
+function labelsDir(): string {
+  // Navigate up from `packages/abi-registry/src/LabelResolver.ts` to repo root.
+  const currentDir = dirname(fileURLToPath(import.meta.url));
+  // From `packages/abi-registry/src/` -> `packages/abi-registry/` -> `packages/` -> repo root
+  const repoRoot = resolve(currentDir, "../../..");
+  return resolve(repoRoot, "data/labels");
+}
+
+/** File names in `data/labels/` to load (excludes JSON that aren't label records). */
+const LABEL_FILES = [
+  "circle-usdc.json",
+  "circle-eurc.json",
+  "aqua.json",
+  "xlm-native.json",
+  "soroswap-router.json",
+  "phoenix-pool-factory.json",
+];
+
+// ---------------------------------------------------------------------------
+// Lazy-loaded bundle
+// ---------------------------------------------------------------------------
+
+let cachedByContractId: Map<string, LabelRecord> | null = null;
+
+/**
+ * Load all label records from `data/labels/` into a contractId → LabelRecord map.
+ * Uses module-level lazy caching so repeated resolutions across instances
+ * avoid re-reading disk.
+ */
+function loadLabels(): Map<string, LabelRecord> {
+  if (cachedByContractId) return cachedByContractId;
+
+  const dir = labelsDir();
+  const map = new Map<string, LabelRecord>();
+
+  for (const file of LABEL_FILES) {
+    try {
+      const raw = JSON.parse(readFileSync(resolve(dir, file), "utf-8")) as LabelRecord;
+      if (raw.contractId) {
+        map.set(raw.contractId, raw);
+      }
+    } catch {
+      // Silently skip unreadable or malformed label files — labels are
+      // advisory and a broken file should never crash the consumer.
+    }
+  }
+
+  cachedByContractId = map;
+  return map;
+}
+
+// ---------------------------------------------------------------------------
+// Resolver class
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolves human-readable entity labels for Soroban contract addresses.
+ *
+ * Labels are loaded from the bundled `data/labels/` directory and are purely
+ * advisory — they must never be used for correctness-critical logic. All
+ * label resolution is gated behind an explicit `enabled` flag.
+ *
+ * @example
+ * ```ts
+ * const resolver = new LabelResolver({ enabled: true });
+ *
+ * // Resolve a single contract ID
+ * const label = resolver.resolve("CCW67TSZV3SSS2HXMBQ5JFGCKJNXKZM7UQUWUZPUTHXSTZLEO7SJMI75");
+ * // → { label: "Circle (USDC Issuer)", entityType: "issuer", confidence: 1.0 }
+ *
+ * // Batch resolution
+ * const labels = resolver.resolveAll([usdcId, aquaId, unknownId]);
+ * // → Map { usdcId => { ... }, aquaId => { ... } }
+ * ```
+ */
+export class LabelResolver {
+  private readonly enabled: boolean;
+
+  constructor(config?: LabelResolverConfig) {
+    this.enabled = config?.enabled ?? false;
+  }
+
+  /**
+   * Resolve the label for a single contract address.
+   *
+   * @param contractId - The C-prefixed Soroban contract address.
+   * @returns A resolved label, or `null` if the resolver is disabled or the
+   *   address has no known label.
+   */
+  resolve(contractId: string): ResolvedLabel | null {
+    if (!this.enabled) return null;
+
+    const labels = loadLabels();
+    const record = labels.get(contractId);
+    if (!record) return null;
+
+    return {
+      label: record.label,
+      entityType: record.entityType,
+      confidence: record.confidence,
+    };
+  }
+
+  /**
+   * Resolve labels for multiple contract addresses in a single call.
+   *
+   * @param contractIds - Array of C-prefixed Soroban contract addresses.
+   * @returns A map of contract ID → resolved label (only entries with known
+   *   labels are included).
+   */
+  resolveAll(contractIds: string[]): Map<string, ResolvedLabel> {
+    const result = new Map<string, ResolvedLabel>();
+
+    if (!this.enabled) return result;
+
+    const labels = loadLabels();
+    for (const id of contractIds) {
+      const record = labels.get(id);
+      if (record) {
+        result.set(id, {
+          label: record.label,
+          entityType: record.entityType,
+          confidence: record.confidence,
+        });
+      }
+    }
+
+    return result;
+  }
+}

--- a/packages/abi-registry/src/index.ts
+++ b/packages/abi-registry/src/index.ts
@@ -69,3 +69,11 @@ export type {
   SchemaFieldDiff,
   VerifySchemaOptions,
 } from "./verifySchema.js";
+
+export { LabelResolver } from "./LabelResolver.js";
+export type {
+  LabelRecord,
+  LabelResolverConfig,
+  ResolvedLabel,
+  EntityType,
+} from "./LabelResolver.js";

--- a/packages/abi-registry/test/LabelResolver.test.ts
+++ b/packages/abi-registry/test/LabelResolver.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from "vitest";
+import { LabelResolver } from "../src/LabelResolver.js";
+
+const USDC_ID = "CCW67TSZV3SSS2HXMBQ5JFGCKJNXKZM7UQUWUZPUTHXSTZLEO7SJMI75";
+const EURC_ID = "CDTKPWPLOURQA2SGTKTUQOWRCBZEORB4BWBOMJ3D3ZTQQSGE5F6JBQLV";
+const AQUA_ID = "CAUIKL3IYGMERDRUN5QQVPKPLZTRNVXV27LFCWQIRNOHSNGB3ZXAEFBX";
+const UNKNOWN_ID = "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM";
+
+describe("LabelResolver", () => {
+  describe("when enabled", () => {
+    const resolver = new LabelResolver({ enabled: true });
+
+    it("resolves USDC contract to Circle issuer label", () => {
+      const label = resolver.resolve(USDC_ID);
+      expect(label).not.toBeNull();
+      expect(label!.label).toBe("Circle (USDC Issuer)");
+      expect(label!.entityType).toBe("issuer");
+      expect(label!.confidence).toBe(1.0);
+    });
+
+    it("resolves EURC contract to Circle issuer label", () => {
+      const label = resolver.resolve(EURC_ID);
+      expect(label).not.toBeNull();
+      expect(label!.label).toBe("Circle (EURC Issuer)");
+      expect(label!.entityType).toBe("issuer");
+      expect(label!.confidence).toBe(1.0);
+    });
+
+    it("resolves AQUA contract to Aquarius issuer label", () => {
+      const label = resolver.resolve(AQUA_ID);
+      expect(label).not.toBeNull();
+      expect(label!.label).toBe("Aquarius DAO (AQUA Issuer)");
+      expect(label!.entityType).toBe("issuer");
+      expect(label!.confidence).toBe(1.0);
+    });
+
+    it("returns null for an unknown contract ID", () => {
+      expect(resolver.resolve(UNKNOWN_ID)).toBeNull();
+    });
+
+    it("returns null for a malformed contract ID", () => {
+      expect(resolver.resolve("not-a-valid-contract-id")).toBeNull();
+    });
+
+    it("resolves multiple contract IDs via resolveAll", () => {
+      const labels = resolver.resolveAll([USDC_ID, EURC_ID, UNKNOWN_ID]);
+      expect(labels.size).toBe(2);
+      expect(labels.get(USDC_ID)?.label).toBe("Circle (USDC Issuer)");
+      expect(labels.get(EURC_ID)?.label).toBe("Circle (EURC Issuer)");
+      expect(labels.has(UNKNOWN_ID)).toBe(false);
+    });
+
+    it("caches label records across instances (module-level memo)", () => {
+      const resolverA = new LabelResolver({ enabled: true });
+      const resolverB = new LabelResolver({ enabled: true });
+      const labelA1 = resolverA.resolve(USDC_ID);
+      const labelA2 = resolverA.resolve(USDC_ID);
+      const labelB = resolverB.resolve(USDC_ID);
+      // ResolvedLabel objects are created fresh each call, but values match
+      expect(labelA1).toStrictEqual(labelA2);
+      expect(labelA1).toStrictEqual(labelB);
+    });
+  });
+
+  describe("when disabled (default)", () => {
+    const resolver = new LabelResolver();
+
+    it("returns null for any contract ID", () => {
+      expect(resolver.resolve(USDC_ID)).toBeNull();
+      expect(resolver.resolve(UNKNOWN_ID)).toBeNull();
+    });
+
+    it("returns empty map for resolveAll", () => {
+      const labels = resolver.resolveAll([USDC_ID, EURC_ID]);
+      expect(labels.size).toBe(0);
+    });
+  });
+
+  describe("when explicitly disabled", () => {
+    const resolver = new LabelResolver({ enabled: false });
+
+    it("returns null for any contract ID", () => {
+      expect(resolver.resolve(USDC_ID)).toBeNull();
+    });
+
+    it("returns empty map for resolveAll", () => {
+      const labels = resolver.resolveAll([USDC_ID, EURC_ID]);
+      expect(labels.size).toBe(0);
+    });
+  });
+});

--- a/packages/abi-registry/validate.js
+++ b/packages/abi-registry/validate.js
@@ -1,12 +1,13 @@
 /**
- * validate.js - Validates all well-known ABI spec files against schema.json.
+ * validate.js - Validates all well-known ABI spec files against schema.json
+ * and all label files in data/labels/ against label.schema.json.
  *
  * Usage:
  *   node validate.js
  *
  * Exit codes:
- *   0  All specs pass validation.
- *   1  One or more specs fail validation, or a file cannot be read/parsed.
+ *   0  All specs and labels pass validation.
+ *   1  One or more specs or labels fail validation, or a file cannot be read/parsed.
  */
 
 import { readFileSync, readdirSync } from "node:fs";
@@ -16,40 +17,42 @@ import Ajv from "ajv";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
+// ── Spec validation ──────────────────────────────────────────────────────────
+
 const SCHEMA_PATH = resolve(__dirname, "specs/well-known/schema.json");
 const SPECS_DIR = resolve(__dirname, "specs/well-known");
 
 // Files that are not contract specs and should be skipped.
-const SKIP = new Set(["schema.json", "index.json"]);
+const SPEC_SKIP = new Set(["schema.json", "index.json"]);
 
 // ---------------------------------------------------------------------------
-// Load schema
+// Load spec schema
 // ---------------------------------------------------------------------------
-let schema;
+let specSchema;
 try {
-  schema = JSON.parse(readFileSync(SCHEMA_PATH, "utf8"));
+  specSchema = JSON.parse(readFileSync(SCHEMA_PATH, "utf8"));
 } catch (err) {
-  process.stderr.write(`[validate] Cannot read schema: ${SCHEMA_PATH}\n  ${err.message}\n`);
+  process.stderr.write(`[validate] Cannot read spec schema: ${SCHEMA_PATH}\n  ${err.message}\n`);
   process.exit(1);
 }
 
 const ajv = new Ajv({ allErrors: true });
-const validate = ajv.compile(schema);
+const validateSpec = ajv.compile(specSchema);
 
 // ---------------------------------------------------------------------------
 // Discover spec files
 // ---------------------------------------------------------------------------
-let files;
+let specFiles;
 try {
-  files = readdirSync(SPECS_DIR)
-    .filter((f) => f.endsWith(".json") && !SKIP.has(f))
+  specFiles = readdirSync(SPECS_DIR)
+    .filter((f) => f.endsWith(".json") && !SPEC_SKIP.has(f))
     .sort();
 } catch (err) {
   process.stderr.write(`[validate] Cannot read specs directory: ${SPECS_DIR}\n  ${err.message}\n`);
   process.exit(1);
 }
 
-if (files.length === 0) {
+if (specFiles.length === 0) {
   process.stderr.write(`[validate] No spec files found in ${SPECS_DIR}\n`);
   process.exit(1);
 }
@@ -57,41 +60,124 @@ if (files.length === 0) {
 // ---------------------------------------------------------------------------
 // Validate each spec
 // ---------------------------------------------------------------------------
-let passed = 0;
-let failed = 0;
+let specPassed = 0;
+let specFailed = 0;
 
-for (const file of files) {
+for (const file of specFiles) {
   const filePath = join(SPECS_DIR, file);
   let data;
 
   try {
     data = JSON.parse(readFileSync(filePath, "utf8"));
   } catch (err) {
-    process.stderr.write(`[validate] FAIL  ${file}\n  Parse error: ${err.message}\n`);
-    failed++;
+    process.stderr.write(`[validate/spec] FAIL  ${file}\n  Parse error: ${err.message}\n`);
+    specFailed++;
     continue;
   }
 
-  const valid = validate(data);
+  const valid = validateSpec(data);
 
   if (valid) {
-    process.stdout.write(`[validate] PASS  ${file}\n`);
-    passed++;
+    process.stdout.write(`[validate/spec] PASS  ${file}\n`);
+    specPassed++;
   } else {
-    process.stderr.write(`[validate] FAIL  ${file}\n`);
-    for (const error of validate.errors) {
+    process.stderr.write(`[validate/spec] FAIL  ${file}\n`);
+    for (const error of validateSpec.errors) {
       const field = error.instancePath || "(root)";
       process.stderr.write(`  ${field}: ${error.message}\n`);
     }
-    failed++;
+    specFailed++;
+  }
+}
+
+// ── Label validation ─────────────────────────────────────────────────────────
+
+const LABEL_SCHEMA_PATH = resolve(__dirname, "schemas/label.schema.json");
+const LABELS_DIR = resolve(__dirname, "../../data/labels");
+
+// Files that are not label records and should be skipped.
+const LABEL_SKIP = new Set(["index.json"]);
+
+// ---------------------------------------------------------------------------
+// Load label schema
+// ---------------------------------------------------------------------------
+let labelSchema;
+try {
+  labelSchema = JSON.parse(readFileSync(LABEL_SCHEMA_PATH, "utf8"));
+} catch (err) {
+  process.stderr.write(`[validate/label] Cannot read label schema: ${LABEL_SCHEMA_PATH}\n  ${err.message}\n`);
+  process.exit(1);
+}
+
+const validateLabel = ajv.compile(labelSchema);
+
+// ---------------------------------------------------------------------------
+// Discover label files
+// ---------------------------------------------------------------------------
+let labelFiles;
+try {
+  labelFiles = readdirSync(LABELS_DIR)
+    .filter((f) => f.endsWith(".json") && !LABEL_SKIP.has(f))
+    .sort();
+} catch (err) {
+  process.stderr.write(`[validate/label] Cannot read labels directory: ${LABELS_DIR}\n  ${err.message}\n`);
+  process.exit(1);
+}
+
+if (labelFiles.length === 0) {
+  process.stderr.write(`[validate/label] No label files found in ${LABELS_DIR}\n`);
+  process.exit(1);
+}
+
+// ---------------------------------------------------------------------------
+// Validate each label
+// ---------------------------------------------------------------------------
+let labelPassed = 0;
+let labelFailed = 0;
+
+for (const file of labelFiles) {
+  const filePath = join(LABELS_DIR, file);
+  let data;
+
+  try {
+    data = JSON.parse(readFileSync(filePath, "utf8"));
+  } catch (err) {
+    process.stderr.write(`[validate/label] FAIL  ${file}\n  Parse error: ${err.message}\n`);
+    labelFailed++;
+    continue;
+  }
+
+  const valid = validateLabel(data);
+
+  if (valid) {
+    // Extra check: at least one verifiable source URL (CI requirement)
+    if (!Array.isArray(data.sources) || data.sources.length === 0) {
+      process.stderr.write(`[validate/label] FAIL  ${file}\n  sources: must have at least one verifiable source URL\n`);
+      labelFailed++;
+      continue;
+    }
+
+    process.stdout.write(`[validate/label] PASS  ${file}\n`);
+    labelPassed++;
+  } else {
+    process.stderr.write(`[validate/label] FAIL  ${file}\n`);
+    for (const error of validateLabel.errors) {
+      const field = error.instancePath || "(root)";
+      process.stderr.write(`  ${field}: ${error.message}\n`);
+    }
+    labelFailed++;
   }
 }
 
 // ---------------------------------------------------------------------------
 // Summary
 // ---------------------------------------------------------------------------
-process.stdout.write(`\n[validate] ${passed} passed, ${failed} failed (${files.length} total)\n`);
+const totalPassed = specPassed + labelPassed;
+const totalFailed = specFailed + labelFailed;
+const totalFiles = specFiles.length + labelFiles.length;
 
-if (failed > 0) {
+process.stdout.write(`\n[validate] ${specPassed}/${specFiles.length} specs passed, ${labelPassed}/${labelFiles.length} labels passed (${totalPassed} passed, ${totalFailed} failed overall)\n`);
+
+if (totalFailed > 0) {
   process.exit(1);
 }


### PR DESCRIPTION
## Summary

Implements Wave 2.3 entity labels for the ABI Registry (issue #910). Adds entity attribution — human-readable identity for opaque contract addresses — making decoded event streams like `transfer(GB..., GC..., 1000000)` readable as `transfer(Circle → Alice, 1000000)`.

## Changes

### New files
- `packages/abi-registry/schemas/label.schema.json` — JSON Schema for entity label records (contractId, label, entityType, confidence, sources, verifiedAt, submittedBy)
- `packages/abi-registry/src/LabelResolver.ts` — Label resolver class with opt-in flag (`enabled: true`); loads labels from `data/labels/` and resolves by contract ID
- `packages/abi-registry/test/LabelResolver.test.ts` — 11 tests covering enabled/disabled states, known/unknown IDs, batch resolution, and module-level caching
- `data/labels/*.json` — 6 seed label records:
  - `circle-usdc.json` (Circle as USDC issuer, confidence 1.0)
  - `circle-eurc.json` (Circle as EURC issuer, confidence 1.0)
  - `aqua.json` (Aquarius DAO as AQUA issuer, confidence 1.0)
  - `xlm-native.json` (Stellar Native XLM, confidence 1.0)
  - `soroswap-router.json` (Soroswap Router protocol, confidence 0.9)
  - `phoenix-pool-factory.json` (Phoenix Pool Factory, confidence 0.9)
- `data/labels/index.json` — Machine-readable index of all label records

### Modified files
- `packages/abi-registry/src/index.ts` — Exports `LabelResolver` class and types (`LabelRecord`, `LabelResolverConfig`, `ResolvedLabel`, `EntityType`)
- `packages/abi-registry/validate.js` — Extended to validate label files against `label.schema.json` with explicit check for `sources.length >= 1` (CI requirement)

## Design decisions
- Labels follow the same JSON Schema conventions as `specs/well-known/schema.json` (title, description, type, required, additionalProperties: false)
- `LabelResolver` uses module-level lazy caching (same pattern as `BundledWellKnownClient`)
- Labels are purely advisory — all resolution is gated behind an explicit `enabled: true` flag, and the resolver silently returns `null` when disabled
- CI validation rejects any label record without at least one verifiable source URL

## Verification
- Typecheck: `tsc --noEmit` passes
- Tests: 219/219 pass (11 new LabelResolver tests)
- Validation: 5/5 specs + 6/6 labels pass

close #910