### PR TITLE
feat(examples): runnable express-starter backend reference

### DIFF
--- a/examples/express-starter/.env.example
+++ b/examples/express-starter/.env.example
@@ -1,0 +1,17 @@
+# Accounts to watch (comma-separated).
+STELLAR_ADDRESSES=GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN
+
+# testnet (default) or mainnet.
+STELLAR_NETWORK=testnet
+
+# Shared HMAC secret. Generate with: openssl rand -hex 32
+WEBHOOK_SECRET=replace-me-with-32-bytes-of-hex
+
+# Where signed deliveries go. Defaults to this process's own receiver.
+# WEBHOOK_URL=http://127.0.0.1:3000/hooks/stellar
+
+# Port for the receiver and /healthz.
+PORT=3000
+
+# Set to use Postgres for the cursor; omit for a file-backed cursor.
+# DATABASE_URL=postgres://orbital:orbital@127.0.0.1:5432/orbital

--- a/examples/express-starter/README.md
+++ b/examples/express-starter/README.md
@@ -1,0 +1,127 @@
+# orbital-express-starter
+
+A runnable backend reference: ingest Stellar events, persist a cursor, deliver
+HMAC-signed webhooks, and verify them on the receiving end. `docs/COOKBOOK.md`
+describes this composition in prose — this is the version that compiles.
+
+Implements issue 9.2 (#897).
+
+## Why Express
+
+The issue allows Express or Fastify. Express, because this is a *reference*: the
+point is that a reader recognises the shape and can lift it into the app they
+already run, and Express is still what most Node backends use. The composition
+is framework-agnostic — `createReceiver()` is 60 lines and the only Express
+surface is `app.post`.
+
+One caveat it exposed: Express 5 needs `path-to-regexp@8`, and this workspace
+pinned `path-to-regexp: 0.1.13` globally for [GHSA-9wv6-86v2-598j](https://github.com/advisories/GHSA-9wv6-86v2-598j).
+The override is now scoped to `path-to-regexp@0`, so the advisory stays covered
+for anything on the 0.x line and Express 5 gets the version its router needs.
+
+## Quickstart
+
+```bash
+cp .env.example .env      # set STELLAR_ADDRESSES and WEBHOOK_SECRET
+pnpm dev
+```
+
+That runs against testnet with a file-backed cursor and no containers. The
+process is both sender and receiver: it delivers signed webhooks to its own
+`/hooks/stellar`, which verifies them — so you can watch the whole loop locally.
+
+With Postgres:
+
+```bash
+docker compose up -d
+DATABASE_URL=postgres://orbital:orbital@127.0.0.1:5432/orbital pnpm dev
+```
+
+The `cursor_store` table is created on startup if it does not exist.
+
+## Configuration
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `STELLAR_ADDRESSES` | — (required) | Comma-separated accounts to watch |
+| `WEBHOOK_SECRET` | — (required, ≥16 chars) | Shared HMAC secret |
+| `STELLAR_NETWORK` | `testnet` | `testnet` or `mainnet` |
+| `WEBHOOK_URL` | this process's receiver | Where deliveries go |
+| `PORT` | `3000` | Receiver and `/healthz` |
+| `DATABASE_URL` | unset | Postgres cursor; file-backed when unset |
+| `CURSOR_FILE` | `.orbital-cursor.json` | File cursor location |
+
+Startup refuses to run on a missing address list, a secret under 16 characters,
+or a non-numeric port — a misconfigured ingester that starts anyway is worse
+than one that does not.
+
+## Resume after a restart
+
+The guarantee: **stop the service, restart it, and it resumes from the last
+event it delivered — no gap, no replay.**
+
+Walk through it:
+
+1. **Start it and let an event arrive.**
+   ```bash
+   pnpm dev
+   ```
+   Send a testnet payment to a watched address (the
+   [Stellar Laboratory](https://laboratory.stellar.org) is the quickest way).
+   You will see the delivery and then the receiver verifying it:
+   ```
+   [receiver] verified payment.received at 2026-08-02T12:00:00Z
+   ```
+
+2. **Look at the cursor.**
+   ```bash
+   cat .orbital-cursor.json
+   # {"horizon:testnet":"241234567890123"}
+   ```
+   That is the paging token of the last event the engine processed.
+
+3. **Stop with Ctrl-C** (SIGINT) or `kill -TERM <pid>`. The handler calls
+   `engine.stop()` and *awaits it* before exiting, so the final cursor write
+   lands:
+   ```
+   [starter] SIGTERM received, shutting down
+   [starter] stopped cleanly
+   ```
+
+4. **Send another payment while it is down.**
+
+5. **Start it again.** The engine reads the cursor and resumes from it, so the
+   event sent during the outage is delivered now rather than skipped. Nothing
+   before the cursor is redelivered.
+
+With `DATABASE_URL` set, step 2 is a row in `cursor_store` instead of a file,
+and the same guarantee holds across several instances sharing the database.
+
+## Verifying deliveries
+
+`src/receiver.ts` is the half you would deploy in your own service. Two things
+it does deliberately:
+
+- **Verifies against the raw body.** `express.json()` parses and re-serialises,
+  and the re-serialised bytes are not always identical to what was signed. The
+  route reads the body as text and parses only after the signature checks out.
+- **Rejects rather than logs.** A tampered payload gets a `401` and never
+  reaches application code. `onRejected` is there to feed your alerting.
+
+Both are covered by tests: a correctly signed delivery is accepted, and a
+payload with one digit changed after signing is rejected.
+
+## Tests
+
+```bash
+pnpm --filter orbital-express-starter test
+```
+
+Fourteen tests, no containers needed: signature acceptance and rejection
+(tampered body, wrong secret, missing headers), cursor persistence and resume,
+configuration refusals, and the SIGTERM ordering — asserting `stop()` completes
+*before* `process.exit`, since exiting first is what loses the last cursor
+write.
+
+Postgres itself is not exercised in CI; `docker compose up -d` plus the
+`DATABASE_URL` run above is the manual check.

--- a/examples/express-starter/README.md
+++ b/examples/express-starter/README.md
@@ -111,15 +111,21 @@ it does deliberately:
 Both are covered by tests: a correctly signed delivery is accepted, and a
 payload with one digit changed after signing is rejected.
 
+It also rate-limits per IP (120 requests/minute by default, `rateLimit` and
+`rateLimitWindowMs` to change it), checked *before* any HMAC work — verification
+is the resource an unauthenticated flood would burn, even though nothing gets
+through. The limiter is in-process; behind more than one replica, move it to
+shared storage or each replica enforces its own budget.
+
 ## Tests
 
 ```bash
 pnpm --filter orbital-express-starter test
 ```
 
-Fourteen tests, no containers needed: signature acceptance and rejection
+Sixteen tests, no containers needed: signature acceptance and rejection
 (tampered body, wrong secret, missing headers), cursor persistence and resume,
-configuration refusals, and the SIGTERM ordering — asserting `stop()` completes
+configuration refusals, rate limiting, and the SIGTERM ordering — asserting `stop()` completes
 *before* `process.exit`, since exiting first is what loses the last cursor
 write.
 

--- a/examples/express-starter/README.md
+++ b/examples/express-starter/README.md
@@ -114,8 +114,9 @@ payload with one digit changed after signing is rejected.
 It also rate-limits per IP (120 requests/minute by default, `rateLimit` and
 `rateLimitWindowMs` to change it), checked *before* any HMAC work — verification
 is the resource an unauthenticated flood would burn, even though nothing gets
-through. The limiter is in-process; behind more than one replica, move it to
-shared storage or each replica enforces its own budget.
+through. It uses `express-rate-limit`, whose counters are in-process by default; behind
+more than one replica, give it a shared store or each replica enforces its own
+budget.
 
 ## Tests
 

--- a/examples/express-starter/docker-compose.yml
+++ b/examples/express-starter/docker-compose.yml
@@ -1,0 +1,26 @@
+# Postgres for the cursor store and the retry queue.
+#
+#   docker compose up -d
+#   DATABASE_URL=postgres://orbital:orbital@127.0.0.1:5432/orbital pnpm dev
+#
+# Without DATABASE_URL the starter uses a file-backed cursor and needs no
+# containers at all - the resume guarantee holds either way.
+services:
+  postgres:
+    image: postgres:17-alpine
+    environment:
+      POSTGRES_USER: orbital
+      POSTGRES_PASSWORD: orbital
+      POSTGRES_DB: orbital
+    ports:
+      - "5432:5432"
+    volumes:
+      - orbital-pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U orbital -d orbital"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+
+volumes:
+  orbital-pgdata:

--- a/examples/express-starter/package.json
+++ b/examples/express-starter/package.json
@@ -22,6 +22,7 @@
     "@orbital-stellar/pulse-core": "workspace:*",
     "@orbital-stellar/pulse-webhooks": "workspace:*",
     "express": "^5.2.0",
+    "express-rate-limit": "^8.3.0",
     "pg": "^8.22.0"
   },
   "devDependencies": {

--- a/examples/express-starter/package.json
+++ b/examples/express-starter/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "orbital-express-starter",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Runnable backend reference: ingest Stellar events, persist a cursor, deliver HMAC-signed webhooks, and verify them on the receiving end.",
+  "license": "MIT",
+  "engines": {
+    "node": ">=20"
+  },
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc --noEmit -p tsconfig.json",
+    "start": "node dist/index.js",
+    "dev": "tsx src/index.ts",
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage"
+  },
+  "dependencies": {
+    "@orbital-stellar/pulse-core": "workspace:*",
+    "@orbital-stellar/pulse-webhooks": "workspace:*",
+    "express": "^5.2.0",
+    "pg": "^8.22.0"
+  },
+  "devDependencies": {
+    "@types/express": "^5.0.6",
+    "@types/node": "^26.1.2",
+    "@types/pg": "^8.11.11",
+    "@vitest/coverage-v8": "^4.1.10",
+    "tsx": "^4.23.1",
+    "vite": "^8.1.5",
+    "vitest": "^4.1.10"
+  }
+}

--- a/examples/express-starter/src/config.ts
+++ b/examples/express-starter/src/config.ts
@@ -1,0 +1,109 @@
+import {
+  FileCursorStore,
+  PostgresCursorStore,
+  type CursorStoreLike,
+} from "@orbital-stellar/pulse-core";
+import type { Network } from "@orbital-stellar/pulse-core";
+
+/**
+ * Runtime configuration, read once at startup.
+ *
+ * Everything has a default that works with no setup, so `pnpm dev` runs
+ * against testnet with a file-backed cursor. Point `DATABASE_URL` at the
+ * `docker compose` Postgres to get the production composition.
+ */
+export type StarterConfig = {
+  network: Network;
+  /** Stellar accounts to watch. */
+  addresses: string[];
+  /** Where signed webhooks are delivered. */
+  webhookUrl: string;
+  /** HMAC secret shared with the receiver. */
+  webhookSecret: string;
+  /** Port for the local receiver + health endpoints. */
+  port: number;
+  /** Postgres connection string; when unset the cursor is file-backed. */
+  databaseUrl: string | undefined;
+  /** Path used by the file-backed cursor store. */
+  cursorFile: string;
+};
+
+export class MissingConfigError extends Error {
+  constructor(name: string, hint: string) {
+    super(`${name} is required. ${hint}`);
+    this.name = "MissingConfigError";
+  }
+}
+
+export function loadConfig(env: NodeJS.ProcessEnv = process.env): StarterConfig {
+  const addresses = (env.STELLAR_ADDRESSES ?? "")
+    .split(",")
+    .map((value) => value.trim())
+    .filter((value) => value !== "");
+
+  if (addresses.length === 0) {
+    throw new MissingConfigError(
+      "STELLAR_ADDRESSES",
+      "Set it to a comma-separated list of Stellar account IDs to watch.",
+    );
+  }
+
+  const webhookSecret = env.WEBHOOK_SECRET ?? "";
+  if (webhookSecret.length < 16) {
+    throw new MissingConfigError(
+      "WEBHOOK_SECRET",
+      "Set it to at least 16 characters - `openssl rand -hex 32` is a good source.",
+    );
+  }
+
+  const port = Number.parseInt(env.PORT ?? "3000", 10);
+  if (!Number.isInteger(port) || port <= 0) {
+    throw new MissingConfigError("PORT", `Expected a positive integer, received "${env.PORT}".`);
+  }
+
+  return {
+    network: env.STELLAR_NETWORK === "mainnet" ? "mainnet" : "testnet",
+    addresses,
+    webhookUrl: env.WEBHOOK_URL ?? `http://127.0.0.1:${port}/hooks/stellar`,
+    webhookSecret,
+    port,
+    databaseUrl: env.DATABASE_URL,
+    cursorFile: env.CURSOR_FILE ?? ".orbital-cursor.json",
+  };
+}
+
+/**
+ * Postgres when `DATABASE_URL` is set, a file otherwise.
+ *
+ * The file store is not a toy: it survives a restart, which is what the
+ * resume guarantee needs. Postgres is what you want when more than one
+ * instance shares the cursor.
+ */
+export async function createCursorStore(
+  config: StarterConfig,
+): Promise<{ store: CursorStoreLike; close: () => Promise<void>; kind: "postgres" | "file" }> {
+  if (!config.databaseUrl) {
+    return {
+      store: new FileCursorStore(config.cursorFile),
+      close: async () => {},
+      kind: "file",
+    };
+  }
+
+  const { Pool } = await import("pg");
+  const pool = new Pool({ connectionString: config.databaseUrl });
+
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS cursor_store (
+      stream_key TEXT PRIMARY KEY,
+      cursor TEXT NOT NULL,
+      updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    );
+  `);
+
+  return {
+    store: new PostgresCursorStore(pool),
+    close: () => pool.end(),
+    kind: "postgres",
+  };
+}

--- a/examples/express-starter/src/index.ts
+++ b/examples/express-starter/src/index.ts
@@ -1,0 +1,17 @@
+import { loadConfig } from "./config.js";
+import { installSignalHandlers, startService } from "./service.js";
+
+/**
+ * Entry point. `pnpm start` after `pnpm build`, or `pnpm dev` to run from
+ * source. See README.md for the resume-after-restart walkthrough.
+ */
+async function main(): Promise<void> {
+  const config = loadConfig();
+  const service = await startService(config);
+  installSignalHandlers(service);
+}
+
+main().catch((error: unknown) => {
+  console.error("[starter] failed to start:", error instanceof Error ? error.message : error);
+  process.exit(1);
+});

--- a/examples/express-starter/src/receiver.ts
+++ b/examples/express-starter/src/receiver.ts
@@ -22,13 +22,61 @@ export type ReceiverOptions = {
   onEvent?: (event: NormalizedEvent) => void;
   /** Called when verification fails, for alerting. */
   onRejected?: (reason: string, request: { ip?: string }) => void;
+  /** Requests allowed per IP per window. Defaults to 120. */
+  rateLimit?: number;
+  /** Rate-limit window in milliseconds. Defaults to 60 000. */
+  rateLimitWindowMs?: number;
 };
+
+/**
+ * Fixed-window per-IP limiter.
+ *
+ * The verify path does HMAC work on every request, so an unauthenticated
+ * flood is a CPU-burn lever even though nothing gets through. In-process and
+ * dependency-free on purpose: a reference should show the shape without
+ * pulling in a rate-limit library. Behind more than one instance, move this to
+ * shared storage - each replica otherwise enforces its own budget.
+ */
+class FixedWindowLimiter {
+  private readonly hits = new Map<string, { count: number; resetAt: number }>();
+
+  constructor(
+    private readonly limit: number,
+    private readonly windowMs: number,
+  ) {}
+
+  /** Returns true when the caller is over budget. */
+  exceeded(key: string, now = Date.now()): boolean {
+    const entry = this.hits.get(key);
+
+    if (!entry || now >= entry.resetAt) {
+      this.hits.set(key, { count: 1, resetAt: now + this.windowMs });
+      this.sweep(now);
+      return false;
+    }
+
+    entry.count += 1;
+    return entry.count > this.limit;
+  }
+
+  /** Drops expired buckets so the map cannot grow without bound. */
+  private sweep(now: number): void {
+    if (this.hits.size < 1024) return;
+    for (const [key, entry] of this.hits) {
+      if (now >= entry.resetAt) this.hits.delete(key);
+    }
+  }
+}
 
 export const SIGNATURE_HEADER = "x-orbital-signature";
 export const TIMESTAMP_HEADER = "x-orbital-timestamp";
 
 export function createReceiver(options: ReceiverOptions): Express {
   const app = express();
+  const limiter = new FixedWindowLimiter(
+    options.rateLimit ?? 120,
+    options.rateLimitWindowMs ?? 60_000,
+  );
 
   app.get("/healthz", (_request: Request, response: Response) => {
     response.json({ ok: true });
@@ -38,6 +86,13 @@ export function createReceiver(options: ReceiverOptions): Express {
     "/hooks/stellar",
     express.text({ type: "*/*", limit: "1mb" }),
     (request: Request, response: Response) => {
+      // Before any cryptographic work - that is the resource being protected.
+      if (limiter.exceeded(request.ip ?? "unknown")) {
+        options.onRejected?.("rate limit exceeded", { ip: request.ip });
+        response.status(429).json({ error: "rate_limited" });
+        return;
+      }
+
       const signature = request.header(SIGNATURE_HEADER);
       const timestamp = request.header(TIMESTAMP_HEADER);
 

--- a/examples/express-starter/src/receiver.ts
+++ b/examples/express-starter/src/receiver.ts
@@ -1,0 +1,67 @@
+import express, { type Express, type Request, type Response } from "express";
+import { verifyWebhook } from "@orbital-stellar/pulse-webhooks";
+import type { NormalizedEvent } from "@orbital-stellar/pulse-core";
+
+/**
+ * The receiving half of the composition: an endpoint that verifies the
+ * signature Orbital sends and rejects anything that does not match.
+ *
+ * Two details matter and are easy to get wrong:
+ *
+ * 1. **Verify against the raw body.** `express.json()` parses and re-serialises,
+ *    and the re-serialised bytes are not always byte-identical to what was
+ *    signed. This route takes the raw text and parses it only after the
+ *    signature checks out.
+ * 2. **Reject, do not merely log.** A tampered payload gets a 401 and is never
+ *    handed to application code.
+ */
+
+export type ReceiverOptions = {
+  secret: string;
+  /** Called once per verified event. */
+  onEvent?: (event: NormalizedEvent) => void;
+  /** Called when verification fails, for alerting. */
+  onRejected?: (reason: string, request: { ip?: string }) => void;
+};
+
+export const SIGNATURE_HEADER = "x-orbital-signature";
+export const TIMESTAMP_HEADER = "x-orbital-timestamp";
+
+export function createReceiver(options: ReceiverOptions): Express {
+  const app = express();
+
+  app.get("/healthz", (_request: Request, response: Response) => {
+    response.json({ ok: true });
+  });
+
+  app.post(
+    "/hooks/stellar",
+    express.text({ type: "*/*", limit: "1mb" }),
+    (request: Request, response: Response) => {
+      const signature = request.header(SIGNATURE_HEADER);
+      const timestamp = request.header(TIMESTAMP_HEADER);
+
+      if (!signature || !timestamp) {
+        options.onRejected?.("missing signature headers", { ip: request.ip });
+        response.status(401).json({ error: "missing_signature" });
+        return;
+      }
+
+      const body = typeof request.body === "string" ? request.body : "";
+      const event = verifyWebhook(body, signature, options.secret, timestamp);
+
+      if (!event) {
+        // Covers a forged signature, a tampered body, and a replayed
+        // timestamp outside the tolerance window.
+        options.onRejected?.("signature verification failed", { ip: request.ip });
+        response.status(401).json({ error: "invalid_signature" });
+        return;
+      }
+
+      options.onEvent?.(event);
+      response.status(202).json({ received: event.type });
+    },
+  );
+
+  return app;
+}

--- a/examples/express-starter/src/receiver.ts
+++ b/examples/express-starter/src/receiver.ts
@@ -1,4 +1,5 @@
 import express, { type Express, type Request, type Response } from "express";
+import rateLimit from "express-rate-limit";
 import { verifyWebhook } from "@orbital-stellar/pulse-webhooks";
 import type { NormalizedEvent } from "@orbital-stellar/pulse-core";
 
@@ -28,55 +29,29 @@ export type ReceiverOptions = {
   rateLimitWindowMs?: number;
 };
 
-/**
- * Fixed-window per-IP limiter.
- *
- * The verify path does HMAC work on every request, so an unauthenticated
- * flood is a CPU-burn lever even though nothing gets through. In-process and
- * dependency-free on purpose: a reference should show the shape without
- * pulling in a rate-limit library. Behind more than one instance, move this to
- * shared storage - each replica otherwise enforces its own budget.
- */
-class FixedWindowLimiter {
-  private readonly hits = new Map<string, { count: number; resetAt: number }>();
-
-  constructor(
-    private readonly limit: number,
-    private readonly windowMs: number,
-  ) {}
-
-  /** Returns true when the caller is over budget. */
-  exceeded(key: string, now = Date.now()): boolean {
-    const entry = this.hits.get(key);
-
-    if (!entry || now >= entry.resetAt) {
-      this.hits.set(key, { count: 1, resetAt: now + this.windowMs });
-      this.sweep(now);
-      return false;
-    }
-
-    entry.count += 1;
-    return entry.count > this.limit;
-  }
-
-  /** Drops expired buckets so the map cannot grow without bound. */
-  private sweep(now: number): void {
-    if (this.hits.size < 1024) return;
-    for (const [key, entry] of this.hits) {
-      if (now >= entry.resetAt) this.hits.delete(key);
-    }
-  }
-}
-
 export const SIGNATURE_HEADER = "x-orbital-signature";
 export const TIMESTAMP_HEADER = "x-orbital-timestamp";
 
 export function createReceiver(options: ReceiverOptions): Express {
   const app = express();
-  const limiter = new FixedWindowLimiter(
-    options.rateLimit ?? 120,
-    options.rateLimitWindowMs ?? 60_000,
-  );
+  /**
+   * Per-IP limiter on the verify path.
+   *
+   * The route does HMAC work on every request, so an unauthenticated flood is
+   * a CPU-burn lever even though nothing gets through. `express-rate-limit`
+   * keeps its counters in memory by default - behind more than one replica,
+   * give it a shared store or each replica enforces its own budget.
+   */
+  const limiter = rateLimit({
+    windowMs: options.rateLimitWindowMs ?? 60_000,
+    limit: options.rateLimit ?? 120,
+    standardHeaders: "draft-7",
+    legacyHeaders: false,
+    handler: (request: Request, response: Response) => {
+      options.onRejected?.("rate limit exceeded", { ip: request.ip });
+      response.status(429).json({ error: "rate_limited" });
+    },
+  });
 
   app.get("/healthz", (_request: Request, response: Response) => {
     response.json({ ok: true });
@@ -84,15 +59,11 @@ export function createReceiver(options: ReceiverOptions): Express {
 
   app.post(
     "/hooks/stellar",
+    // Before the body parser and before any cryptographic work - that is the
+    // resource being protected.
+    limiter,
     express.text({ type: "*/*", limit: "1mb" }),
     (request: Request, response: Response) => {
-      // Before any cryptographic work - that is the resource being protected.
-      if (limiter.exceeded(request.ip ?? "unknown")) {
-        options.onRejected?.("rate limit exceeded", { ip: request.ip });
-        response.status(429).json({ error: "rate_limited" });
-        return;
-      }
-
       const signature = request.header(SIGNATURE_HEADER);
       const timestamp = request.header(TIMESTAMP_HEADER);
 

--- a/examples/express-starter/src/service.ts
+++ b/examples/express-starter/src/service.ts
@@ -1,0 +1,100 @@
+import { EventEngine, type CursorStoreLike } from "@orbital-stellar/pulse-core";
+import { WebhookDelivery } from "@orbital-stellar/pulse-webhooks";
+import type { Server } from "node:http";
+import { createReceiver } from "./receiver.js";
+import { createCursorStore, type StarterConfig } from "./config.js";
+
+/**
+ * Wires the whole composition together and, importantly, takes it apart again.
+ *
+ * The shutdown path is the part worth copying: on SIGTERM the engine is
+ * stopped *and awaited* before the process exits, so the cursor write for the
+ * last delivered event completes. Exiting on the signal without waiting is how
+ * a restart replays or, worse, skips events.
+ */
+export type StarterService = {
+  stop: () => Promise<void>;
+  /** Resolved once the HTTP receiver is listening. */
+  port: number;
+  cursorKind: "postgres" | "file";
+};
+
+export async function startService(config: StarterConfig): Promise<StarterService> {
+  const { store, close: closeStore, kind } = await createCursorStore(config);
+
+  const app = createReceiver({
+    secret: config.webhookSecret,
+    onEvent: (event) => {
+      console.log(`[receiver] verified ${event.type} at ${event.timestamp}`);
+    },
+    onRejected: (reason, request) => {
+      console.warn(`[receiver] rejected delivery from ${request.ip ?? "unknown"}: ${reason}`);
+    },
+  });
+
+  const server: Server = await new Promise((resolve) => {
+    const listening = app.listen(config.port, () => resolve(listening));
+  });
+
+  const engine = new EventEngine({
+    network: config.network,
+    cursorStore: store as CursorStoreLike,
+  });
+
+  const deliveries: WebhookDelivery[] = [];
+  for (const address of config.addresses) {
+    const watcher = engine.subscribe(address);
+    deliveries.push(
+      new WebhookDelivery(watcher, {
+        url: config.webhookUrl,
+        secret: config.webhookSecret,
+        retries: 3,
+      }),
+    );
+  }
+
+  engine.start();
+  console.log(
+    `[starter] watching ${config.addresses.length} address(es) on ${config.network}, ` +
+      `cursor: ${kind}, receiver: http://127.0.0.1:${config.port}`,
+  );
+
+  let stopped = false;
+  const stop = async (): Promise<void> => {
+    if (stopped) return;
+    stopped = true;
+
+    // Order matters: stop ingesting, let the engine flush its cursor, then
+    // close the sockets and the pool.
+    await engine.stop();
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+    await closeStore();
+    console.log("[starter] stopped cleanly");
+  };
+
+  return { stop, port: config.port, cursorKind: kind };
+}
+
+/** Installs SIGTERM/SIGINT handlers that shut down before exiting. */
+export function installSignalHandlers(service: StarterService): () => void {
+  const handler = (signal: NodeJS.Signals) => () => {
+    console.log(`[starter] ${signal} received, shutting down`);
+    void service.stop().then(
+      () => process.exit(0),
+      (error) => {
+        console.error("[starter] shutdown failed", error);
+        process.exit(1);
+      },
+    );
+  };
+
+  const onTerm = handler("SIGTERM");
+  const onInt = handler("SIGINT");
+  process.on("SIGTERM", onTerm);
+  process.on("SIGINT", onInt);
+
+  return () => {
+    process.off("SIGTERM", onTerm);
+    process.off("SIGINT", onInt);
+  };
+}

--- a/examples/express-starter/test/starter.test.ts
+++ b/examples/express-starter/test/starter.test.ts
@@ -251,3 +251,57 @@ describe("graceful shutdown (#897)", () => {
     exit.mockRestore();
   });
 });
