### PR TITLE
test(web): cover the demo safety rails and gate them in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,6 +181,29 @@ jobs:
       - name: Typecheck apps/web
         run: pnpm tsc --noEmit -p apps/web/tsconfig.json
 
+  test-web:
+    needs: changes
+    if: ${{ needs.changes.outputs.web == 'true' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v7
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 20
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      # apps/web imports pulse-core and pulse-webhooks from their built output.
+      - name: Build workspace dependencies
+        run: |
+          pnpm tsc -p packages/abi-registry/tsconfig.json
+          pnpm tsc -p packages/pulse-core/tsconfig.json
+          pnpm tsc -p packages/pulse-webhooks/tsconfig.json
+      - name: Test apps/web
+        run: pnpm --filter orbital/web run test
+
   build-web:
     needs: changes
     if: ${{ needs.changes.outputs.web == 'true' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,7 +189,7 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v7
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@v6.0.9
       - uses: actions/setup-node@v7
         with:
           node-version: 20

--- a/apps/web/test/demoEmitterConfig.test.ts
+++ b/apps/web/test/demoEmitterConfig.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { assertRestrictedSecretNetwork } from "@orbital-stellar/pulse-core";
+import { isDemoEmitterConfigured } from "@/lib/fireDemoEvent";
+
+const VARS = ["DEMO_EMITTER_CONTRACT_ID", "DEMO_EMITTER_SECRET"] as const;
+const saved: Record<string, string | undefined> = {};
+
+beforeEach(() => {
+  for (const key of VARS) {
+    saved[key] = process.env[key];
+    delete process.env[key];
+  }
+});
+
+afterEach(() => {
+  for (const key of VARS) {
+    if (saved[key] === undefined) delete process.env[key];
+    else process.env[key] = saved[key];
+  }
+});
+
+describe("isDemoEmitterConfigured", () => {
+  it("reports NOT configured when the contract has not been deployed", () => {
+    // contracts/deployed.testnet.json ships with placeholder IDs until
+    // contracts/deploy/deploy_testnet.sh is run. Reporting `configured: true`
+    // here would leave the UI offering a button that cannot work.
+    expect(isDemoEmitterConfigured()).toBe(false);
+  });
+
+  it("stays NOT configured when a contract ID is set but no secret is", () => {
+    process.env.DEMO_EMITTER_CONTRACT_ID =
+      "CCW67TSZV3SSS2HXMBQ5JFGCKJNXKZM7UQUWUZPUTHXSTZLEO7SJMI75";
+    expect(isDemoEmitterConfigured()).toBe(false);
+  });
+
+  it("rejects the deploy script's placeholder as if it were unset", () => {
+    process.env.DEMO_EMITTER_CONTRACT_ID = "<POPULATED BY deploy_testnet.sh>";
+    process.env.DEMO_EMITTER_SECRET = "SDEMO";
+    expect(isDemoEmitterConfigured()).toBe(false);
+  });
+
+  it("reports configured only with a real contract ID and a secret", () => {
+    process.env.DEMO_EMITTER_CONTRACT_ID =
+      "CCW67TSZV3SSS2HXMBQ5JFGCKJNXKZM7UQUWUZPUTHXSTZLEO7SJMI75";
+    process.env.DEMO_EMITTER_SECRET = "SDEMOSECRET";
+    expect(isDemoEmitterConfigured()).toBe(true);
+  });
+});
+
+describe("contracts/deployed.testnet.json", () => {
+  it("is either fully placeholder or fully populated, never half-wired", () => {
+    // A manifest with a real registry ID but a placeholder demoEmitter (or the
+    // reverse) is the state that produces a half-live demo.
+    const manifest = JSON.parse(
+      readFileSync(
+        resolve(process.cwd(), "..", "..", "contracts", "deployed.testnet.json"),
+        "utf-8",
+      ),
+    ) as { contracts: Record<string, { contractId: string }> };
+
+    const ids = Object.values(manifest.contracts).map((c) => c.contractId);
+    const placeholders = ids.filter((id) => id.startsWith("<") || id.includes("POPULATED BY"));
+    expect(placeholders.length === 0 || placeholders.length === ids.length).toBe(true);
+  });
+});
+
+describe("assertRestrictedSecretNetwork", () => {
+  it("permits the testnet passphrase", () => {
+    expect(() =>
+      assertRestrictedSecretNetwork({
+        secretName: "DEMO_EMITTER_SECRET",
+        networkPassphrase: "Test SDF Network ; September 2015",
+        context: "demo",
+      }),
+    ).not.toThrow();
+  });
+
+  it("refuses to sign when the demo path is pointed at mainnet", () => {
+    // The fire-event button is anonymous and unauthenticated. If this
+    // deployment is ever configured for mainnet, refusing is the only
+    // acceptable behaviour - a stranger's click must not move real value.
+    expect(() =>
+      assertRestrictedSecretNetwork({
+        secretName: "DEMO_EMITTER_SECRET",
+        networkPassphrase: "Public Global Stellar Network ; September 2015",
+        context: "demo",
+      }),
+    ).toThrow();
+  });
+});

--- a/apps/web/test/fireEventGuards.test.ts
+++ b/apps/web/test/fireEventGuards.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import {
+  checkFireEventRateLimit,
+  __resetFireEventRateLimitForTests,
+} from "@/lib/fireEventRateLimit";
+
+const UPSTASH_VARS = ["UPSTASH_REDIS_REST_URL", "UPSTASH_REDIS_REST_TOKEN"] as const;
+
+describe("checkFireEventRateLimit", () => {
+  const saved: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    for (const key of UPSTASH_VARS) {
+      saved[key] = process.env[key];
+      delete process.env[key];
+    }
+    __resetFireEventRateLimitForTests();
+  });
+
+  afterEach(() => {
+    for (const key of UPSTASH_VARS) {
+      if (saved[key] === undefined) delete process.env[key];
+      else process.env[key] = saved[key];
+    }
+    __resetFireEventRateLimitForTests();
+  });
+
+  it("fails CLOSED with 503 when Upstash is not configured", async () => {
+    // POST /api/demo/fire-event signs a real testnet transaction with a funded
+    // key. A misconfigured deploy must refuse to fire rather than run without
+    // a shared limiter - an in-memory fallback would be per-instance on
+    // serverless and would not bound anything.
+    const result = await checkFireEventRateLimit("203.0.113.9");
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.status).toBe(503);
+    expect(result.body.error).toBe("rate_limiter_not_configured");
+  });
+
+  it("fails closed when only one of the two variables is set", async () => {
+    process.env.UPSTASH_REDIS_REST_URL = "https://example.upstash.io";
+    __resetFireEventRateLimitForTests();
+
+    const result = await checkFireEventRateLimit("203.0.113.9");
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.status).toBe(503);
+  });
+
+  it("stays closed for every caller, not just the first", async () => {
+    for (const ip of ["203.0.113.1", "203.0.113.2", "203.0.113.3"]) {
+      const result = await checkFireEventRateLimit(ip);
+      expect(result.ok).toBe(false);
+    }
+  });
+});

