### PR TITLE
feat(api): implement observability, health probe, and SLO docs (#919)

### DIFF
--- a/apps/web/app/api/registry/metrics.ts
+++ b/apps/web/app/api/registry/metrics.ts
@@ -1,0 +1,55 @@
+import { metrics, trace } from '@opentelemetry/api';
+
+const meter = metrics.getMeter('hosted-api-registry');
+
+// Request counters and histograms
+export const requestCounter = meter.createCounter('registry_api_requests_total', {
+  description: 'Total number of HTTP requests to the registry API',
+});
+
+export const requestLatencyHistogram = meter.createHistogram('registry_api_request_duration_seconds', {
+  description: 'Latency histogram for registry API requests',
+  unit: 's',
+});
+
+// Cache metrics
+export const cacheHitCounter = meter.createCounter('registry_api_cache_hits_total', {
+  description: 'Total cache hits',
+});
+
+export const cacheMissCounter = meter.createCounter('registry_api_cache_misses_total', {
+  description: 'Total cache misses',
+});
+
+// Chain read & fallback metrics
+export const chainReadCounter = meter.createCounter('registry_api_chain_reads_total', {
+  description: 'Total read requests reaching the chain',
+});
+
+export const fallbackCounter = meter.createCounter('registry_api_fallbacks_total', {
+  description: 'Total requests triggering fallback mechanism',
+});
+
+// Structured logging helper for fallbacks
+export function logAndRecordFallback(specHash: string, reason: string, details?: Record<string, unknown>) {
+  fallbackCounter.add(1, { reason });
+
+  console.warn(
+    JSON.stringify({
+      level: 'warn',
+      event: 'registry_fallback_triggered',
+      timestamp: new Date().toISOString(),
+      spec_hash: specHash,
+      reason,
+      ...details,
+    })
+  );
+}
+
+// Tracing span attribute helper
+export function setSpecHashSpanAttribute(specHash: string) {
+  const activeSpan = trace.getActiveSpan();
+  if (activeSpan) {
+    activeSpan.setAttribute('spec.hash', specHash);
+  }
+}

--- a/apps/web/app/api/v1/registry/health/route.ts
+++ b/apps/web/app/api/v1/registry/health/route.ts
@@ -1,0 +1,12 @@
+import { NextResponse } from 'next/server';
+
+export async function GET() {
+  const healthCheck = {
+    status: 'ok',
+    timestamp: new Date().toISOString(),
+    uptime: process.uptime(),
+    service: 'hosted-api-registry',
+  };
+
+  return NextResponse.json(healthCheck, { status: 200 });
+}

--- a/docs/slo.md
+++ b/docs/slo.md
@@ -1,0 +1,16 @@
+# Service Level Objectives (SLOs) - Hosted API
+
+This document defines availability, latency, and freshness targets for hosted registry endpoints.
+
+## 1. Availability Target
+* **Objective:** 99.9% uptime over a rolling 30-day window.
+* **Indicator (SLI):** Ratio of successful responses (`2xx` and `3xx`) against total requests served by `/v1/registry/*`.
+* **Health Probe:** Continuously monitored via `/v1/registry/health`.
+
+## 2. Latency Target (p95)
+* **Objective:** 95% of requests served in under 200 milliseconds ($p95 < 200ms$).
+* **Indicator (SLI):** Measured via `registry_api_request_duration_seconds` metric.
+
+## 3. Freshness-in-Ledgers Target
+* **Objective:** 99.0% of resolution requests return chain state synchronized within 2 ledger rounds ($< 30$ seconds).
+* **Indicator (SLI):** Tracked using `registry_api_chain_reads_total` versus `registry_api_fallbacks_total`.


### PR DESCRIPTION
### Summary of Changes (#919)

- **Metrics Instrumentation (`apps/web/app/api/registry/metrics.ts`)**: Added OpenTelemetry instruments for request counts, latency histogram, cache hits/misses, chain reads, and fallbacks following the `OtelWebhookMetrics` pattern.
- **Tracing & Structured Logging**: Configured span attribute injection for `spec.hash` and JSON structured log output on fallback routes.
- **Uptime Probe (`apps/web/app/api/v1/registry/health/route.ts`)**: Created the public health check endpoint returning system status and uptime.
- **SLO Definitions (`docs/slo.md`)**: Documented service level targets for availability (99.9%), p95 latency (<200ms), and ledger freshness.

Closes #919