+
+describe("receiver rate limiting (#897)", () => {
+  it("returns 429 once an IP is over budget, before doing HMAC work", async () => {
+    const rejections: string[] = [];
+    const app = createReceiver({
+      secret: SECRET,
+      rateLimit: 2,
+      rateLimitWindowMs: 60_000,
+      onRejected: (reason) => rejections.push(reason),
+    });
+    const server = await listen(app);
+
+    const send = async () => {
+      const { body, timestamp, signature } = signedRequest(paymentPayload());
+      return fetch(`${server.url}/hooks/stellar`, {
+        method: "POST",
+        headers: { [SIGNATURE_HEADER]: signature, [TIMESTAMP_HEADER]: timestamp },
+        body,
+      });
+    };
+
+    expect((await send()).status).toBe(202);
+    expect((await send()).status).toBe(202);
+
+    const limited = await send();
+    expect(limited.status).toBe(429);
+    expect(await limited.json()).toEqual({ error: "rate_limited" });
+    expect(rejections).toContain("rate limit exceeded");
+
+    await server.close();
+  });
+
+  it("lets a caller through again once the window rolls over", async () => {
+    const app = createReceiver({ secret: SECRET, rateLimit: 1, rateLimitWindowMs: 20 });
+    const server = await listen(app);
+
+    const send = async () => {
+      const { body, timestamp, signature } = signedRequest(paymentPayload());
+      return fetch(`${server.url}/hooks/stellar`, {
+        method: "POST",
+        headers: { [SIGNATURE_HEADER]: signature, [TIMESTAMP_HEADER]: timestamp },
+        body,
+      });
+    };
+
+    expect((await send()).status).toBe(202);
+    expect((await send()).status).toBe(429);
+
+    await new Promise((resolve) => setTimeout(resolve, 30));
+    expect((await send()).status).toBe(202);
+
+    await server.close();
+  });
+});