--- a/apps/web/test/rateLimits.test.ts
+++ b/apps/web/test/rateLimits.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { DEMO_LIMITS, acquireStream, checkWebhookCooldown, clientIp } from "@/lib/demo-limits";
+
+function ipHeaders(ip: string): Request {
+  return new Request("https://orbital.example/api/events/G", {
+    headers: { "x-vercel-forwarded-for": ip },
+  });
+}
+
+/** Each test gets a distinct IP - the limiter state is module-level. */
+let counter = 0;
+const freshIp = () => `198.51.100.${++counter % 250}${Math.floor(counter / 250)}`;
+
+describe("acquireStream", () => {
+  it("permits the configured number of concurrent streams per IP", () => {
+    const ip = freshIp();
+    const first = acquireStream(ip);
+    expect(first.ok).toBe(true);
+
+    const second = acquireStream(ip);
+    expect(second.ok).toBe(false);
+    if (!second.ok) {
+      expect(second.body.reason).toBe("per_ip_stream_limit");
+      expect(second.body.upgradeUrl).toBe(DEMO_LIMITS.upgradeUrl);
+    }
+  });
+
+  it("frees the slot on release", () => {
+    const ip = freshIp();
+    const slot = acquireStream(ip);
+    expect(slot.ok).toBe(true);
+    if (!slot.ok) return;
+
+    slot.release();
+    expect(acquireStream(ip).ok).toBe(true);
+  });
+
+  it("is idempotent on repeated release, so a double teardown cannot mint slots", () => {
+    const ip = freshIp();
+    const slot = acquireStream(ip);
+    if (!slot.ok) throw new Error("expected slot");
+
+    // Both the abort listener and the session timer call close() in the SSE
+    // routes; the guard there is belt, this is braces.
+    slot.release();
+    slot.release();
+    slot.release();
+
+    const a = acquireStream(ip);
+    expect(a.ok).toBe(true);
+    expect(acquireStream(ip).ok).toBe(false);
+  });
+
+  it("tracks IPs independently", () => {
+    const a = freshIp();
+    const b = freshIp();
+    expect(acquireStream(a).ok).toBe(true);
+    expect(acquireStream(b).ok).toBe(true);
+  });
+});
+
+describe("checkWebhookCooldown", () => {
+  afterEach(() => vi.useRealTimers());
+
+  it("allows the first call and rejects an immediate second", () => {
+    const ip = freshIp();
+    expect(checkWebhookCooldown(ip).ok).toBe(true);
+
+    const second = checkWebhookCooldown(ip);
+    expect(second.ok).toBe(false);
+    if (!second.ok) {
+      expect(second.body.reason).toBe("rate_limit");
+      expect(second.body.retryAfterMs).toBeGreaterThan(0);
+      expect(second.body.retryAfterMs).toBeLessThanOrEqual(DEMO_LIMITS.webhookCooldownMs);
+    }
+  });
+
+  it("allows again once the cooldown has elapsed", () => {
+    vi.useFakeTimers();
+    const ip = freshIp();
+    expect(checkWebhookCooldown(ip).ok).toBe(true);
+    expect(checkWebhookCooldown(ip).ok).toBe(false);
+
+    vi.advanceTimersByTime(DEMO_LIMITS.webhookCooldownMs + 1);
+    expect(checkWebhookCooldown(ip).ok).toBe(true);
+  });
+});
+
+describe("limits are keyed on the trusted identity", () => {
+  it("a rotating forged XFF cannot escape the webhook cooldown", () => {
+    const real = freshIp();
+    // Every request comes from the same real peer; only the forged prefix moves.
+    const requests = ["1.1.1.1", "2.2.2.2", "3.3.3.3"].map(
+      (forged) =>
+        new Request("https://orbital.example/api/webhook-sample", {
+          headers: { "x-vercel-forwarded-for": real, "x-forwarded-for": forged },
+        }),
+    );
+
+    const results = requests.map((req) => checkWebhookCooldown(clientIp(req)).ok);
+    expect(results).toEqual([true, false, false]);
+  });
+
+  it("resolves the same bucket for the same peer regardless of forged headers", () => {
+    const real = freshIp();
+    expect(clientIp(ipHeaders(real))).toBe(real);
+  });
+});

