### PR TITLE
feat(hardening): bundle-size budgets and reconnection chaos tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,6 +147,10 @@ jobs:
           node-version: 20
           cache: pnpm
       - run: pnpm install --frozen-lockfile
+      # pulse-core imports @orbital-stellar/abi-registry, which resolves to its
+      # dist output - the suite cannot load without it built first.
+      - name: Build abi-registry
+        run: pnpm tsc -p packages/abi-registry/tsconfig.json
       # Fixed seed on PRs so a failure here is always reproducible from the
       # branch alone. nightly-chaos.yml runs the same suite with a random seed.
       - name: Reconnection chaos suite (fixed seed)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,7 +124,35 @@ jobs:
       - name: Build pulse-notify
         run: pnpm tsc -p packages/pulse-notify/tsconfig.json
       - name: Check bundle size
+        id: size
         run: pnpm --filter @orbital-stellar/pulse-notify size
+      - name: Explain the budget failure
+        # size-limit prints the size and the delta against the budget; --why
+        # adds the top contributing modules, which is what you actually need to
+        # decide whether a dependency or your own code moved the number.
+        if: failure() && steps.size.outcome == 'failure'
+        run: pnpm --filter @orbital-stellar/pulse-notify run size:why
+
+  chaos-tests:
+    needs: changes
+    if: ${{ needs.changes.outputs.packages == 'true' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v7
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 20
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      # Fixed seed on PRs so a failure here is always reproducible from the
+      # branch alone. nightly-chaos.yml runs the same suite with a random seed.
+      - name: Reconnection chaos suite (fixed seed)
+        env:
+          CHAOS_SEED: "20260802"
+        run: pnpm --filter @orbital-stellar/pulse-core exec vitest run test/chaos
 
   typecheck-web:
     needs: changes

--- a/.github/workflows/nightly-chaos.yml
+++ b/.github/workflows/nightly-chaos.yml
@@ -29,6 +29,10 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile
 
+      # pulse-core imports @orbital-stellar/abi-registry from its dist output.
+      - name: Build abi-registry
+        run: pnpm tsc -p packages/abi-registry/tsconfig.json
+
       - name: Pick a seed
         id: seed
         run: |

--- a/.github/workflows/nightly-chaos.yml
+++ b/.github/workflows/nightly-chaos.yml
@@ -1,0 +1,60 @@
+name: Nightly chaos
+
+# CI runs the reconnection chaos suite with a fixed seed so PR failures are
+# reproducible. This runs the same suite nightly with a random seed to find the
+# faults a single seed never reaches. The seed is printed and included in the
+# job summary, so a red night can be replayed with CHAOS_SEED=<seed>.
+
+on:
+  schedule:
+    - cron: "17 3 * * *"
+  workflow_dispatch:
+    inputs:
+      seed:
+        description: "Replay a specific seed (leave empty for a random one)"
+        required: false
+        type: string
+
+jobs:
+  chaos:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v7
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 20
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+
+      - name: Pick a seed
+        id: seed
+        run: |
+          seed="${{ inputs.seed }}"
+          if [ -z "$seed" ]; then
+            seed=$(( RANDOM * 32768 + RANDOM ))
+          fi
+          echo "seed=$seed" >> "$GITHUB_OUTPUT"
+          echo "Chaos seed: $seed"
+
+      - name: Reconnection chaos suite (random seed)
+        env:
+          CHAOS_SEED: ${{ steps.seed.outputs.seed }}
+        run: pnpm --filter @orbital-stellar/pulse-core exec vitest run test/chaos
+
+      - name: Record the seed in the job summary
+        if: always()
+        run: |
+          {
+            echo "### Reconnection chaos"
+            echo
+            echo "Seed: \`${{ steps.seed.outputs.seed }}\`"
+            echo
+            echo "Replay locally:"
+            echo
+            echo '```bash'
+            echo "CHAOS_SEED=${{ steps.seed.outputs.seed }} pnpm --filter @orbital-stellar/pulse-core exec vitest run test/chaos"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/README.md
+++ b/README.md
@@ -59,6 +59,18 @@ The longer-form thesis, the multi-year vision, and the SCF grant case live in [`
 
 > The full classic-operation taxonomy is shipped (payments, account create/merge/options/bump-sequence, trustlines + auth, offers, claimables, liquidity pools, manage-data), alongside Soroban contract event subscription (`engine.subscribeContract`), cursor persistence, and the ABI registry client - see [`ROADMAP.md`](ROADMAP.md).
 
+### Browser bundle sizes
+
+`@orbital-stellar/pulse-notify` is the only package that ships to the browser. Each entry point carries an enforced budget - CI fails on a regression and prints the top contributing modules. `react` and `react-dom` are peer dependencies and excluded.
+
+| Entry point | Minified | Minified + gzip | Budget (gzip) |
+|---|---|---|---|
+| `@orbital-stellar/pulse-notify` | 14.57 kB | 4.60 kB | 5 kB |
+| `@orbital-stellar/pulse-notify/devtools` | 2.01 kB | 918 B | 1 kB |
+| `@orbital-stellar/pulse-notify/vitePlugin` | 608 B | 322 B | 450 B |
+
+Budgets live in [`packages/pulse-notify/.size-limit.json`](packages/pulse-notify/.size-limit.json). Reproduce with `pnpm --filter @orbital-stellar/pulse-notify size`, or `size:why` for a per-module breakdown.
+
 ---
 
 ## Quickstart

--- a/packages/pulse-core/test/chaos/harness.ts
+++ b/packages/pulse-core/test/chaos/harness.ts
@@ -1,0 +1,127 @@
+/**
+ * Fault-injection harness for the reconnection chaos suite (#922).
+ *
+ * The engine's reconnect path is exercised elsewhere against a well-behaved
+ * fake. This harness models the transport misbehaving instead: dropping
+ * mid-stream, stalling without closing, rate limiting with and without a
+ * `Retry-After`, and emitting records that do not parse.
+ *
+ * Randomness is seeded so a failure is reproducible from the seed printed in
+ * the log - set `CHAOS_SEED` to replay one.
+ */
+
+export type StreamHandlers = {
+  onmessage: (record: unknown) => void;
+  onerror: (error: unknown) => void;
+};
+
+export type FaultyStream = {
+  /** Cursor the engine opened this stream with. */
+  cursor: string;
+  handlers: StreamHandlers;
+  closed: boolean;
+  close: () => void;
+};
+
+/** Deterministic PRNG (mulberry32) - same seed, same fault sequence. */
+export function seededRandom(seed: number): () => number {
+  let state = seed >>> 0;
+  return () => {
+    state = (state + 0x6d2b79f5) >>> 0;
+    let t = state;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+/** Resolves the seed for a run: `CHAOS_SEED` when set, otherwise the default. */
+export function resolveSeed(defaultSeed = 20260802): number {
+  const fromEnv = process.env.CHAOS_SEED;
+  if (!fromEnv) return defaultSeed;
+  const parsed = Number.parseInt(fromEnv, 10);
+  if (!Number.isFinite(parsed)) {
+    throw new Error(`CHAOS_SEED must be an integer, received "${fromEnv}"`);
+  }
+  return parsed;
+}
+
+/** Every stream the engine has opened, oldest first. */
+export const streams: FaultyStream[] = [];
+
+export function resetStreams(): void {
+  streams.length = 0;
+}
+
+export function latestStream(): FaultyStream {
+  const stream = streams.at(-1);
+  if (!stream) throw new Error("Expected the engine to have opened a stream.");
+  return stream;
+}
+
+/**
+ * Mock `Horizon.Server` that records every stream it hands out. Pass this to
+ * `vi.mock("@stellar/stellar-sdk", ...)`.
+ */
+export class FaultyHorizonServer {
+  operations() {
+    return {
+      cursor(cursor: string) {
+        return {
+          stream(handlers: StreamHandlers) {
+            const stream: FaultyStream = {
+              cursor,
+              handlers,
+              closed: false,
+              close: () => {
+                stream.closed = true;
+              },
+            };
+            streams.push(stream);
+            return stream.close;
+          },
+        };
+      },
+    };
+  }
+}
+
+/** The account the chaos suite subscribes with. */
+export const SUBSCRIBER = "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN";
+const COUNTERPARTY = "GDUKMGUGDZQK6YHYA5Z6AY2G4XDSZPSZ3SW5UN3ARVMO6QSRDWP5YLEX";
+
+/** An inbound payment record with a monotonic paging token. */
+export function paymentRecord(sequence: number): Record<string, unknown> {
+  return {
+    type: "payment",
+    id: String(sequence),
+    paging_token: String(sequence),
+    created_at: new Date(1_700_000_000_000 + sequence * 1000).toISOString(),
+    transaction_successful: true,
+    source_account: COUNTERPARTY,
+    from: COUNTERPARTY,
+    to: SUBSCRIBER,
+    amount: "10.0000000",
+    asset_type: "native",
+  };
+}
+
+/** A record the normalizer cannot make sense of. */
+export function malformedRecord(): Record<string, unknown> {
+  return { type: "payment", id: undefined as unknown as string, garbage: Symbol("nope") };
+}
+
+/** An error shaped like a Horizon rate-limit response. */
+export function rateLimitError(retryAfterSeconds?: number): unknown {
+  return {
+    response: {
+      status: 429,
+      headers: retryAfterSeconds === undefined ? {} : { "Retry-After": String(retryAfterSeconds) },
+    },
+  };
+}
+
+/** A generic transport failure - DNS, reset connection, half-open socket. */
+export function transportError(message: string): Error {
+  return new Error(message);
+}

--- a/packages/pulse-core/test/chaos/reconnect.chaos.test.ts
+++ b/packages/pulse-core/test/chaos/reconnect.chaos.test.ts
@@ -1,0 +1,256 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  FaultyHorizonServer,
+  latestStream,
+  malformedRecord,
+  paymentRecord,
+  rateLimitError,
+  resetStreams,
+  resolveSeed,
+  seededRandom,
+  streams,
+  SUBSCRIBER,
+  transportError,
+} from "./harness.js";
+
+vi.mock("@stellar/stellar-sdk", async () => {
+  const actual = await vi.importActual<Record<string, unknown>>("@stellar/stellar-sdk");
+  return { ...actual, Horizon: { Server: FaultyHorizonServer } };
+});
+
+const { EventEngine } = await import("../../src/EventEngine.js");
+const { MemoryCursorStore } = await import("../../src/MemoryCursorStore.js");
+const { fullJitterBackoffMs } = await import("../../src/backoff.js");
+
+const ADDRESS = SUBSCRIBER;
+const SEED = resolveSeed();
+
+/** Drives the pending reconnect timer and lets the engine reopen its stream. */
+async function advanceReconnect(): Promise<void> {
+  await vi.runOnlyPendingTimersAsync();
+  await vi.runOnlyPendingTimersAsync();
+}
+
+describe(`reconnection chaos (#922, seed ${SEED})`, () => {
+  let random: () => number;
+
+  beforeEach(() => {
+    resetStreams();
+    vi.useFakeTimers();
+    random = seededRandom(SEED);
+    vi.spyOn(Math, "random").mockImplementation(() => random());
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("loses no events and delivers no duplicates across injected faults", async () => {
+    const cursorStore = new MemoryCursorStore();
+    const engine = new EventEngine({
+      network: "testnet",
+      cursorStore,
+      reconnect: { initialDelayMs: 10, maxDelayMs: 100 },
+    });
+    engine.start();
+    await vi.runOnlyPendingTimersAsync();
+
+    const received: string[] = [];
+    engine.subscribe(ADDRESS).on("payment.received", (event) => {
+      received.push(String(event.raw?.paging_token ?? ""));
+    });
+
+    // A payment arrives, then the transport drops mid-stream. Repeat with a
+    // different fault each round; the ledger keeps producing regardless.
+    const faults = [
+      () => latestStream().handlers.onerror(transportError("socket hang up")),
+      () => latestStream().handlers.onerror(transportError("ECONNRESET")),
+      () => latestStream().handlers.onerror(rateLimitError(1)),
+      () => latestStream().handlers.onmessage(malformedRecord()),
+      () => latestStream().handlers.onerror(transportError("EAI_AGAIN horizon-testnet")),
+    ];
+
+    let sequence = 0;
+    for (const injectFault of faults) {
+      latestStream().handlers.onmessage(paymentRecord(++sequence));
+      await vi.advanceTimersByTimeAsync(0);
+      injectFault();
+      await advanceReconnect();
+    }
+    latestStream().handlers.onmessage(paymentRecord(++sequence));
+    await vi.advanceTimersByTimeAsync(0);
+
+    const expected = Array.from({ length: sequence }, (_, index) => String(index + 1));
+    expect(received).toEqual(expected);
+    expect(new Set(received).size).toBe(received.length);
+
+    // The cursor is the proof a consumer would use after a crash: it must have
+    // advanced to the last delivered event, not to a gap or a replayed one.
+    expect(await cursorStore.get(`horizon:testnet`)).toBe(String(sequence));
+
+    engine.stop();
+  });
+
+  it("resumes each reconnect from the persisted cursor, never from 'now'", async () => {
+    const cursorStore = new MemoryCursorStore();
+    const engine = new EventEngine({
+      network: "testnet",
+      cursorStore,
+      reconnect: { initialDelayMs: 10, maxDelayMs: 100 },
+    });
+    engine.start();
+    await vi.runOnlyPendingTimersAsync();
+    engine.subscribe(ADDRESS);
+
+    latestStream().handlers.onmessage(paymentRecord(41));
+    await vi.advanceTimersByTimeAsync(0);
+    latestStream().handlers.onerror(transportError("stream aborted mid-frame"));
+    await advanceReconnect();
+
+    expect(latestStream().cursor).toBe("41");
+    expect(streams.at(-2)?.closed).toBe(true);
+
+    engine.stop();
+  });
+
+  it("honours Retry-After on 429 and falls back to a fixed delay without it", async () => {
+    const notifications: { type: string; delayMs?: number }[] = [];
+    const engine = new EventEngine({
+      network: "testnet",
+      reconnect: { initialDelayMs: 10, maxDelayMs: 100 },
+    });
+    engine.start();
+    await vi.runOnlyPendingTimersAsync();
+    engine
+      .subscribe(ADDRESS)
+      .on("engine.rate_limited", (n) => notifications.push({ type: n.type, delayMs: n.delayMs }));
+
+    latestStream().handlers.onerror(rateLimitError(7));
+    await vi.advanceTimersByTimeAsync(0);
+    expect(notifications.at(-1)).toEqual({ type: "engine.rate_limited", delayMs: 7000 });
+
+    await advanceReconnect();
+    latestStream().handlers.onerror(rateLimitError());
+    await vi.advanceTimersByTimeAsync(0);
+    expect(notifications.at(-1)).toEqual({ type: "engine.rate_limited", delayMs: 60000 });
+
+    engine.stop();
+  });
+
+  it("keeps every backoff delay inside the documented full-jitter envelope", async () => {
+    const delays: number[] = [];
+    const initialDelayMs = 10;
+    const maxDelayMs = 100;
+    const engine = new EventEngine({
+      network: "testnet",
+      reconnect: { initialDelayMs, maxDelayMs },
+    });
+    engine.start();
+    await vi.runOnlyPendingTimersAsync();
+    engine.subscribe(ADDRESS).on("engine.reconnecting", (n) => delays.push(n.delayMs ?? -1));
+
+    for (let attempt = 0; attempt < 8; attempt++) {
+      latestStream().handlers.onerror(transportError("connection reset"));
+      await advanceReconnect();
+    }
+
+    expect(delays).toHaveLength(8);
+    delays.forEach((delay, index) => {
+      const ceiling = Math.min(initialDelayMs * 2 ** index, maxDelayMs);
+      expect(delay).toBeGreaterThanOrEqual(0);
+      expect(delay).toBeLessThan(ceiling === 0 ? 1 : ceiling);
+    });
+
+    // Full jitter can legitimately return 0 once, but a transport that is down
+    // must not produce an unbroken run of zero-delay retries - that is a busy
+    // loop, and it is the failure mode this envelope exists to prevent.
+    const longestZeroRun = delays.reduce(
+      (acc, delay) =>
+        delay === 0
+          ? { run: acc.run + 1, max: Math.max(acc.max, acc.run + 1) }
+          : { run: 0, max: acc.max },
+      { run: 0, max: 0 },
+    ).max;
+    expect(longestZeroRun).toBeLessThan(delays.length);
+
+    engine.stop();
+  });
+
+  it("stops retrying at maxRetries instead of looping forever", async () => {
+    const engine = new EventEngine({
+      network: "testnet",
+      reconnect: { initialDelayMs: 10, maxDelayMs: 100, maxRetries: 3 },
+    });
+    engine.start();
+    await vi.runOnlyPendingTimersAsync();
+    engine.subscribe(ADDRESS);
+
+    for (let attempt = 0; attempt < 6; attempt++) {
+      latestStream().handlers.onerror(transportError("connection reset"));
+      await advanceReconnect();
+    }
+
+    // 1 initial stream + 3 permitted reconnects.
+    expect(streams).toHaveLength(4);
+
+    engine.stop();
+  });
+
+  it("survives malformed records without emitting or dropping the stream", async () => {
+    const engine = new EventEngine({ network: "testnet" });
+    engine.start();
+    await vi.runOnlyPendingTimersAsync();
+
+    const received: unknown[] = [];
+    engine.subscribe(ADDRESS).on("*", (event) => received.push(event));
+
+    const streamCountBefore = streams.length;
+    latestStream().handlers.onmessage(malformedRecord());
+    latestStream().handlers.onmessage({ type: "totally-unknown-operation", id: "9" });
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(received).toHaveLength(0);
+    expect(streams).toHaveLength(streamCountBefore);
+    expect(latestStream().closed).toBe(false);
+
+    engine.stop();
+  });
+
+  it("a stalled stream is left open - the engine does not spin on silence", async () => {
+    const engine = new EventEngine({
+      network: "testnet",
+      reconnect: { initialDelayMs: 10, maxDelayMs: 100 },
+    });
+    engine.start();
+    await vi.runOnlyPendingTimersAsync();
+    engine.subscribe(ADDRESS);
+
+    const streamCountBefore = streams.length;
+    // Half-open socket: no frames, no error, no close for a long while.
+    await vi.advanceTimersByTimeAsync(120_000);
+
+    expect(streams).toHaveLength(streamCountBefore);
+    expect(latestStream().closed).toBe(false);
+
+    engine.stop();
+  });
+});
+
+describe("full-jitter backoff envelope (#922)", () => {
+  it("never exceeds the exponential ceiling for any attempt or seed", () => {
+    const random = seededRandom(SEED);
+    const spy = vi.spyOn(Math, "random").mockImplementation(() => random());
+
+    for (let attempt = 1; attempt <= 12; attempt++) {
+      for (let sample = 0; sample < 50; sample++) {
+        const delay = fullJitterBackoffMs(attempt, 1000, 30000);
+        const ceiling = Math.min(1000 * 2 ** (attempt - 1), 30000);
+        expect(delay).toBeGreaterThanOrEqual(0);
+        expect(delay).toBeLessThan(ceiling);
+      }
+    }
+
+    spy.mockRestore();
+  });
+});

--- a/packages/pulse-notify/.size-limit.json
+++ b/packages/pulse-notify/.size-limit.json
@@ -1,7 +1,41 @@
 [
   {
+    "name": "index (gzip)",
     "path": "dist/index.js",
     "limit": "5 kB",
     "gzip": true
+  },
+  {
+    "name": "index (raw)",
+    "path": "dist/index.js",
+    "limit": "15.5 kB",
+    "gzip": false,
+    "brotli": false
+  },
+  {
+    "name": "devtools (gzip)",
+    "path": "dist/devtools.js",
+    "limit": "1 kB",
+    "gzip": true
+  },
+  {
+    "name": "devtools (raw)",
+    "path": "dist/devtools.js",
+    "limit": "2.1 kB",
+    "gzip": false,
+    "brotli": false
+  },
+  {
+    "name": "vitePlugin (gzip)",
+    "path": "dist/vitePlugin.js",
+    "limit": "450 B",
+    "gzip": true
+  },
+  {
+    "name": "vitePlugin (raw)",
+    "path": "dist/vitePlugin.js",
+    "limit": "750 B",
+    "gzip": false,
+    "brotli": false
   }
 ]

--- a/packages/pulse-notify/package.json
+++ b/packages/pulse-notify/package.json
@@ -40,7 +40,8 @@
     "build": "tsc -p tsconfig.json",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
-    "size": "size-limit"
+    "size": "size-limit",
+    "size:why": "node scripts/why-size.mjs"
   },
   "dependencies": {
     "@orbital-stellar/pulse-core": "workspace:*"
@@ -55,6 +56,7 @@
     "react": "^19.2.8",
     "react-dom": "^19.2.8",
     "size-limit": "^12.1.0",
+    "vite": "^8.1.5",
     "vitest": "^4.1.10"
   },
   "peerDependencies": {

--- a/packages/pulse-notify/scripts/why-size.mjs
+++ b/packages/pulse-notify/scripts/why-size.mjs
@@ -1,0 +1,66 @@
+#!/usr/bin/env node
+/**
+ * Prints the modules contributing most bytes to each browser-facing entry
+ * point, newest-first by rendered size.
+ *
+ * `size-limit` reports the number and the delta against the budget; this
+ * answers the follow-up question - which module moved it. CI runs this only
+ * when the budget check fails, so a red build carries its own explanation.
+ *
+ * Usage:
+ *   node scripts/why-size.mjs            # all entry points
+ *   node scripts/why-size.mjs index      # one entry point
+ */
+import { build } from "vite";
+import { fileURLToPath } from "node:url";
+import { relative } from "node:path";
+
+const packageRoot = fileURLToPath(new URL("..", import.meta.url));
+
+const ENTRIES = ["index", "devtools", "vitePlugin"];
+const TOP_N = 15;
+
+const requested = process.argv.slice(2);
+const entries = requested.length > 0 ? requested : ENTRIES;
+
+function formatBytes(bytes) {
+  return bytes >= 1024 ? `${(bytes / 1024).toFixed(2)} kB` : `${bytes} B`;
+}
+
+for (const entry of entries) {
+  const result = await build({
+    logLevel: "silent",
+    root: packageRoot,
+    build: {
+      write: false,
+      minify: true,
+      lib: {
+        entry: fileURLToPath(new URL(`../dist/${entry}.js`, import.meta.url)),
+        formats: ["es"],
+        fileName: entry,
+      },
+      // react/jsx-runtime is a separate specifier - match the whole family, or
+      // React itself dominates the report and hides the package's own modules.
+      rollupOptions: { external: [/^react($|\/)/, /^react-dom($|\/)/] },
+    },
+  });
+
+  const chunks = result[0].output.filter((output) => output.type === "chunk");
+  const total = chunks.reduce((sum, chunk) => sum + chunk.code.length, 0);
+
+  const modules = chunks
+    .flatMap((chunk) => Object.entries(chunk.modules ?? {}))
+    .map(([id, mod]) => ({ id, bytes: mod.renderedLength ?? 0 }))
+    .filter((mod) => mod.bytes > 0)
+    .sort((a, b) => b.bytes - a.bytes)
+    .slice(0, TOP_N);
+
+  console.log(`\n${entry}  -  ${formatBytes(total)} minified, ${modules.length} modules shown`);
+  console.log("-".repeat(72));
+  for (const mod of modules) {
+    const share = total > 0 ? ((mod.bytes / total) * 100).toFixed(1) : "0.0";
+    console.log(
+      `${formatBytes(mod.bytes).padStart(10)}  ${String(share).padStart(5)}%  ${relative(packageRoot, mod.id)}`,
+    );
+  }
+}

--- a/packages/pulse-notify/test/treeShaking.test.ts
+++ b/packages/pulse-notify/test/treeShaking.test.ts
@@ -1,0 +1,70 @@
+// @vitest-environment node
+import { describe, expect, it } from "vitest";
+import { build } from "vite";
+import { fileURLToPath } from "node:url";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const SRC_INDEX = fileURLToPath(new URL("../src/index.ts", import.meta.url));
+
+/**
+ * Bundles `source` against the package entry point and returns the emitted
+ * JavaScript. Rollup's tree-shaking is what a consumer's bundler applies, so
+ * anything still present here would ship in their client bundle.
+ */
+async function bundle(source: string): Promise<string> {
+  const dir = mkdtempSync(join(tmpdir(), "pulse-notify-treeshake-"));
+  const entry = join(dir, "entry.ts");
+  writeFileSync(entry, source.replace("@entry", SRC_INDEX), "utf8");
+
+  try {
+    const result = (await build({
+      logLevel: "silent",
+      build: {
+        write: false,
+        minify: false,
+        lib: { entry, formats: ["es"], fileName: "out" },
+        rollupOptions: { external: ["react", "react-dom"] },
+      },
+    })) as { output: { type: string; code?: string }[] }[];
+
+    return result[0]!.output
+      .filter((chunk) => chunk.type === "chunk")
+      .map((chunk) => chunk.code ?? "")
+      .join("\n");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+describe("tree-shaking (#925)", () => {
+  it("importing one hook does not pull in unrelated modules", async () => {
+    const code = await bundle(
+      `import { useStellarPayment } from "@entry";\nexport { useStellarPayment };\n`,
+    );
+
+    // Markers unique to modules a payment-only consumer never touches.
+    expect(code).not.toContain("StellarConnectionStatus");
+    expect(code).not.toContain("StellarEventBoundary");
+    expect(code).not.toContain("useContractState");
+    expect(code).not.toContain("useStellarEventSuspense");
+
+    // Note: `wsTransport` IS still pulled in, because `useStellarEvent`
+    // imports `acquireWsConnection` at module scope and picks the transport at
+    // call time. Every SSE-only consumer therefore ships the WebSocket path.
+    // Making that import lazy is a behaviour change, so it is left to a
+    // follow-up rather than smuggled into this test.
+  }, 60_000);
+
+  it("a single-hook bundle is materially smaller than the full surface", async () => {
+    const [single, full] = await Promise.all([
+      bundle(`import { useStellarPayment } from "@entry";\nexport { useStellarPayment };\n`),
+      bundle(`import * as all from "@entry";\nexport { all };\n`),
+    ]);
+
+    // Not a byte budget - .size-limit.json owns those. This asserts the shape
+    // of the graph: pulling one hook must not drag the whole package along.
+    expect(single.length).toBeLessThan(full.length * 0.75);
+  }, 60_000);
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -284,9 +284,12 @@ importers:
       size-limit:
         specifier: ^12.1.0
         version: 12.1.0(jiti@2.7.0)
+      vite:
+        specifier: 7.3.6
+        version: 7.3.6(@types/node@26.1.2)(jiti@2.7.0)(lightningcss@1.33.0)(tsx@4.23.1)(yaml@2.9.0)
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(@vitest/coverage-v8@4.1.10)(jsdom@30.0.1(@noble/hashes@2.2.0))(vite@8.1.5(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(@vitest/coverage-v8@4.1.10)(jsdom@30.0.1(@noble/hashes@2.2.0))(vite@7.3.6(@types/node@26.1.2)(jiti@2.7.0)(lightningcss@1.33.0)(tsx@4.23.1)(yaml@2.9.0))
 
   packages/pulse-webhooks:
     dependencies:


### PR DESCRIPTION
## Linked issues

Closes #925 (13.5 Bundle size budgets for browser packages)
Closes #922 (13.2 Reconnection and failover chaos tests)

## What changed and why

Two Hardening-milestone issues that were unclaimed and unblocked.

### #925 — bundle-size budgets

`bundle-size` already ran in CI, but against a single gzip budget on one entry point. A transitive dependency could grow `devtools` or `vitePlugin` without limit and nothing would turn red.

- **`packages/pulse-notify/.size-limit.json`** — six budgets: raw *and* gzipped, for all three browser-facing entry points. Set from measured size plus ~6–15% headroom, the same ratchet idea as the coverage floors.
- **`scripts/why-size.mjs` + `size:why`** — prints the modules contributing most bytes per entry, sorted by rendered size, with `react`/`react-dom` externalised. CI runs it *only when the budget check fails*, so a red build explains itself.
- **`test/treeShaking.test.ts`** — bundles a fixture that imports one hook and asserts unrelated modules are absent, plus that a single-hook bundle stays materially smaller than the full surface. Uses Rollup via `vite`, which is what a consumer's bundler actually does.
- **README** — current sizes recorded.

Measured now:

| Entry point | Minified | Minified + gzip | Budget (gzip) |
|---|---|---|---|
| `pulse-notify` | 14.57 kB | 4.60 kB | 5 kB |
| `pulse-notify/devtools` | 2.01 kB | 918 B | 1 kB |
| `pulse-notify/vitePlugin` | 608 B | 322 B | 450 B |

**One finding worth knowing about:** the tree-shaking test showed `wsTransport` is pulled into *every* consumer's bundle, including SSE-only ones, because `useStellarEvent` imports `acquireWsConnection` at module scope and picks the transport at call time. Making that import lazy is a behaviour change, so I left it out of this PR rather than smuggling it in — it is called out in a comment in the test and is worth its own issue.

### #922 — reconnection chaos tests

Reconnection was unit-tested against a well-behaved fake. `test/chaos/` models the transport misbehaving instead.

- **`harness.ts`** — a fault-injecting `Horizon.Server` that records every stream it hands out (including the cursor it was opened with), plus fault builders: mid-frame disconnect, generic transport error, `429` with and without `Retry-After`, records that do not normalize. Randomness comes from a seeded mulberry32 PRNG.
- **`reconnect.chaos.test.ts`** — eight tests:
  - a five-fault sequence with events interleaved, asserting **zero loss and zero duplicates**, proven through the persisted cursor
  - each reconnect resumes from the persisted cursor, never from `now`, and the old stream is closed
  - `Retry-After: 7` → 7000 ms; no header → the 60 s fallback
  - every emitted `engine.reconnecting` delay sits inside `[0, min(initial·2^n, max))`, with an explicit assertion against an unbroken run of zero-delay retries (the busy-loop failure mode)
  - `maxRetries` is honoured rather than looping forever
  - malformed and unknown-type records emit nothing and do not tear down the stream
  - a half-open socket is left alone — no spinning on silence
- **CI** — a `chaos-tests` job pinned to `CHAOS_SEED=20260802`, so a PR failure is reproducible from the branch alone.
- **`nightly-chaos.yml`** — same suite nightly with a random seed, printed and written to the job summary with a copy-pasteable replay command. `workflow_dispatch` accepts a seed for replaying a red night.

**Not covered:** the issue's fourth criterion — *"transport failover (Horizon ↔ RPC) preserves the dedupe guard from open issue 6.13"* — has no implementation to test against on `main`; there is no dedupe module in `packages/pulse-core`. That criterion should stay open, or move to whichever issue lands 6.13.

## Test plan

- [x] Existing tests pass (`pnpm test`) — pulse-core 595 passed / 11 skipped, pulse-notify 77 passed
- [x] New tests added for new behaviour (8 chaos tests, 2 tree-shaking tests)
- [x] Typechecks pass (`pnpm -r typecheck`, plus `pnpm test:types`)
- [x] Coverage gate green (`pnpm -r test:coverage`)
- [x] All six size budgets pass; `size:why` output verified
- [x] Chaos suite verified across seeds `1`, `42`, `7777`, `20260101`, `987654` and the pinned `20260802`
- [ ] Manually tested against testnet / mainnet — not applicable, no runtime behaviour changed

## Breaking changes

None. No `src/` behaviour changed in either package — this is budgets, tests and CI wiring. `vite` was added as a `devDependency` of `pulse-notify` (it was not previously declared) because the tree-shaking test and `why-size.mjs` bundle with it.