--- a/examples/express-starter/test/starter.test.ts
+++ b/examples/express-starter/test/starter.test.ts
@@ -1,0 +1,253 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { signWebhookPayload } from "@orbital-stellar/pulse-webhooks";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { FileCursorStore } from "@orbital-stellar/pulse-core";
+import { createReceiver, SIGNATURE_HEADER, TIMESTAMP_HEADER } from "../src/receiver.js";
+import { loadConfig, MissingConfigError } from "../src/config.js";
+
+const SECRET = "0123456789abcdef0123456789abcdef";
+const STREAM_KEY = "horizon:testnet";
+
+function signedRequest(body: string, secret = SECRET) {
+  // The header carries milliseconds - `verifyWebhook` compares it against
+  // Date.now() directly, so a seconds-precision value reads as ancient.
+  const timestamp = String(Date.now());
+  return { body, timestamp, signature: signWebhookPayload(body, timestamp, secret) };
+}
+
+function paymentPayload(): string {
+  return JSON.stringify({
+    type: "payment.received",
+    to: "GDUKMGUGDZQK6YHYA5Z6AY2G4XDSZPSZ3SW5UN3ARVMO6QSRDWP5YLEX",
+    from: "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN",
+    amount: "10.0000000",
+    asset: "XLM",
+    timestamp: "2026-08-02T12:00:00Z",
+  });
+}
+
+/** Starts the receiver on an ephemeral port and returns its base URL. */
+async function listen(app: ReturnType<typeof createReceiver>) {
+  const server = app.listen(0);
+  await new Promise((resolve) => server.once("listening", resolve));
+  const address = server.address();
+  const port = typeof address === "object" && address ? address.port : 0;
+  return {
+    url: `http://127.0.0.1:${port}`,
+    close: () => new Promise<void>((resolve) => server.close(() => resolve())),
+  };
+}
+
+describe("webhook receiver (#897)", () => {
+  it("accepts a correctly signed delivery and surfaces the event", async () => {
+    const received: string[] = [];
+    const app = createReceiver({ secret: SECRET, onEvent: (event) => received.push(event.type) });
+    const server = await listen(app);
+
+    const { body, timestamp, signature } = signedRequest(paymentPayload());
+    const response = await fetch(`${server.url}/hooks/stellar`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        [SIGNATURE_HEADER]: signature,
+        [TIMESTAMP_HEADER]: timestamp,
+      },
+      body,
+    });
+
+    expect(response.status).toBe(202);
+    expect(received).toEqual(["payment.received"]);
+    await server.close();
+  });
+
+  it("rejects a tampered payload with 401 and never surfaces it", async () => {
+    const rejections: string[] = [];
+    const received: string[] = [];
+    const app = createReceiver({
+      secret: SECRET,
+      onEvent: (event) => received.push(event.type),
+      onRejected: (reason) => rejections.push(reason),
+    });
+    const server = await listen(app);
+
+    const { body, timestamp, signature } = signedRequest(paymentPayload());
+    // One digit changed after signing - the classic tamper.
+    const tampered = body.replace('"10.0000000"', '"1000.0000000"');
+
+    const response = await fetch(`${server.url}/hooks/stellar`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        [SIGNATURE_HEADER]: signature,
+        [TIMESTAMP_HEADER]: timestamp,
+      },
+      body: tampered,
+    });
+
+    expect(response.status).toBe(401);
+    expect(await response.json()).toEqual({ error: "invalid_signature" });
+    expect(received).toEqual([]);
+    expect(rejections).toHaveLength(1);
+    await server.close();
+  });
+
+  it("rejects a delivery signed with the wrong secret", async () => {
+    const app = createReceiver({ secret: SECRET });
+    const server = await listen(app);
+
+    const { body, timestamp, signature } = signedRequest(
+      paymentPayload(),
+      "a-different-secret-32b",
+    );
+    const response = await fetch(`${server.url}/hooks/stellar`, {
+      method: "POST",
+      headers: { [SIGNATURE_HEADER]: signature, [TIMESTAMP_HEADER]: timestamp },
+      body,
+    });
+
+    expect(response.status).toBe(401);
+    await server.close();
+  });
+
+  it("rejects a delivery with no signature headers", async () => {
+    const app = createReceiver({ secret: SECRET });
+    const server = await listen(app);
+
+    const response = await fetch(`${server.url}/hooks/stellar`, {
+      method: "POST",
+      body: paymentPayload(),
+    });
+
+    expect(response.status).toBe(401);
+    expect(await response.json()).toEqual({ error: "missing_signature" });
+    await server.close();
+  });
+
+  it("answers /healthz", async () => {
+    const server = await listen(createReceiver({ secret: SECRET }));
+    const response = await fetch(`${server.url}/healthz`);
+    expect(await response.json()).toEqual({ ok: true });
+    await server.close();
+  });
+});
+
+describe("cursor resume after restart (#897)", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "orbital-express-starter-"));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("a second process reads the cursor the first one persisted", async () => {
+    // First "run": ingest up to paging token 4242 and shut down.
+    const first = new FileCursorStore(dir);
+    await first.set(STREAM_KEY, "4242");
+
+    // Second "run": a brand-new store instance over the same directory, which
+    // is what a restarted container sees.
+    const second = new FileCursorStore(dir);
+    expect(await second.get(STREAM_KEY)).toBe("4242");
+  });
+
+  it("reports no cursor for a stream it has never seen, rather than a stale one", async () => {
+    const store = new FileCursorStore(dir);
+    await store.set(STREAM_KEY, "4242");
+
+    expect(await store.get("horizon:mainnet")).toBeNull();
+  });
+
+  it("advances monotonically as events arrive", async () => {
+    const store = new FileCursorStore(dir);
+    for (const cursor of ["1", "2", "3"]) {
+      await store.set(STREAM_KEY, cursor);
+    }
+
+    expect(await new FileCursorStore(dir).get(STREAM_KEY)).toBe("3");
+  });
+});
+
+describe("configuration", () => {
+  const base = {
+    STELLAR_ADDRESSES: "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN",
+    WEBHOOK_SECRET: SECRET,
+  };
+
+  it("defaults to testnet with a file-backed cursor and this process's receiver", () => {
+    const config = loadConfig({ ...base } as NodeJS.ProcessEnv);
+
+    expect(config.network).toBe("testnet");
+    expect(config.databaseUrl).toBeUndefined();
+    expect(config.webhookUrl).toBe("http://127.0.0.1:3000/hooks/stellar");
+  });
+
+  it("refuses to start with no addresses", () => {
+    expect(() => loadConfig({ WEBHOOK_SECRET: SECRET } as NodeJS.ProcessEnv)).toThrow(
+      MissingConfigError,
+    );
+  });
+
+  it("refuses a webhook secret too short to be one", () => {
+    expect(() => loadConfig({ ...base, WEBHOOK_SECRET: "short" } as NodeJS.ProcessEnv)).toThrow(
+      /at least 16 characters/,
+    );
+  });
+
+  it("refuses a non-numeric port instead of listening on NaN", () => {
+    expect(() => loadConfig({ ...base, PORT: "not-a-port" } as NodeJS.ProcessEnv)).toThrow(
+      MissingConfigError,
+    );
+  });
+
+  it("switches to mainnet only on an exact match", () => {
+    expect(loadConfig({ ...base, STELLAR_NETWORK: "mainnet" } as NodeJS.ProcessEnv).network).toBe(
+      "mainnet",
+    );
+    expect(loadConfig({ ...base, STELLAR_NETWORK: "Mainnet" } as NodeJS.ProcessEnv).network).toBe(
+      "testnet",
+    );
+  });
+});
+
+describe("graceful shutdown (#897)", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("stops the engine and flushes the cursor before the process exits", async () => {
+    const order: string[] = [];
+
+    const service = {
+      port: 0,
+      cursorKind: "file" as const,
+      stop: vi.fn(async () => {
+        order.push("stop");
+      }),
+    };
+
+    const { installSignalHandlers } = await import("../src/service.js");
+    const exit = vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
+      order.push(`exit:${code}`);
+      return undefined as never;
+    }) as never);
+
+    const uninstall = installSignalHandlers(service);
+    process.emit("SIGTERM");
+
+    // Let the stop promise settle.
+    await vi.waitFor(() => expect(order).toContain("exit:0"));
+
+    // stop() ran to completion *before* exit was called - that ordering is the
+    // whole point: exiting first loses the final cursor write.
+    expect(order).toEqual(["stop", "exit:0"]);
+    expect(service.stop).toHaveBeenCalledOnce();
+
+    uninstall();
+    exit.mockRestore();
+  });
+});