--- a/apps/web/test/stubs/server-only.ts
+++ b/apps/web/test/stubs/server-only.ts
@@ -1,0 +1,5 @@
+// The real `server-only` package throws on import outside a React Server
+// Component graph, which would make every server-side module untestable.
+// Vitest aliases the package to this no-op (see vitest.config.ts). The guard
+// it provides is a build-time one that `next build` still enforces.
+export {};

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -7,6 +7,10 @@ export default defineConfig({
   resolve: {
     alias: {
       "@": fileURLToPath(new URL("./", import.meta.url)),
+      // `server-only` throws on import outside a React Server Component graph,
+      // which would make every server-side lib untestable. `next build` still
+      // enforces the real boundary.
+      "server-only": fileURLToPath(new URL("./test/stubs/server-only.ts", import.meta.url)),
     },
   },
   test: {


### PR DESCRIPTION
> **Stacked on #1002.** Last in the chain: #997 → #998 → #999 → #1000 → #1001 → #1002 → this.

## The gap

`apps/web` had **zero tests**. Six API routes, both rate limiters, the fail-closed Upstash guard, the mainnet signing assertion, and the placeholder-contract check were all unverified.

Worse: `apps/web` had no `test` script, so the root `pnpm -r --if-present test` **skipped it silently** rather than reporting a gap.

Every finding in this stack lived in that hole.

## What is covered

Chosen for what they protect, not for coverage percentage:

- **`acquireStream` / `checkWebhookCooldown`** — limits hold, `release()` is idempotent (both the abort listener and the session timer call `close()` in the SSE routes), IPs stay independent, cooldown expires on schedule.
- **`checkFireEventRateLimit`** — fails **closed** with 503 when Upstash is unconfigured, including when only one of the two variables is set. This is the guard between an anonymous button and a funded testnet key; an in-memory fallback would be per-instance on serverless and bound nothing.
- **`assertRestrictedSecretNetwork`** — refuses to sign on a mainnet passphrase. The fire-event button is unauthenticated, so a stranger's click must not be able to move real value.
- **`isDemoEmitterConfigured`** — placeholder contract IDs count as unconfigured, so the UI cannot offer a button that cannot work.
- **`contracts/deployed.testnet.json`** — asserts the manifest is either fully placeholder or fully populated. A half-wired manifest is what produces a demo that looks live and isn't.
- **rate-limit bucket keying** — a rotating forged XFF cannot mint new buckets (companion to #997).

## Notes

`server-only` is aliased to a stub for tests — it throws on import outside a React Server Component graph, which would otherwise make every server-side lib untestable. `next build` still enforces the real boundary.

Adds a **`test-web` job** to `ci.yml` beside `typecheck-web` and `build-web`, gated on the same `changes.outputs.web` filter. Verified by running the job's exact command sequence locally.

40 tests across 5 files.