### PR TITLE
fix(ci): build every package before the coverage job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -279,8 +279,12 @@ jobs:
           node-version: 20
           cache: pnpm
       - run: pnpm install --frozen-lockfile
-      - name: Build abi-registry
-        run: pnpm tsc -p packages/abi-registry/tsconfig.json
+      # Every package must be built, not just abi-registry: workspace packages
+      # resolve each other through their published `main` (./dist/index.js), so
+      # a cross-package import in a test file - e.g. anchor-sdk's sep10 suite
+      # importing WebAuth from pulse-core - fails to resolve without a dist.
+      - name: Build packages
+        run: pnpm build
       - name: Run coverage (thresholds enforced)
         run: pnpm -r --if-present test:coverage
       - name: Upload coverage reports


### PR DESCRIPTION
The `coverage` job builds only `abi-registry`. Workspace packages resolve each other through `main` (`./dist/index.js`), so any test that imports across packages fails with:

```
Error: Failed to resolve entry for package "@orbital-stellar/pulse-core". The package may have incorrect main/module/exports specified in its package.json.
```

This is what reddens `coverage` on #999-#1003: #999 adds `import { WebAuth } from "@orbital-stellar/pulse-core"` to `packages/anchor-sdk/test/sep10.test.ts`.

Verified locally on #999's branch: `4 failed | 1 passed` before, `5 passed (67 tests)` after `pnpm build`.

`pnpm build` covers abi-registry too, so the old step is redundant.