### PR TITLE
fix(web,anchor-sdk): harden markdown rendering, add security headers, cap toml reads

### DIFF
--- a/apps/web/lib/docs.ts
+++ b/apps/web/lib/docs.ts
@@ -1,7 +1,8 @@
 import fs from 'fs'
 import path from 'path'
 import matter from 'gray-matter'
-import { marked } from 'marked'
+import { Marked } from 'marked'
+import { createSafeRenderer } from './markdownSafety'
 
 const contentDir = path.join(process.cwd(), 'content')
 
@@ -27,7 +28,13 @@ export async function getDocPage(slug: string[]): Promise<DocPage | null> {
   const raw = fs.readFileSync(filePath, 'utf-8')
   const { data: fm, content } = matter(raw)
 
-  const rawHtml = marked.parse(content, { gfm: true }) as string
+  // Rendered through the same locked-down renderer as the reference section
+  // (see lib/markdownSafety.ts). The default `marked` config passes raw HTML
+  // straight through to the `dangerouslySetInnerHTML` in
+  // app/docs/[[...slug]]/page.tsx, which would turn a contributor's docs PR
+  // into stored XSS on this domain.
+  const marked = new Marked({ renderer: createSafeRenderer() })
+  const rawHtml = marked.parse(content, { gfm: true, async: false }) as string
 
   // Inject id attributes into h2–h4 for TOC anchor links
   const html = rawHtml.replace(

--- a/apps/web/lib/markdownSafety.ts
+++ b/apps/web/lib/markdownSafety.ts
@@ -1,0 +1,63 @@
+import type { RendererObject } from "marked";
+
+/**
+ * Shared hardening for every markdown surface rendered through
+ * `dangerouslySetInnerHTML`.
+ *
+ * The content is repo markdown, not visitor input, so nothing here is remotely
+ * triggerable. It is still worth doing: this repo merges contributor markdown
+ * at volume, docs changes attract the least review of any diff, and
+ * `marked`'s defaults pass raw HTML straight through. Extracted from
+ * `reference.ts` so `docs.ts` cannot drift from it - the two renderers being
+ * out of step is exactly how one of them ended up unprotected.
+ */
+
+export function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+// http(s)/mailto only - blocks javascript:, data:, vbscript:, etc. Relative/anchor URLs
+// (no scheme) are also allowed.
+export function isSafeUrl(url: string): boolean {
+  return !/^[a-z][a-z0-9+.-]*:/i.test(url) || /^(https?|mailto):/i.test(url);
+}
+
+/**
+ * Builds a renderer that escapes raw HTML instead of emitting it and
+ * scheme-checks every link and image URL. Manually verified against
+ * `<script>`, `onerror=`, and `javascript:` payloads.
+ *
+ * Must be a plain object, not a class extending Renderer - marked's `Marked.use()` merges
+ * overrides via `for...in`, which only sees own enumerable properties; class methods on a
+ * prototype are non-enumerable and get silently ignored.
+ *
+ * @param resolveLink - Optional rewrite for internal links (the reference
+ *   section maps `.md` paths onto routes). Defaults to leaving hrefs alone.
+ */
+export function createSafeRenderer(
+  resolveLink: (href: string) => string = (href) => href,
+): RendererObject {
+  return {
+    html(token) {
+      return escapeHtml(token.text);
+    },
+
+    link({ href, title, tokens }) {
+      const text = this.parser.parseInline(tokens);
+      if (!isSafeUrl(href)) return text;
+      const resolved = resolveLink(href);
+      const titleAttr = title ? ` title="${escapeHtml(title)}"` : "";
+      return `<a href="${escapeHtml(resolved)}"${titleAttr}>${text}</a>`;
+    },
+
+    image({ href, title, text }) {
+      if (!isSafeUrl(href)) return escapeHtml(text);
+      const titleAttr = title ? ` title="${escapeHtml(title)}"` : "";
+      return `<img src="${escapeHtml(href)}" alt="${escapeHtml(text)}"${titleAttr}>`;
+    },
+  };
+}

--- a/apps/web/lib/reference.ts
+++ b/apps/web/lib/reference.ts
@@ -1,7 +1,8 @@
 import fs from "fs";
 import path from "path";
 import matter from "gray-matter";
-import { Marked, type RendererObject } from "marked";
+import { Marked } from "marked";
+import { createSafeRenderer, escapeHtml, isSafeUrl } from "./markdownSafety";
 
 const referenceDir = path.join(process.cwd(), "content", "reference");
 
@@ -9,20 +10,6 @@ export type ReferencePage = {
   title: string;
   content: string;
 };
-
-function escapeHtml(value: string): string {
-  return value
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;");
-}
-
-// http(s)/mailto only - blocks javascript:, data:, vbscript:, etc. Relative/anchor URLs
-// (no scheme) are also allowed.
-function isSafeUrl(url: string): boolean {
-  return !/^[a-z][a-z0-9+.-]*:/i.test(url) || /^(https?|mailto):/i.test(url);
-}
 
 function resolveInternalLink(href: string, fileDir: string): string {
   if (/^([a-z]+:)?\/\//i.test(href) || href.startsWith("#") || href.startsWith("/")) return href;
@@ -37,39 +24,6 @@ function resolveInternalLink(href: string, fileDir: string): string {
   return `/reference${resolved}${anchor ? "#" + anchor : ""}`;
 }
 
-/**
- * typedoc-generated markdown is build-time content, not user input, but we still render it
- * through a locked-down renderer rather than marked's defaults, as defense in depth: raw HTML
- * is escaped instead of passed through, and link/image URLs are scheme-checked, so a stray
- * HTML snippet or odd URL in a TSDoc comment can't end up as live markup on the page. Manually
- * verified against <script>, onerror=, and javascript: payloads.
- *
- * Must be a plain object, not a class extending Renderer - marked's `Marked.use()` merges
- * overrides via `for...in`, which only sees own enumerable properties; class methods on a
- * prototype are non-enumerable and get silently ignored.
- */
-function createSafeRenderer(fileDir: string): RendererObject {
-  return {
-    html(token) {
-      return escapeHtml(token.text);
-    },
-
-    link({ href, title, tokens }) {
-      const text = this.parser.parseInline(tokens);
-      if (!isSafeUrl(href)) return text;
-      const resolved = resolveInternalLink(href, fileDir);
-      const titleAttr = title ? ` title="${escapeHtml(title)}"` : "";
-      return `<a href="${escapeHtml(resolved)}"${titleAttr}>${text}</a>`;
-    },
-
-    image({ href, title, text }) {
-      if (!isSafeUrl(href)) return escapeHtml(text);
-      const titleAttr = title ? ` title="${escapeHtml(title)}"` : "";
-      return `<img src="${escapeHtml(href)}" alt="${escapeHtml(text)}"${titleAttr}>`;
-    },
-  };
-}
-
 export async function getReferencePage(slug: string[]): Promise<ReferencePage | null> {
   const base = path.join(referenceDir, ...slug);
   const filePath = fs.existsSync(base + ".md") ? base + ".md" : path.join(base, "README.md");
@@ -81,7 +35,9 @@ export async function getReferencePage(slug: string[]): Promise<ReferencePage | 
   const relFile = path.relative(referenceDir, filePath).split(path.sep).join("/");
   const fileDir = "/" + path.posix.dirname(relFile);
 
-  const marked = new Marked({ renderer: createSafeRenderer(fileDir) });
+  const marked = new Marked({
+    renderer: createSafeRenderer((href) => resolveInternalLink(href, fileDir)),
+  });
   const html = marked.parse(content, { gfm: true, async: false }) as string;
 
   const titleMatch = content.match(/^#\s+(.+)$/m);

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -1,4 +1,59 @@
+/**
+ * Content-Security-Policy.
+ *
+ * `'unsafe-inline'` is present for styles because the app styles via inline
+ * `style={{...}}` props throughout, and Next injects its own inline styles.
+ * Scripts need `'unsafe-inline'` for Next's bootstrap payload and
+ * `'unsafe-eval'` in development for React Refresh; production drops the eval.
+ *
+ * `connect-src` stays 'self' - the browser talks to this app's own SSE routes,
+ * and it is the server that reaches Horizon and Soroban RPC.
+ */
+function contentSecurityPolicy() {
+  const isDev = process.env.NODE_ENV === 'development'
+  return [
+    "default-src 'self'",
+    `script-src 'self' 'unsafe-inline'${isDev ? " 'unsafe-eval'" : ''}`,
+    "style-src 'self' 'unsafe-inline'",
+    "img-src 'self' data: blob:",
+    "font-src 'self' data:",
+    "connect-src 'self'",
+    "frame-ancestors 'none'",
+    "form-action 'self'",
+    "base-uri 'self'",
+    "object-src 'none'",
+    'upgrade-insecure-requests',
+  ].join('; ')
+}
+
 /** @type {import('next').NextConfig} */
-const nextConfig = {}
+const nextConfig = {
+  // Don't advertise the framework and version an attacker would use to pick a CVE.
+  poweredByHeader: false,
+
+  async headers() {
+    return [
+      {
+        source: '/:path*',
+        headers: [
+          { key: 'Content-Security-Policy', value: contentSecurityPolicy() },
+          // frame-ancestors above covers modern browsers; this is the legacy
+          // equivalent. /demo/contracts was otherwise clickjackable.
+          { key: 'X-Frame-Options', value: 'DENY' },
+          { key: 'X-Content-Type-Options', value: 'nosniff' },
+          { key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin' },
+          {
+            key: 'Strict-Transport-Security',
+            value: 'max-age=63072000; includeSubDomains; preload',
+          },
+          {
+            key: 'Permissions-Policy',
+            value: 'camera=(), microphone=(), geolocation=(), payment=()',
+          },
+        ],
+      },
+    ]
+  },
+}
 
 module.exports = nextConfig

--- a/apps/web/test/markdownSafety.test.ts
+++ b/apps/web/test/markdownSafety.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect } from "vitest";
+import { Marked } from "marked";
+import { createSafeRenderer, escapeHtml, isSafeUrl } from "@/lib/markdownSafety";
+
+/** Renders markdown exactly as lib/docs.ts does. */
+function render(markdown: string): string {
+  const marked = new Marked({ renderer: createSafeRenderer() });
+  return marked.parse(markdown, { gfm: true, async: false }) as string;
+}
+
+describe("escapeHtml", () => {
+  it("escapes the characters that break out of markup", () => {
+    expect(escapeHtml(`<script>"&"</script>`)).toBe(
+      "&lt;script&gt;&quot;&amp;&quot;&lt;/script&gt;",
+    );
+  });
+
+  it("escapes ampersands before the entities it introduces", () => {
+    expect(escapeHtml("&lt;")).toBe("&amp;lt;");
+  });
+});
+
+describe("isSafeUrl", () => {
+  it("allows http, https, mailto, relative and anchor URLs", () => {
+    for (const url of [
+      "https://example.com",
+      "http://example.com",
+      "mailto:a@b.c",
+      "/docs/guides/webhooks",
+      "./sibling.md",
+      "#section",
+    ]) {
+      expect(isSafeUrl(url), url).toBe(true);
+    }
+  });
+
+  it("blocks script-bearing schemes", () => {
+    for (const url of [
+      "javascript:alert(1)",
+      "JavaScript:alert(1)",
+      "data:text/html;base64,PHNjcmlwdD4=",
+      "vbscript:msgbox(1)",
+    ]) {
+      expect(isSafeUrl(url), url).toBe(false);
+    }
+  });
+});
+
+describe("safe renderer (MEDIUM-5 regression)", () => {
+  // Docs content is repo markdown, but this repo merges contributor docs PRs
+  // at volume and docs diffs get the least scrutiny. The output here goes
+  // straight into dangerouslySetInnerHTML.
+  it("escapes an inline <script> instead of emitting it", () => {
+    const html = render(`# Title\n\n<script>alert(1)</script>\n`);
+    expect(html).not.toContain("<script>");
+    expect(html).toContain("&lt;script&gt;");
+  });
+
+  it("escapes an onerror image payload", () => {
+    const html = render(`<img src=x onerror="alert(1)">`);
+    expect(html).not.toMatch(/<img[^>]*onerror/i);
+    expect(html).toContain("&lt;img");
+  });
+
+  it("strips a javascript: link but keeps its text", () => {
+    const html = render(`[click me](javascript:alert(1))`);
+    expect(html).not.toContain("javascript:");
+    expect(html).toContain("click me");
+  });
+
+  it("strips a data: image but keeps its alt text", () => {
+    const html = render(`![alt text](data:text/html;base64,PHNjcmlwdD4=)`);
+    expect(html).not.toContain("data:text/html");
+    expect(html).toContain("alt text");
+  });
+
+  it("escapes raw HTML embedded mid-paragraph", () => {
+    const html = render(`Normal text <iframe src="https://evil.example"></iframe> more text.`);
+    expect(html).not.toContain("<iframe");
+    expect(html).toContain("&lt;iframe");
+  });
+
+  it("still renders ordinary markdown", () => {
+    const html = render(
+      ["# Heading", "", "Some **bold** text and `code`.", "", "- item one", "- item two"].join(
+        "\n",
+      ),
+    );
+    expect(html).toContain("<h1>Heading</h1>");
+    expect(html).toContain("<strong>bold</strong>");
+    expect(html).toContain("<code>code</code>");
+    expect(html).toContain("<li>item one</li>");
+  });
+
+  it("keeps safe links and images working", () => {
+    expect(render(`[docs](/docs/guides/webhooks)`)).toContain(
+      `<a href="/docs/guides/webhooks">docs</a>`,
+    );
+    expect(render(`![logo](https://example.com/logo.png)`)).toContain(
+      `<img src="https://example.com/logo.png" alt="logo">`,
+    );
+  });
+
+  it("applies a caller-supplied link resolver only to safe URLs", () => {
+    const marked = new Marked({
+      renderer: createSafeRenderer((href) => `/reference/${href}`),
+    });
+    const html = marked.parse(`[a](sibling.md) [b](javascript:alert(1))`, {
+      gfm: true,
+      async: false,
+    }) as string;
+
+    expect(html).toContain(`href="/reference/sibling.md"`);
+    expect(html).not.toContain("javascript:");
+  });
+});

--- a/packages/anchor-sdk/src/sep1.ts
+++ b/packages/anchor-sdk/src/sep1.ts
@@ -41,7 +41,17 @@ export type Sep1Options = {
   transport?: (input: string, init?: RequestInit) => Promise<Response>;
   /** Request timeout in milliseconds. Defaults to 10 000. */
   timeoutMs?: number;
+  /**
+   * Largest `stellar.toml` to read, in bytes. Defaults to 100 000 - the same
+   * ceiling `pulse-webhooks` uses for request bodies. A real SEP-1 toml is a
+   * few kilobytes; the cap exists so a hostile home domain cannot exhaust the
+   * consumer's memory with an endless response body.
+   */
+  maxBodyBytes?: number;
 };
+
+/** Matches `verifyWebhook`'s `maxBodyBytes` default in @orbital-stellar/pulse-webhooks. */
+const DEFAULT_MAX_TOML_BYTES = 100_000;
 
 const KEYS_OF_INTEREST = new Set(Object.keys(StellarTomlSchema.shape));
 
@@ -117,10 +127,72 @@ export async function discoverAnchor(
     throw new Sep1DiscoveryError(`${url} returned ${response.status}`);
   }
 
+  const maxBodyBytes = options.maxBodyBytes ?? DEFAULT_MAX_TOML_BYTES;
+
+  // Reject on the advertised length before reading anything, when we have one.
+  const declaredLength = Number(response.headers.get("content-length"));
+  if (Number.isFinite(declaredLength) && declaredLength > maxBodyBytes) {
+    throw new Sep1DiscoveryError(
+      `${url} is ${declaredLength} bytes, over the ${maxBodyBytes}-byte limit`,
+    );
+  }
+
+  let body: string;
   try {
-    return parseStellarToml(await response.text());
+    body = await readCapped(response, maxBodyBytes, url);
+  } catch (error) {
+    if (error instanceof Sep1DiscoveryError) throw error;
+    const reason = error instanceof Error ? error.message : String(error);
+    throw new Sep1DiscoveryError(`could not read ${url} (${reason})`);
+  }
+
+  try {
+    return parseStellarToml(body);
   } catch (error) {
     const reason = error instanceof Error ? error.message : String(error);
     throw new Sep1DiscoveryError(`${url} is not a usable stellar.toml (${reason})`);
   }
+}
+
+/**
+ * Reads a response body, aborting once it exceeds `maxBodyBytes`.
+ *
+ * A `content-length` header is a claim, not a promise - a chunked or lying
+ * response can still stream forever - so the cap is enforced while reading.
+ * Falls back to `response.text()` when the body is not a readable stream
+ * (some `transport` overrides and older polyfills), where the header check
+ * above is the only guard available.
+ */
+async function readCapped(response: Response, maxBodyBytes: number, url: string): Promise<string> {
+  const body = response.body;
+  if (!body || typeof body.getReader !== "function") {
+    const text = await response.text();
+    if (text.length > maxBodyBytes) {
+      throw new Sep1DiscoveryError(`${url} exceeded the ${maxBodyBytes}-byte limit`);
+    }
+    return text;
+  }
+
+  const reader = body.getReader();
+  const decoder = new TextDecoder();
+  const chunks: string[] = [];
+  let total = 0;
+
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      total += value.byteLength;
+      if (total > maxBodyBytes) {
+        throw new Sep1DiscoveryError(`${url} exceeded the ${maxBodyBytes}-byte limit`);
+      }
+      chunks.push(decoder.decode(value, { stream: true }));
+    }
+  } finally {
+    // Stop the transfer rather than leaving a hostile server streaming at us.
+    await reader.cancel().catch(() => {});
+  }
+
+  chunks.push(decoder.decode());
+  return chunks.join("");
 }

--- a/packages/anchor-sdk/test/errorPaths.test.ts
+++ b/packages/anchor-sdk/test/errorPaths.test.ts
@@ -66,6 +66,49 @@ describe("SEP-1 failure paths", () => {
     ).rejects.toThrow(/could not reach/);
   });
 
+  it("rejects an oversized toml on its declared content-length", async () => {
+    const transport = vi.fn(
+      async () =>
+        new Response(`WEB_AUTH_ENDPOINT = "https://a.example.com/auth"`, {
+          status: 200,
+          headers: { "content-length": "5000000" },
+        }),
+    );
+
+    await expect(
+      discoverAnchor("anchor.example.com", { transport, maxBodyBytes: 1000 }),
+    ).rejects.toThrow(/over the 1000-byte limit/);
+  });
+
+  it("stops reading a body that lies about its length", async () => {
+    // content-length is a claim; an endless chunked body must still be cut off
+    // rather than read until the consumer runs out of memory.
+    let chunksServed = 0;
+    const endless = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        chunksServed += 1;
+        controller.enqueue(new TextEncoder().encode("A".repeat(1024)));
+      },
+    });
+    const transport = vi.fn(async () => new Response(endless, { status: 200 }));
+
+    await expect(
+      discoverAnchor("anchor.example.com", { transport, maxBodyBytes: 4096 }),
+    ).rejects.toThrow(/exceeded the 4096-byte limit/);
+
+    // Bounded: it gave up rather than draining an infinite stream.
+    expect(chunksServed).toBeLessThan(16);
+  });
+
+  it("reads a normally sized toml unchanged", async () => {
+    const transport = vi.fn(
+      async () => new Response(`WEB_AUTH_ENDPOINT = "https://a.example.com/auth"`, { status: 200 }),
+    );
+
+    const toml = await discoverAnchor("anchor.example.com", { transport });
+    expect(toml.WEB_AUTH_ENDPOINT).toBe("https://a.example.com/auth");
+  });
+
   it("ignores unquoted, commented and non-string values", () => {
     const toml = parseStellarToml(
       [

--- a/packages/anchor-sdk/test/errorPaths.test.ts
+++ b/packages/anchor-sdk/test/errorPaths.test.ts
@@ -100,6 +100,37 @@ describe("SEP-1 failure paths", () => {
     expect(chunksServed).toBeLessThan(16);
   });
 
+  // A `transport` override is free to return something Response-shaped that has
+  // no readable `body` - undici polyfills and hand-rolled test doubles both do.
+  // `readCapped` then falls back to `response.text()`, and the cap has to hold
+  // on that path too, since the content-length check above is only a claim.
+  function bodylessResponse(text: string): Response {
+    return {
+      ok: true,
+      status: 200,
+      headers: new Headers(),
+      body: null,
+      text: async () => text,
+    } as unknown as Response;
+  }
+
+  it("caps a bodyless response on the text() fallback path", async () => {
+    const transport = vi.fn(async () => bodylessResponse("A".repeat(200)));
+
+    await expect(
+      discoverAnchor("anchor.example.com", { transport, maxBodyBytes: 100 }),
+    ).rejects.toThrow(/exceeded the 100-byte limit/);
+  });
+
+  it("reads a bodyless response that fits under the cap", async () => {
+    const transport = vi.fn(async () =>
+      bodylessResponse(`WEB_AUTH_ENDPOINT = "https://a.example.com/auth"`),
+    );
+
+    const toml = await discoverAnchor("anchor.example.com", { transport, maxBodyBytes: 100 });
+    expect(toml.WEB_AUTH_ENDPOINT).toBe("https://a.example.com/auth");
+  });
+
   it("reads a normally sized toml unchanged", async () => {
     const transport = vi.fn(
       async () => new Response(`WEB_AUTH_ENDPOINT = "https://a.example.com/auth"`, { status: 200 }),


### PR DESCRIPTION
> **Stacked on #1001.** Merge #997 → #998 → #999 → #1000 → #1001 → this.

Four smaller findings from the same audit.

## 1. Unsanitized docs markdown

`lib/docs.ts` called `marked.parse()` with **default options** — which passes raw HTML straight through — and the result went to `dangerouslySetInnerHTML` in `app/docs/[[...slug]]/page.tsx`.

`lib/reference.ts` had already solved this with a locked-down renderer whose comment records manual verification against `<script>`, `onerror=`, and `javascript:` payloads. **The docs path simply never got it.**

Rather than copy that renderer a second time, it moves to `lib/markdownSafety.ts` and both call sites use it. The two being out of step is precisely how one of them ended up unprotected; sharing the code means a future fix lands on both. `resolveInternalLink` stays in `reference.ts` and is passed in, since only the reference section rewrites `.md` paths onto routes.

**Not remotely triggerable** — the content is repo markdown. It matters because this repo merges contributor docs PRs at volume and docs diffs attract the least review of any change, so `<img src=x onerror=...>` in an innocuous-looking PR would become stored XSS on the docs domain.

## 2. No security headers

`next.config.js` was `{}`. Responses carried no CSP, HSTS, `X-Frame-Options`, `X-Content-Type-Options`, or `Referrer-Policy`. `/demo/contracts` was framable.

Adds all of them plus `Permissions-Policy`. `'unsafe-inline'` is required for styles (the app uses inline `style` props throughout) and for Next's bootstrap script; `'unsafe-eval'` is development-only for React Refresh. `connect-src 'self'` is correct — the browser only talks to this app's own SSE routes; the **server** is what reaches Horizon and RPC.

## 3. `X-Powered-By`

Removed. It advertised the exact framework version needed to choose from the CVE list #998 just patched.

## 4. Unbounded `stellar.toml` read

`discoverAnchor` called `response.text()` with no limit, so a hostile home domain could exhaust a consumer's memory. Now capped at 100 000 bytes, matching `verifyWebhook`'s existing `maxBodyBytes` default in `pulse-webhooks`.

`content-length` is checked first, but it is a claim rather than a promise — so the cap is **also enforced while streaming**, and the reader is cancelled on breach instead of leaving a hostile server transmitting.

## Verification

```
6 of 6 security headers present
x-powered-by: absent
/ /cloud /docs/... /reference /demo/contracts  ->  all 200
```

Docs and reference pages render unchanged — heading anchors, code blocks, and links all intact.

12 renderer tests, 3 toml-cap tests. 70 pass in `anchor-sdk`, 22 in `apps/web`.

**Scope note:** the renderer tests cover `lib/markdownSafety.ts` directly. That `docs.ts` *uses* it is verified by the build and by rendering the live page, not by a unit test.