### PR TITLE
test(abi-registry): restore and ratchet the coverage floor

### DIFF
--- a/packages/abi-registry/vitest.config.ts
+++ b/packages/abi-registry/vitest.config.ts
@@ -18,16 +18,17 @@ export default defineConfig({
         // Pure type declarations — no runtime code to cover
         "src/types.ts",
       ],
-      // Functions re-baselined from 87 to 80: #937, #940, #947 and #960 landed
-      // between #923 measuring the baseline and #923 merging, adding exported
-      // helpers faster than tests reached them (measured 85.42%).
-      // Lines temporarily reduced from 77 to 76 due to being 0.05% short (1336/1737 vs need 1337)
-      // TODO: Add 1 more line of coverage to restore to 77%
+      // Ratcheted to just under measured on `main` after #944 landed:
+      // statements 77.19, branches 68.68, functions 89.37, lines 78.00.
+      //
+      // The lines floor had been dropped 77 -> 76 in #944 with a TODO, when the
+      // branch was 0.05% short. It is not short any more, so the floor is back
+      // above where it was rather than left as a ratchet that moved backwards.
       thresholds: {
-        statements: 76,
-        branches: 66,
-        functions: 80,
-        lines: 76,
+        statements: 77,
+        branches: 68,
+        functions: 89,
+        lines: 77,
       },
       reporter: ["text", "html", "json-summary"],
     },


### PR DESCRIPTION
## What changed

#944 lowered the abi-registry lines coverage floor from **77 → 76** with a `TODO: Add 1 more line of coverage to restore to 77%`, because that branch was 0.05% short (1336/1737, needed 1337).

Measured on `main` now that it has landed:

| | Measured | Old floor | New floor |
|---|---|---|---|
| Statements | 77.19% | 76 | **77** |
| Branches | 68.68% | 66 | **68** |
| Functions | 89.37% | 80 | **89** |
| Lines | 78.00% | 76 | **77** |

It is not short any more, so rather than only undoing the drop, all four floors are set to just under measured. A ratchet that can move backwards is not a ratchet — the whole value of these numbers is that they only go one way.

The `functions` floor is the biggest move (80 → 89). It had been re-baselined down to 80 in #923 because #937/#940/#947/#960 added exported helpers faster than tests reached them; that gap has since closed on its own.

## Test plan

- [x] `pnpm --filter @orbital-stellar/abi-registry test:coverage` passes at the new floors (338 tests)
- [x] `pnpm -r --if-present test:coverage` green across every workspace
- [x] `format:check` clean

Config-only change; no source touched.