--- a/examples/express-starter/test/starter.test.ts
+++ b/examples/express-starter/test/starter.test.ts
@@ -284,7 +284,7 @@ describe("receiver rate limiting (#897)", () => {
   });
 
   it("lets a caller through again once the window rolls over", async () => {
-    const app = createReceiver({ secret: SECRET, rateLimit: 1, rateLimitWindowMs: 20 });
+    const app = createReceiver({ secret: SECRET, rateLimit: 1, rateLimitWindowMs: 250 });
     const server = await listen(app);
 
     const send = async () => {
@@ -299,7 +299,7 @@ describe("receiver rate limiting (#897)", () => {
     expect((await send()).status).toBe(202);
     expect((await send()).status).toBe(429);
 
-    await new Promise((resolve) => setTimeout(resolve, 30));
+    await new Promise((resolve) => setTimeout(resolve, 350));
     expect((await send()).status).toBe(202);
 
     await server.close();

--- a/examples/express-starter/tsconfig.json
+++ b/examples/express-starter/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": ".",
+    "types": ["node"]
+  },
+  "include": ["src", "test"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/examples/express-starter/vitest.config.ts
+++ b/examples/express-starter/vitest.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig } from "vitest/config";
+import { fileURLToPath } from "node:url";
 
 export default defineConfig({
   test: {
@@ -13,6 +14,18 @@ export default defineConfig({
       // the starter, not by CI. Floors reflect what is genuinely covered.
       thresholds: { statements: 55, branches: 75, functions: 48, lines: 58 },
       reporter: ["text", "json-summary"],
+    },
+  },
+  resolve: {
+    // Resolve the workspace packages from source, like the other packages do -
+    // otherwise the suite needs their dist output to have been built first.
+    alias: {
+      "@orbital-stellar/pulse-core": fileURLToPath(
+        new URL("../../packages/pulse-core/src/index.ts", import.meta.url),
+      ),
+      "@orbital-stellar/pulse-webhooks": fileURLToPath(
+        new URL("../../packages/pulse-webhooks/src/index.ts", import.meta.url),
+      ),
     },
   },
 });

--- a/examples/express-starter/vitest.config.ts
+++ b/examples/express-starter/vitest.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["test/**/*.test.ts"],
+    coverage: {
+      provider: "v8",
+      include: ["src/**/*.ts"],
+      exclude: ["node_modules/", "dist/", "test/", "**/*.test.ts", "**/*.config.*", "src/index.ts"],
+      // service.ts wires a live EventEngine against Horizon, so only its
+      // shutdown ordering is unit-testable; the rest is exercised by running
+      // the starter, not by CI. Floors reflect what is genuinely covered.
+      thresholds: { statements: 55, branches: 75, functions: 48, lines: 58 },
+      reporter: ["text", "json-summary"],
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  path-to-regexp: 0.1.13
+  path-to-regexp@0: 0.1.13
   vite: 7.3.6
   axios: 1.17.0
   postcss: ^8.5.16
@@ -138,6 +138,43 @@ importers:
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
+
+  examples/express-starter:
+    dependencies:
+      '@orbital-stellar/pulse-core':
+        specifier: workspace:*
+        version: link:../../packages/pulse-core
+      '@orbital-stellar/pulse-webhooks':
+        specifier: workspace:*
+        version: link:../../packages/pulse-webhooks
+      express:
+        specifier: ^5.2.0
+        version: 5.2.1
+      pg:
+        specifier: ^8.22.0
+        version: 8.22.0
+    devDependencies:
+      '@types/express':
+        specifier: ^5.0.6
+        version: 5.0.6
+      '@types/node':
+        specifier: ^26.1.2
+        version: 26.1.2
+      '@types/pg':
+        specifier: ^8.11.11
+        version: 8.20.0
+      '@vitest/coverage-v8':
+        specifier: ^4.1.10
+        version: 4.1.10(vitest@4.1.10)
+      tsx:
+        specifier: ^4.23.1
+        version: 4.23.1
+      vite:
+        specifier: 7.3.6
+        version: 7.3.6(@types/node@26.1.2)(jiti@2.7.0)(lightningcss@1.33.0)(tsx@4.23.1)(yaml@2.9.0)
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(@vitest/coverage-v8@4.1.10)(jsdom@30.0.1(@noble/hashes@2.2.0))(vite@7.3.6(@types/node@26.1.2)(jiti@2.7.0)(lightningcss@1.33.0)(tsx@4.23.1)(yaml@2.9.0))
 
   packages/abi-registry:
     dependencies:
@@ -1235,8 +1272,14 @@ packages:
   '@types/aria-query@5.0.4':
     resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
+  '@types/body-parser@1.19.6':
+    resolution: {integrity: sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==}
+
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/connect@3.4.38':
+    resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
 
   '@types/debug@4.1.13':
     resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
@@ -1253,8 +1296,17 @@ packages:
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
 
+  '@types/express-serve-static-core@5.1.3':
+    resolution: {integrity: sha512-dPfW8NFiOF4wOHc7+N/QSxlY9cfSsenewGbAz8C8U/MULPd/YZ27LvJUIlzaXie7e6Ove9YunJGgC9tbHD2cKw==}
+
+  '@types/express@5.0.6':
+    resolution: {integrity: sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==}
+
   '@types/hast@3.0.4':
     resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
+
+  '@types/http-errors@2.0.5':
+    resolution: {integrity: sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==}
 
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
@@ -1271,6 +1323,12 @@ packages:
   '@types/pg@8.20.0':
     resolution: {integrity: sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==}
 
+  '@types/qs@6.15.1':
+    resolution: {integrity: sha512-GZHUBZR9hckSUhrxmp1nG6NwdpM9fCunJwyThLW1X3AyHgd9IlHb6VANpQQqDr2o/qQp6McZ3y/IA2rVzKzSbw==}
+
+  '@types/range-parser@1.2.7':
+    resolution: {integrity: sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==}
+
   '@types/react-dom@19.2.3':
     resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
     peerDependencies:
@@ -1278,6 +1336,12 @@ packages:
 
   '@types/react@19.2.17':
     resolution: {integrity: sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==}
+
+  '@types/send@1.2.1':
+    resolution: {integrity: sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==}
+
+  '@types/serve-static@2.2.0':
+    resolution: {integrity: sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==}
 
   '@types/unist@2.0.11':
     resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
@@ -1397,6 +1461,10 @@ packages:
   '@vitest/utils@4.1.10':
     resolution: {integrity: sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==}
 
+  accepts@2.0.0:
+    resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
+    engines: {node: '>= 0.6'}
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -1506,6 +1574,10 @@ packages:
   bintrees@1.0.2:
     resolution: {integrity: sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==}
 
+  body-parser@2.3.0:
+    resolution: {integrity: sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==}
+    engines: {node: '>=18'}
+
   brace-expansion@2.1.4:
     resolution: {integrity: sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==}
 
@@ -1525,8 +1597,16 @@ packages:
     resolution: {integrity: sha512-fey6+4jDK7TFtFg/klGSvNKJctyU7n2aQdnM+CO0ruLPbqqMOM8Tio0Pc+deqUeVKX1tL5DQep1zQ7+37aTAsA==}
     engines: {node: '>= 0.8'}
 
+  bytes@3.1.2:
+    resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
+    engines: {node: '>= 0.8'}
+
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
+
+  call-bound@1.0.4:
+    resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
     engines: {node: '>= 0.4'}
 
   caniuse-lite@1.0.30001803:
@@ -1578,8 +1658,28 @@ packages:
     resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
     engines: {node: '>=20'}
 
+  content-disposition@1.1.0:
+    resolution: {integrity: sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==}
+    engines: {node: '>=18'}
+
+  content-type@1.0.5:
+    resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
+    engines: {node: '>= 0.6'}
+
+  content-type@2.0.0:
+    resolution: {integrity: sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==}
+    engines: {node: '>=18'}
+
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  cookie-signature@1.2.2:
+    resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
+    engines: {node: '>=6.6.0'}
+
+  cookie@0.7.2:
+    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
+    engines: {node: '>= 0.6'}
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -1618,6 +1718,10 @@ packages:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
 
+  depd@2.0.0:
+    resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
+    engines: {node: '>= 0.8'}
+
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
@@ -1636,11 +1740,18 @@ packages:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
 
+  ee-first@1.1.1:
+    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
+
   electron-to-chromium@1.5.399:
     resolution: {integrity: sha512-lEcqhErbHjXRvd41rnWLpzbyU/IXfIYo7QwaFWmxGeLiLyY2TBCdHnWY88vB+p3ubnihRypDm66panXl7TylLA==}
 
   emoji-regex@10.6.0:
     resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
+
+  encodeurl@2.0.0:
+    resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
+    engines: {node: '>= 0.8'}
 
   enhanced-resolve@5.24.5:
     resolution: {integrity: sha512-L1l8TNvomm6UVW5B253AGxQagSQr+vGwhMlrrfRS2qmhx46AMpMVJKQYLvWYbysTMY8VoicOvzHzoHMbyzB+4A==}
@@ -1677,6 +1788,9 @@ packages:
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
+
+  escape-html@1.0.3:
+    resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
 
   escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
@@ -1745,6 +1859,10 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
+  etag@1.8.1:
+    resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
+    engines: {node: '>= 0.6'}
+
   eventsource-parser@3.1.0:
     resolution: {integrity: sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==}
     engines: {node: '>=18.0.0'}
@@ -1756,6 +1874,10 @@ packages:
   expect-type@1.4.0:
     resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
     engines: {node: '>=12.0.0'}
+
+  express@5.2.1:
+    resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
+    engines: {node: '>= 18'}
 
   extend-shallow@2.0.1:
     resolution: {integrity: sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==}
@@ -1796,6 +1918,10 @@ packages:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
     engines: {node: '>=16.0.0'}
 
+  finalhandler@2.1.1:
+    resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
+    engines: {node: '>= 18.0.0'}
+
   find-up@5.0.0:
     resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
     engines: {node: '>=10'}
@@ -1820,6 +1946,10 @@ packages:
     resolution: {integrity: sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==}
     engines: {node: '>= 6'}
 
+  forwarded@0.2.0:
+    resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
+    engines: {node: '>= 0.6'}
+
   fraction.js@5.3.4:
     resolution: {integrity: sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==}
 
@@ -1836,6 +1966,10 @@ packages:
         optional: true
       react-dom:
         optional: true
+
+  fresh@2.0.0:
+    resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
+    engines: {node: '>= 0.8'}
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
@@ -1925,6 +2059,10 @@ packages:
   html-url-attributes@3.0.1:
     resolution: {integrity: sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==}
 
+  http-errors@2.0.1:
+    resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
+    engines: {node: '>= 0.8'}
+
   https-proxy-agent@5.0.1:
     resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
     engines: {node: '>= 6'}
@@ -1937,6 +2075,10 @@ packages:
     resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
     engines: {node: '>=18'}
     hasBin: true
+
+  iconv-lite@0.7.3:
+    resolution: {integrity: sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==}
+    engines: {node: '>=0.10.0'}
 
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
@@ -1957,8 +2099,15 @@ packages:
     resolution: {integrity: sha512-Yg7+ztRkqslMAS2iFaU+Oa4KTSidr63OsFGlOrJoW981kIYO3CGCS3wA95P1mUi/IVSJkn0D479KTJpVpvFNuw==}
     engines: {node: '>=18'}
 
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
   inline-style-parser@0.2.7:
     resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
+
+  ipaddr.js@1.9.1:
+    resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
+    engines: {node: '>= 0.10'}
 
   is-alphabetical@2.0.1:
     resolution: {integrity: sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==}
@@ -1990,6 +2139,9 @@ packages:
 
   is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
+  is-promise@4.0.0:
+    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
 
   is-retry-allowed@3.0.0:
     resolution: {integrity: sha512-9xH0xvoggby+u0uGF7cZXdrutWiBiaFG8ZT4YFPXL8NzkyAwX3AKGLeFQLvzDpM430+nDFBZ1LHkie/8ocL06A==}
@@ -2298,6 +2450,14 @@ packages:
   mdn-data@2.27.1:
     resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
 
+  media-typer@1.1.1:
+    resolution: {integrity: sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ==}
+    engines: {node: '>= 0.8'}
+
+  merge-descriptors@2.0.0:
+    resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
+    engines: {node: '>=18'}
+
   micromark-core-commonmark@2.0.3:
     resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
 
@@ -2386,9 +2546,17 @@ packages:
     resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
     engines: {node: '>= 0.6'}
 
+  mime-db@1.54.0:
+    resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
+    engines: {node: '>= 0.6'}
+
   mime-types@2.1.35:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
+
+  mime-types@3.0.2:
+    resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
+    engines: {node: '>=18'}
 
   minimatch@10.2.6:
     resolution: {integrity: sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==}
@@ -2423,6 +2591,10 @@ packages:
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
+  negotiator@1.0.0:
+    resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
+    engines: {node: '>= 0.6'}
+
   next@16.2.10:
     resolution: {integrity: sha512-2som5AVXb3kE6Yjine3/mNbBayYF58eguBWIVVUdr1y/L426xyVEgYxgBG+1QC34P2x5E+tcDup6XkuOAX3dCA==}
     engines: {node: '>=20.9.0'}
@@ -2448,9 +2620,20 @@ packages:
     resolution: {integrity: sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==}
     engines: {node: '>=18'}
 
+  object-inspect@1.13.4:
+    resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
+    engines: {node: '>= 0.4'}
+
   obug@2.1.4:
     resolution: {integrity: sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==}
     engines: {node: '>=12.20.0'}
+
+  on-finished@2.4.1:
+    resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
+    engines: {node: '>= 0.8'}
+
+  once@1.4.0:
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
   openapi-typescript@7.13.0:
     resolution: {integrity: sha512-EFP392gcqXS7ntPvbhBzbF8TyBA+baIYEm791Hy5YkjDYKTnk/Tn5OQeKm5BIZvJihpp8Zzr4hzx0Irde1LNGQ==}
@@ -2480,6 +2663,10 @@ packages:
   parse5@8.0.1:
     resolution: {integrity: sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==}
 
+  parseurl@1.3.3:
+    resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
+    engines: {node: '>= 0.8'}
+
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
@@ -2487,6 +2674,9 @@ packages:
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
+
+  path-to-regexp@8.4.2:
+    resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
@@ -2582,6 +2772,10 @@ packages:
   property-information@7.2.0:
     resolution: {integrity: sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==}
 
+  proxy-addr@2.0.7:
+    resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
+    engines: {node: '>= 0.10'}
+
   proxy-from-env@2.1.0:
     resolution: {integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==}
     engines: {node: '>=10'}
@@ -2592,6 +2786,18 @@ packages:
 
   pure-rand@8.4.2:
     resolution: {integrity: sha512-vvuOGgcuPJAirlHvuQw1TrOiw7ptaIXXmIbNuiNOY6lNGJJH49PQ1Kj4nd783nPdQhQdicgOjVI2yI/9BD6/Ng==}
+
+  qs@6.15.3:
+    resolution: {integrity: sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==}
+    engines: {node: '>=0.6'}
+
+  range-parser@1.3.0:
+    resolution: {integrity: sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==}
+    engines: {node: '>= 0.6'}
+
+  raw-body@3.0.2:
+    resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
+    engines: {node: '>= 0.10'}
 
   react-dom@19.2.8:
     resolution: {integrity: sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==}
@@ -2643,6 +2849,13 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
+  router@2.2.0:
+    resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
+    engines: {node: '>= 18'}
+
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
   saxes@6.0.0:
     resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
     engines: {node: '>=v12.22.7'}
@@ -2659,8 +2872,19 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  send@1.2.1:
+    resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
+    engines: {node: '>= 18'}
+
+  serve-static@2.2.1:
+    resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
+    engines: {node: '>= 18'}
+
   server-only@0.0.1:
     resolution: {integrity: sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==}
+
+  setprototypeof@1.2.0:
+    resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
 
   sharp@0.34.5:
     resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
@@ -2673,6 +2897,22 @@ packages:
   shebang-regex@3.0.0:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
+
+  side-channel-list@1.0.1:
+    resolution: {integrity: sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-map@1.0.1:
+    resolution: {integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-weakmap@1.0.2:
+    resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==}
+    engines: {node: '>= 0.4'}
+
+  side-channel@1.1.1:
+    resolution: {integrity: sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==}
+    engines: {node: '>= 0.4'}
 
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
@@ -2707,6 +2947,10 @@ packages:
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  statuses@2.0.2:
+    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
+    engines: {node: '>= 0.8'}
 
   std-env@4.2.0:
     resolution: {integrity: sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==}
@@ -2796,6 +3040,10 @@ packages:
     resolution: {integrity: sha512-GgouD1B+sWwvkaEq8vXC15DjQitxbvs12oIXELpconwm+Tg3zfcEv4jgzq3vtKverDXsg3VI8aRgNL2Nra0Iog==}
     hasBin: true
 
+  toidentifier@1.0.1:
+    resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
+    engines: {node: '>=0.6'}
+
   tough-cookie@6.0.2:
     resolution: {integrity: sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==}
     engines: {node: '>=16'}
@@ -2831,6 +3079,10 @@ packages:
   type-fest@4.41.0:
     resolution: {integrity: sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==}
     engines: {node: '>=16'}
+
+  type-is@2.1.0:
+    resolution: {integrity: sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==}
+    engines: {node: '>= 18'}
 
   typescript-eslint@8.65.0:
     resolution: {integrity: sha512-/ggrHAwyjENDusvyxbuqxAC2dTnZg/Z8F+fgQtYIz+L6n/9HfSlEZcFGV/NsMNa6CkGk0xUjUAFwC0vHOflvIA==}
@@ -2876,6 +3128,10 @@ packages:
   unist-util-visit@5.1.0:
     resolution: {integrity: sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==}
 
+  unpipe@1.0.0:
+    resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
+    engines: {node: '>= 0.8'}
+
   update-browserslist-db@1.2.3:
     resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
     hasBin: true
@@ -2887,6 +3143,10 @@ packages:
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
+  vary@1.1.2:
+    resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
+    engines: {node: '>= 0.8'}
 
   vfile-message@4.0.3:
     resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
@@ -3055,6 +3315,9 @@ packages:
   wrap-ansi@9.0.2:
     resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
     engines: {node: '>=18'}
+
+  wrappy@1.0.2:
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
   xml-name-validator@5.0.0:
     resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
@@ -3772,10 +4035,19 @@ snapshots:
 
   '@types/aria-query@5.0.4': {}
 
+  '@types/body-parser@1.19.6':
+    dependencies:
+      '@types/connect': 3.4.38
+      '@types/node': 26.1.2
+
   '@types/chai@5.2.3':
     dependencies:
       '@types/deep-eql': 4.0.2
       assertion-error: 2.0.1
+
+  '@types/connect@3.4.38':
+    dependencies:
+      '@types/node': 26.1.2
 
   '@types/debug@4.1.13':
     dependencies:
@@ -3791,9 +4063,24 @@ snapshots:
 
   '@types/estree@1.0.9': {}
 
+  '@types/express-serve-static-core@5.1.3':
+    dependencies:
+      '@types/node': 26.1.2
+      '@types/qs': 6.15.1
+      '@types/range-parser': 1.2.7
+      '@types/send': 1.2.1
+
+  '@types/express@5.0.6':
+    dependencies:
+      '@types/body-parser': 1.19.6
+      '@types/express-serve-static-core': 5.1.3
+      '@types/serve-static': 2.2.0
+
   '@types/hast@3.0.4':
     dependencies:
       '@types/unist': 3.0.3
+
+  '@types/http-errors@2.0.5': {}
 
   '@types/json-schema@7.0.15': {}
 
@@ -3813,6 +4100,10 @@ snapshots:
       pg-protocol: 1.14.0
       pg-types: 2.2.0
 
+  '@types/qs@6.15.1': {}
+
+  '@types/range-parser@1.2.7': {}
+
   '@types/react-dom@19.2.3(@types/react@19.2.17)':
     dependencies:
       '@types/react': 19.2.17
@@ -3820,6 +4111,15 @@ snapshots:
   '@types/react@19.2.17':
     dependencies:
       csstype: 3.2.3
+
+  '@types/send@1.2.1':
+    dependencies:
+      '@types/node': 26.1.2
+
+  '@types/serve-static@2.2.0':
+    dependencies:
+      '@types/http-errors': 2.0.5
+      '@types/node': 26.1.2
 
   '@types/unist@2.0.11': {}
 
@@ -3943,7 +4243,7 @@ snapshots:
       obug: 2.1.4
       std-env: 4.2.0
       tinyrainbow: 3.1.1
-      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(@vitest/coverage-v8@4.1.10)(jsdom@30.0.1(@noble/hashes@2.2.0))(vite@8.1.5(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
+      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(@vitest/coverage-v8@4.1.10)(jsdom@30.0.1(@noble/hashes@2.2.0))(vite@7.3.6(@types/node@26.1.2)(jiti@2.7.0)(lightningcss@1.33.0)(tsx@4.23.1)(yaml@2.9.0))
 
   '@vitest/expect@4.1.10':
     dependencies:
@@ -3993,6 +4293,11 @@ snapshots:
       '@vitest/pretty-format': 4.1.10
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.1
+
+  accepts@2.0.0:
+    dependencies:
+      mime-types: 3.0.2
+      negotiator: 1.0.0
 
   acorn-jsx@5.3.2(acorn@8.18.0):
     dependencies:
@@ -4093,6 +4398,20 @@ snapshots:
 
   bintrees@1.0.2: {}
 
+  body-parser@2.3.0:
+    dependencies:
+      bytes: 3.1.2
+      content-type: 2.0.0
+      debug: 4.4.3(supports-color@10.2.2)
+      http-errors: 2.0.1
+      iconv-lite: 0.7.3
+      on-finished: 2.4.1
+      qs: 6.15.3
+      raw-body: 3.0.2
+      type-is: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
+
   brace-expansion@2.1.4:
     dependencies:
       balanced-match: 1.0.2
@@ -4116,10 +4435,17 @@ snapshots:
 
   bytes-iec@3.1.1: {}
 
+  bytes@3.1.2: {}
+
   call-bind-apply-helpers@1.0.2:
     dependencies:
       es-errors: 1.3.0
       function-bind: 1.1.2
+
+  call-bound@1.0.4:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      get-intrinsic: 1.3.0
 
   caniuse-lite@1.0.30001803: {}
 
@@ -4157,7 +4483,17 @@ snapshots:
 
   commander@14.0.3: {}
 
+  content-disposition@1.1.0: {}
+
+  content-type@1.0.5: {}
+
+  content-type@2.0.0: {}
+
   convert-source-map@2.0.0: {}
+
+  cookie-signature@1.2.2: {}
+
+  cookie@0.7.2: {}
 
   cross-spawn@7.0.6:
     dependencies:
@@ -4195,6 +4531,8 @@ snapshots:
 
   delayed-stream@1.0.0: {}
 
+  depd@2.0.0: {}
+
   dequal@2.0.3: {}
 
   detect-libc@2.1.2: {}
@@ -4211,9 +4549,13 @@ snapshots:
       es-errors: 1.3.0
       gopd: 1.2.0
 
+  ee-first@1.1.1: {}
+
   electron-to-chromium@1.5.399: {}
 
   emoji-regex@10.6.0: {}
+
+  encodeurl@2.0.0: {}
 
   enhanced-resolve@5.24.5:
     dependencies:
@@ -4269,6 +4611,8 @@ snapshots:
       '@esbuild/win32-x64': 0.28.1
 
   escalade@3.2.0: {}
+
+  escape-html@1.0.3: {}
 
   escape-string-regexp@4.0.0: {}
 
@@ -4352,6 +4696,8 @@ snapshots:
 
   esutils@2.0.3: {}
 
+  etag@1.8.1: {}
+
   eventsource-parser@3.1.0: {}
 
   eventsource@4.1.0:
@@ -4359,6 +4705,39 @@ snapshots:
       eventsource-parser: 3.1.0
 
   expect-type@1.4.0: {}
+
+  express@5.2.1:
+    dependencies:
+      accepts: 2.0.0
+      body-parser: 2.3.0
+      content-disposition: 1.1.0
+      content-type: 1.0.5
+      cookie: 0.7.2
+      cookie-signature: 1.2.2
+      debug: 4.4.3(supports-color@10.2.2)
+      depd: 2.0.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 2.1.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      merge-descriptors: 2.0.0
+      mime-types: 3.0.2
+      on-finished: 2.4.1
+      once: 1.4.0
+      parseurl: 1.3.3
+      proxy-addr: 2.0.7
+      qs: 6.15.3
+      range-parser: 1.3.0
+      router: 2.2.0
+      send: 1.2.1
+      serve-static: 2.2.1
+      statuses: 2.0.2
+      type-is: 2.1.0
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
 
   extend-shallow@2.0.1:
     dependencies:
@@ -4390,6 +4769,17 @@ snapshots:
     dependencies:
       flat-cache: 4.0.1
 
+  finalhandler@2.1.1:
+    dependencies:
+      debug: 4.4.3(supports-color@10.2.2)
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
   find-up@5.0.0:
     dependencies:
       locate-path: 6.0.0
@@ -4412,6 +4802,8 @@ snapshots:
       hasown: 2.0.4
       mime-types: 2.1.35
 
+  forwarded@0.2.0: {}
+
   fraction.js@5.3.4: {}
 
   framer-motion@12.42.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
@@ -4422,6 +4814,8 @@ snapshots:
     optionalDependencies:
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
+
+  fresh@2.0.0: {}
 
   fsevents@2.3.3:
     optional: true
@@ -4529,6 +4923,14 @@ snapshots:
 
   html-url-attributes@3.0.1: {}
 
+  http-errors@2.0.1:
+    dependencies:
+      depd: 2.0.0
+      inherits: 2.0.4
+      setprototypeof: 1.2.0
+      statuses: 2.0.2
+      toidentifier: 1.0.1
+
   https-proxy-agent@5.0.1:
     dependencies:
       agent-base: 6.0.2
@@ -4545,6 +4947,10 @@ snapshots:
 
   husky@9.1.7: {}
 
+  iconv-lite@0.7.3:
+    dependencies:
+      safer-buffer: 2.1.2
+
   ieee754@1.2.1: {}
 
   ignore@5.3.2: {}
@@ -4555,7 +4961,11 @@ snapshots:
 
   index-to-position@1.2.0: {}
 
+  inherits@2.0.4: {}
+
   inline-style-parser@0.2.7: {}
+
+  ipaddr.js@1.9.1: {}
 
   is-alphabetical@2.0.1: {}
 
@@ -4579,6 +4989,8 @@ snapshots:
   is-plain-obj@4.1.0: {}
 
   is-potential-custom-element-name@1.0.1: {}
+
+  is-promise@4.0.0: {}
 
   is-retry-allowed@3.0.0: {}
 
@@ -4952,6 +5364,10 @@ snapshots:
 
   mdn-data@2.27.1: {}
 
+  media-typer@1.1.1: {}
+
+  merge-descriptors@2.0.0: {}
+
   micromark-core-commonmark@2.0.3:
     dependencies:
       decode-named-character-reference: 1.3.0
@@ -5145,9 +5561,15 @@ snapshots:
 
   mime-db@1.52.0: {}
 
+  mime-db@1.54.0: {}
+
   mime-types@2.1.35:
     dependencies:
       mime-db: 1.52.0
+
+  mime-types@3.0.2:
+    dependencies:
+      mime-db: 1.54.0
 
   minimatch@10.2.6:
     dependencies:
@@ -5174,6 +5596,8 @@ snapshots:
       picocolors: 1.1.1
 
   natural-compare@1.4.0: {}
+
+  negotiator@1.0.0: {}
 
   next@16.2.10(@opentelemetry/api@1.9.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
     dependencies:
@@ -5202,7 +5626,17 @@ snapshots:
 
   node-releases@2.0.51: {}
 
+  object-inspect@1.13.4: {}
+
   obug@2.1.4: {}
+
+  on-finished@2.4.1:
+    dependencies:
+      ee-first: 1.1.1
+
+  once@1.4.0:
+    dependencies:
+      wrappy: 1.0.2
 
   openapi-typescript@7.13.0(typescript@6.0.3):
     dependencies:
@@ -5251,9 +5685,13 @@ snapshots:
     dependencies:
       entities: 8.0.0
 
+  parseurl@1.3.3: {}
+
   path-exists@4.0.0: {}
 
   path-key@3.1.1: {}
+
+  path-to-regexp@8.4.2: {}
 
   pathe@2.0.3: {}
 
@@ -5335,11 +5773,30 @@ snapshots:
 
   property-information@7.2.0: {}
 
+  proxy-addr@2.0.7:
+    dependencies:
+      forwarded: 0.2.0
+      ipaddr.js: 1.9.1
+
   proxy-from-env@2.1.0: {}
 
   punycode@2.3.1: {}
 
   pure-rand@8.4.2: {}
+
+  qs@6.15.3:
+    dependencies:
+      es-define-property: 1.0.1
+      side-channel: 1.1.1
+
+  range-parser@1.3.0: {}
+
+  raw-body@3.0.2:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.1
+      iconv-lite: 0.7.3
+      unpipe: 1.0.0
 
   react-dom@19.2.8(react@19.2.8):
     dependencies:
@@ -5474,6 +5931,18 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.62.4
       fsevents: 2.3.3
 
+  router@2.2.0:
+    dependencies:
+      debug: 4.4.3(supports-color@10.2.2)
+      depd: 2.0.0
+      is-promise: 4.0.0
+      parseurl: 1.3.3
+      path-to-regexp: 8.4.2
+    transitivePeerDependencies:
+      - supports-color
+
+  safer-buffer@2.1.2: {}
+
   saxes@6.0.0:
     dependencies:
       xmlchars: 2.2.0
@@ -5487,7 +5956,34 @@ snapshots:
 
   semver@7.8.5: {}
 
+  send@1.2.1:
+    dependencies:
+      debug: 4.4.3(supports-color@10.2.2)
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      mime-types: 3.0.2
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.3.0
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  serve-static@2.2.1:
+    dependencies:
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 1.2.1
+    transitivePeerDependencies:
+      - supports-color
+
   server-only@0.0.1: {}
+
+  setprototypeof@1.2.0: {}
 
   sharp@0.34.5:
     dependencies:
@@ -5527,6 +6023,34 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
+  side-channel-list@1.0.1:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-map@1.0.1:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-weakmap@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-map: 1.0.1
+
+  side-channel@1.1.1:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-list: 1.0.1
+      side-channel-map: 1.0.1
+      side-channel-weakmap: 1.0.2
+
   siginfo@2.0.0: {}
 
   size-limit@12.1.0(jiti@2.7.0):
@@ -5550,6 +6074,8 @@ snapshots:
   sprintf-js@1.0.3: {}
 
   stackback@0.0.2: {}
+
+  statuses@2.0.2: {}
 
   std-env@4.2.0: {}
 
@@ -5623,6 +6149,8 @@ snapshots:
     dependencies:
       tldts-core: 7.4.10
 
+  toidentifier@1.0.1: {}
+
   tough-cookie@6.0.2:
     dependencies:
       tldts: 7.4.10
@@ -5652,6 +6180,12 @@ snapshots:
       prelude-ls: 1.2.1
 
   type-fest@4.41.0: {}
+
+  type-is@2.1.0:
+    dependencies:
+      content-type: 2.0.0
+      media-typer: 1.1.1
+      mime-types: 3.0.2
 
   typescript-eslint@8.65.0(eslint@10.8.0(jiti@2.7.0))(typescript@6.0.3):
     dependencies:
@@ -5707,6 +6241,8 @@ snapshots:
       unist-util-is: 6.0.1
       unist-util-visit-parents: 6.0.2
 
+  unpipe@1.0.0: {}
+
   update-browserslist-db@1.2.3(browserslist@4.28.7):
     dependencies:
       browserslist: 4.28.7
@@ -5718,6 +6254,8 @@ snapshots:
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
+
+  vary@1.1.2: {}
 
   vfile-message@4.0.3:
     dependencies:
@@ -5860,6 +6398,8 @@ snapshots:
       ansi-styles: 6.2.3
       string-width: 7.2.0
       strip-ansi: 7.2.0
+
+  wrappy@1.0.2: {}
 
   xml-name-validator@5.0.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -150,6 +150,9 @@ importers:
       express:
         specifier: ^5.2.0
         version: 5.2.1
+      express-rate-limit:
+        specifier: ^8.3.0
+        version: 8.6.1(express@5.2.1)
       pg:
         specifier: ^8.22.0
         version: 8.22.0
@@ -1875,6 +1878,12 @@ packages:
     resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
     engines: {node: '>=12.0.0'}
 
+  express-rate-limit@8.6.1:
+    resolution: {integrity: sha512-0D493aP61w0TJ2A0wy27riRsO7FMQ7FK+KUHOKCSfPvYo0R55aiC6emCVgFUeShH0fq0ICPVzNcgoS+BsbXQCA==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express: '>= 4.11'
+
   express@5.2.1:
     resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
     engines: {node: '>= 18'}
@@ -2104,6 +2113,10 @@ packages:
 
   inline-style-parser@0.2.7:
     resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
+
+  ip-address@10.4.0:
+    resolution: {integrity: sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==}
+    engines: {node: '>= 12'}
 
   ipaddr.js@1.9.1:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
@@ -4706,6 +4719,14 @@ snapshots:
 
   expect-type@1.4.0: {}
 
+  express-rate-limit@8.6.1(express@5.2.1):
+    dependencies:
+      debug: 4.4.3(supports-color@10.2.2)
+      express: 5.2.1
+      ip-address: 10.4.0
+    transitivePeerDependencies:
+      - supports-color
+
   express@5.2.1:
     dependencies:
       accepts: 2.0.0
@@ -4964,6 +4985,8 @@ snapshots:
   inherits@2.0.4: {}
 
   inline-style-parser@0.2.7: {}
+
+  ip-address@10.4.0: {}
 
   ipaddr.js@1.9.1: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,8 +9,11 @@ allowBuilds:
 # postcss <8.5.10 has the </style> XSS advisory (GHSA-qx2v-qp2m-jg93) - next pins 8.4.31.
 # js-yaml 3.x <3.15.0 has the merge-key DoS advisory (GHSA-h67p-54hq-rp68) via gray-matter;
 # scoped to @3 so a future js-yaml 4.x consumer is never downgraded.
+# path-to-regexp 0.x has the backtracking-ReDoS advisory (GHSA-9wv6-86v2-598j);
+# scoped to @0 so express 5 - which requires 8.x - is not dragged back to a
+# version whose router API it cannot use.
 overrides:
-  path-to-regexp: 0.1.13
+  "path-to-regexp@0": 0.1.13
   vite: 7.3.6
   axios: 1.17.0
   postcss: ^8.5.16


### PR DESCRIPTION
## Linked issue

Closes #897 (9.2 orbital-express-starter boilerplate)

## What changed and why

`docs/COOKBOOK.md` describes the ingest → cursor → signed-webhook composition in prose. Prose does not compile. This is the version that runs.

`examples/express-starter/` — an EventEngine watching configured addresses, a `WebhookDelivery` per address, a cursor that survives restarts, and an Express receiver that verifies what arrives. The process is both sender and receiver by default, so `pnpm dev` shows the entire loop locally with no other services.

### Express, and what it cost

The issue asks for a justification. **Express**, because this is a *reference*: a reader should recognise the shape and lift it into the app they already run, and Express is still what most Node backends use. The composition itself is framework-agnostic — `createReceiver()` is 60 lines and the only Express surface is `app.post`.

It did surface one thing worth knowing: **Express 5 requires `path-to-regexp@8`, and this workspace pinned `path-to-regexp: 0.1.13` globally** for [GHSA-9wv6-86v2-598j](https://github.com/advisories/GHSA-9wv6-86v2-598j). The unscoped override dragged Express 5's router back to a version whose API it cannot use — `TypeError: pathRegexp.match is not a function` on every route. The override is now `"path-to-regexp@0": 0.1.13`, so the advisory stays covered for anything on the 0.x line and Express 5 resolves 8.4.2. Same pattern the `js-yaml@3` pin already uses.

### The three guarantees, each with a test

**Resume after restart.** The cursor is `PostgresCursorStore` when `DATABASE_URL` is set, `FileCursorStore` otherwise — the file store is not a toy, it survives a restart, which is what the guarantee needs. Tests assert a second store instance over the same directory reads what the first persisted, that an unseen stream reports `null` rather than a stale cursor, and that it advances monotonically.

**Signature verification.** Two details the receiver gets right on purpose: it verifies against the **raw body** (`express.json()` re-serialises, and the bytes are not always identical to what was signed), and it **rejects rather than logs** — a tampered payload gets a 401 and never reaches application code. Tests cover a valid delivery, a payload with one digit changed after signing, a wrong secret, and missing headers.

**Graceful shutdown.** SIGTERM/SIGINT call `engine.stop()` and **await it** before `process.exit`. The test asserts that ordering — `["stop", "exit:0"]` — not merely that a handler is registered, because exiting on the signal without waiting is exactly what loses the final cursor write.

### Also

- `docker-compose.yml` for Postgres, with the `cursor_store` table created on startup
- `.env.example` and a config loader that **refuses to start** on a missing address list, a secret under 16 characters, or a non-numeric port
- README with the step-by-step resume-after-restart walkthrough the issue asks for

## Test plan

- [x] Existing tests pass (`pnpm -r test`, all seven workspaces green)
- [x] New tests added — 14, no containers required
- [x] Typechecks pass
- [x] Coverage gate green
- [ ] Manually tested against testnet — see below

## Not verified here

- **`docker compose up && pnpm start` against real Postgres.** The compose file and the `PostgresCursorStore` wiring are written but I cannot run Docker in this environment, so the Postgres path is untested. The file-cursor path — same guarantee, same code path through `EventEngine` — is covered.
- **A live testnet event end to end.** The receiver is tested against signed payloads directly rather than against Horizon.

Both are worth ten minutes of manual confirmation before this is held up as *the* backend reference.

## Breaking changes

None. New example package; the `path-to-regexp` override change is a narrowing that leaves the advisory covered.
