### PR TITLE
fix(ci): re-baseline abi-registry functions coverage floor

### DIFF
--- a/packages/abi-registry/vitest.config.ts
+++ b/packages/abi-registry/vitest.config.ts
@@ -18,10 +18,13 @@ export default defineConfig({
         // Pure type declarations — no runtime code to cover
         "src/types.ts",
       ],
+      // Functions re-baselined from 87 to 80: #937, #940, #947 and #960 landed
+      // between #923 measuring the baseline and #923 merging, adding exported
+      // helpers faster than tests reached them (measured 85.42%).
       thresholds: {
         statements: 76,
         branches: 66,
-        functions: 87,
+        functions: 80,
         lines: 77,
       },
       reporter: ["text", "html", "json-summary"],


### PR DESCRIPTION
`main` is red on the `coverage` job:

```
packages/abi-registry: All files | 77.1 | 68.97 | 85.42 | 78.11
ERROR: Coverage for functions (85.42%) does not meet global threshold (87%)
```

#923 measured abi-registry at 92.12% functions and set the floor at 87. Between that measurement and #923 merging, #937, #940, #947 and #960 all landed in the same package, adding exported helpers faster than tests reached them. Statements (77.1 vs 76), branches (68.97 vs 66) and lines (78.11 vs 77) still clear their floors; only functions does not.

Lowers the functions floor to 80 - ~5pts under measured, matching the ratchet convention #923 established. Raising it back up is a normal PR, and the natural place is whichever PR adds the missing tests for `ChainedAbiRegistryClient.getResolvedSpec`, the `generate.ts` guard emitters and `watch.ts`.